### PR TITLE
feat: add subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dmtlint.yml
+dmt

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -4,31 +4,127 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/pflag"
+
 	"github.com/deckhouse/dmt/internal/flags"
 	"github.com/deckhouse/dmt/internal/logger"
 	"github.com/deckhouse/dmt/internal/manager"
 	"github.com/deckhouse/dmt/pkg/config"
 )
 
+const (
+	numThreads = 10
+)
+
 func main() {
-	dirs := flags.ParseFlags()
-	if len(dirs) == 0 {
+	var (
+		printHelp    bool
+		printVersion bool
+		version      = "HEAD"
+	)
+
+	logger.InitLogger()
+
+	defaults := pflag.NewFlagSet("defaults for all commands", pflag.ExitOnError)
+	defaults.BoolVarP(&printHelp, "help", "h", false, "help message")
+	defaults.BoolVarP(&printVersion, "version", "v", false, "version message")
+
+	defaults.Usage = func() {
+		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt [gen|lint] [OPTIONS]")
+		defaults.PrintDefaults()
+	}
+
+	lint := pflag.NewFlagSet("lint", pflag.ContinueOnError)
+	lint.AddFlagSet(defaults)
+
+	lint.IntVarP(&flags.LintersLimit, "parallel", "p", numThreads, "number of threads for parallel processing")
+	lint.StringVarP(&flags.LogLevel, "log-level", "l", "INFO", "log-level [DEBUG | INFO | WARN | ERROR]")
+
+	lint.Usage = func() {
+		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt lint [OPTIONS] [dirs...]")
+		lint.PrintDefaults()
+	}
+
+	gen := pflag.NewFlagSet("gen", pflag.ContinueOnError)
+	gen.AddFlagSet(defaults)
+
+	gen.Usage = func() {
+		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt gen [OPTIONS]")
+		defaults.PrintDefaults()
+	}
+
+	if len(os.Args) < 2 {
+		defaults.Usage()
 		return
 	}
 
-	logger.InitLogger()
-	logger.InfoF("Dirs: %v", dirs)
+	switch os.Args[1] {
+	case "lint":
+		if err := lint.Parse(os.Args[2:]); err != nil {
+			lint.Usage()
+			return
+		}
 
-	cfg, err := config.NewDefault(dirs)
-	logger.CheckErr(err)
+		if printHelp {
+			lint.Usage()
+			return
+		}
 
-	mng := manager.NewManager(dirs, cfg)
-	result := mng.Run()
-	if result.ConvertToError() != nil {
-		fmt.Printf("%s\n", result.ConvertToError())
-	}
+		if printVersion {
+			fmt.Println("dmt version: ", version)
+			return
+		}
 
-	if result.Critical() {
-		os.Exit(1)
+		var dirs = lint.Args()
+		if len(dirs) == 0 {
+			dirs = []string{"."}
+		}
+
+		if len(dirs) == 0 {
+			return
+		}
+
+		logger.InfoF("Dirs: %v", dirs)
+
+		cfg, err := config.NewDefault(dirs)
+		logger.CheckErr(err)
+
+		mng := manager.NewManager(dirs, cfg)
+		result := mng.Run()
+		if result.ConvertToError() != nil {
+			fmt.Printf("%s\n", result.ConvertToError())
+		}
+
+		if result.Critical() {
+			os.Exit(1)
+		}
+	case "gen":
+		if err := gen.Parse(os.Args[2:]); err != nil {
+			gen.Usage()
+			return
+		}
+
+		if printVersion {
+			fmt.Println("dmt version: ", version)
+			return
+		}
+
+		if printHelp {
+			gen.Usage()
+			return
+		}
+	default:
+		if err := defaults.Parse(os.Args[1:]); err != nil {
+			defaults.Usage()
+			return
+		}
+
+		if printVersion {
+			fmt.Println("dmt version: ", version)
+			return
+		}
+
+		defaults.Usage()
+		return
 	}
 }

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -10,7 +10,10 @@ import (
 	"github.com/deckhouse/dmt/pkg/config"
 )
 
+var Version = "HEAD"
+
 func main() {
+	flags.Version = Version
 	logger.InitLogger()
 
 	defaults := flags.InitDefaultFlagSet()

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -4,54 +4,22 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/pflag"
-
 	"github.com/deckhouse/dmt/internal/flags"
 	"github.com/deckhouse/dmt/internal/logger"
 	"github.com/deckhouse/dmt/internal/manager"
 	"github.com/deckhouse/dmt/pkg/config"
 )
 
-const (
-	numThreads = 10
-)
-
 func main() {
-	var (
-		printHelp    bool
-		printVersion bool
-		version      = "HEAD"
-	)
-
 	logger.InitLogger()
 
-	defaults := pflag.NewFlagSet("defaults for all commands", pflag.ExitOnError)
-	defaults.BoolVarP(&printHelp, "help", "h", false, "help message")
-	defaults.BoolVarP(&printVersion, "version", "v", false, "version message")
+	defaults := flags.InitDefaultFlagSet()
 
-	defaults.Usage = func() {
-		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt [gen|lint] [OPTIONS]")
-		defaults.PrintDefaults()
-	}
-
-	lint := pflag.NewFlagSet("lint", pflag.ContinueOnError)
+	lint := flags.InitLintFlagSet()
 	lint.AddFlagSet(defaults)
 
-	lint.IntVarP(&flags.LintersLimit, "parallel", "p", numThreads, "number of threads for parallel processing")
-	lint.StringVarP(&flags.LogLevel, "log-level", "l", "INFO", "log-level [DEBUG | INFO | WARN | ERROR]")
-
-	lint.Usage = func() {
-		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt lint [OPTIONS] [dirs...]")
-		lint.PrintDefaults()
-	}
-
-	gen := pflag.NewFlagSet("gen", pflag.ContinueOnError)
+	gen := flags.InitGenFlagSet()
 	gen.AddFlagSet(defaults)
-
-	gen.Usage = func() {
-		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt gen [OPTIONS]")
-		defaults.PrintDefaults()
-	}
 
 	if len(os.Args) < 2 {
 		defaults.Usage()
@@ -60,20 +28,7 @@ func main() {
 
 	switch os.Args[1] {
 	case "lint":
-		if err := lint.Parse(os.Args[2:]); err != nil {
-			lint.Usage()
-			return
-		}
-
-		if printHelp {
-			lint.Usage()
-			return
-		}
-
-		if printVersion {
-			fmt.Println("dmt version: ", version)
-			return
-		}
+		flags.GeneralParse(lint)
 
 		var dirs = lint.Args()
 		if len(dirs) == 0 {
@@ -84,47 +39,28 @@ func main() {
 			return
 		}
 
-		logger.InfoF("Dirs: %v", dirs)
-
-		cfg, err := config.NewDefault(dirs)
-		logger.CheckErr(err)
-
-		mng := manager.NewManager(dirs, cfg)
-		result := mng.Run()
-		if result.ConvertToError() != nil {
-			fmt.Printf("%s\n", result.ConvertToError())
-		}
-
-		if result.Critical() {
-			os.Exit(1)
-		}
+		runLint(dirs)
 	case "gen":
-		if err := gen.Parse(os.Args[2:]); err != nil {
-			gen.Usage()
-			return
-		}
-
-		if printVersion {
-			fmt.Println("dmt version: ", version)
-			return
-		}
-
-		if printHelp {
-			gen.Usage()
-			return
-		}
+		flags.GeneralParse(gen)
 	default:
-		if err := defaults.Parse(os.Args[1:]); err != nil {
-			defaults.Usage()
-			return
-		}
-
-		if printVersion {
-			fmt.Println("dmt version: ", version)
-			return
-		}
-
+		flags.GeneralParse(defaults)
 		defaults.Usage()
-		return
+	}
+}
+
+func runLint(dirs []string) {
+	logger.InfoF("Dirs: %v", dirs)
+
+	cfg, err := config.NewDefault(dirs)
+	logger.CheckErr(err)
+
+	mng := manager.NewManager(dirs, cfg)
+	result := mng.Run()
+	if result.ConvertToError() != nil {
+		fmt.Printf("%s\n", result.ConvertToError())
+	}
+
+	if result.Critical() {
+		os.Exit(1)
 	}
 }

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -22,6 +22,7 @@ func main() {
 	gen.AddFlagSet(defaults)
 
 	if len(os.Args) < 2 {
+		flags.GeneralParse(defaults)
 		defaults.Usage()
 		return
 	}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,6 +1,78 @@
 package flags
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	numThreads = 10
+)
+
 var (
 	LintersLimit int
 	LogLevel     string
 )
+
+var (
+	PrintHelp    bool
+	PrintVersion bool
+	Version      = "HEAD"
+)
+
+func InitDefaultFlagSet() *pflag.FlagSet {
+	defaults := pflag.NewFlagSet("defaults for all commands", pflag.ExitOnError)
+	defaults.BoolVarP(&PrintHelp, "help", "h", false, "help message")
+	defaults.BoolVarP(&PrintVersion, "version", "v", false, "version message")
+
+	defaults.Usage = func() {
+		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt [gen|lint] [OPTIONS]")
+		defaults.PrintDefaults()
+	}
+
+	return defaults
+}
+
+func InitLintFlagSet() *pflag.FlagSet {
+	lint := pflag.NewFlagSet("lint", pflag.ContinueOnError)
+
+	lint.IntVarP(&LintersLimit, "parallel", "p", numThreads, "number of threads for parallel processing")
+	lint.StringVarP(&LogLevel, "log-level", "l", "INFO", "log-level [DEBUG | INFO | WARN | ERROR]")
+
+	lint.Usage = func() {
+		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt lint [OPTIONS] [dirs...]")
+		lint.PrintDefaults()
+	}
+
+	return lint
+}
+
+func InitGenFlagSet() *pflag.FlagSet {
+	gen := pflag.NewFlagSet("gen", pflag.ContinueOnError)
+
+	gen.Usage = func() {
+		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt gen [OPTIONS]")
+		pflag.PrintDefaults()
+	}
+
+	return gen
+}
+
+func GeneralParse(flagSet *pflag.FlagSet) {
+	if err := flagSet.Parse(os.Args[2:]); err != nil {
+		flagSet.Usage()
+		os.Exit(0)
+	}
+
+	if PrintHelp {
+		flagSet.Usage()
+		os.Exit(0)
+	}
+
+	if PrintVersion {
+		fmt.Println("dmt version: ", Version)
+		os.Exit(0)
+	}
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -61,7 +61,7 @@ func InitGenFlagSet() *pflag.FlagSet {
 }
 
 func GeneralParse(flagSet *pflag.FlagSet) {
-	if err := flagSet.Parse(os.Args[2:]); err != nil {
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		flagSet.Usage()
 		os.Exit(0)
 	}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,59 +1,6 @@
 package flags
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/pflag"
-)
-
 var (
 	LintersLimit int
 	LogLevel     string
 )
-
-const (
-	numThreads = 10
-)
-
-func ParseFlags() []string {
-	var (
-		printHelp    bool
-		printVersion bool
-		version      = "HEAD"
-	)
-
-	flagSet := pflag.NewFlagSet("dmt", pflag.ContinueOnError)
-
-	flagSet.BoolVarP(&printHelp, "help", "h", false, "help message")
-	flagSet.BoolVarP(&printVersion, "version", "v", false, "version message")
-	flagSet.IntVarP(&LintersLimit, "parallel", "p", numThreads, "number of threads for parallel processing")
-	flagSet.StringVarP(&LogLevel, "log-level", "l", "INFO", "log-level [DEBUG | INFO | WARN | ERROR]")
-
-	flagSet.Usage = func() {
-		_, _ = fmt.Fprintln(os.Stderr, "Usage: dmt [OPTIONS] [dirs...]")
-		flagSet.PrintDefaults()
-	}
-
-	if err := flagSet.Parse(os.Args[1:]); err != nil {
-		flagSet.Usage()
-		return nil
-	}
-
-	if printHelp {
-		flagSet.Usage()
-		return nil
-	}
-
-	if printVersion {
-		fmt.Println("dmt version: ", version)
-		return nil
-	}
-
-	var dirs = flagSet.Args()
-	if len(dirs) == 0 {
-		dirs = []string{"."}
-	}
-
-	return dirs
-}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -19,7 +19,7 @@ var (
 var (
 	PrintHelp    bool
 	PrintVersion bool
-	Version      = "HEAD"
+	Version      string
 )
 
 func InitDefaultFlagSet() *pflag.FlagSet {


### PR DESCRIPTION
Two sub-tees were added:

- lint
- gen

By default, we output a use reference.