### PR TITLE
fix: set log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .dmtlint.yml
-dmt

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -17,7 +17,6 @@ var Version = "HEAD"
 func main() {
 	flags.Version = Version
 	color.NoColor = false
-	logger.InitLogger()
 
 	defaults := flags.InitDefaultFlagSet()
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/deckhouse/dmt/internal/logger"
+
 	"github.com/spf13/pflag"
 )
 
@@ -65,6 +67,8 @@ func GeneralParse(flagSet *pflag.FlagSet) {
 		flagSet.Usage()
 		os.Exit(0)
 	}
+
+	logger.InitLogger(LogLevel)
 
 	if PrintHelp {
 		flagSet.Usage()

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,13 +6,11 @@ import (
 	"log"
 	"log/slog"
 	"os"
-
-	"github.com/deckhouse/dmt/internal/flags"
 )
 
 var logger *slog.Logger
 
-func InitLogger() {
+func InitLogger(logLevel string) {
 	log.SetOutput(io.Discard)
 
 	lvl := new(slog.LevelVar)
@@ -20,16 +18,16 @@ func InitLogger() {
 
 	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: lvl}))
 
-	if flags.LogLevel == "DEBUG" {
+	if logLevel == "DEBUG" {
 		lvl.Set(slog.LevelDebug)
 	}
-	if flags.LogLevel == "INFO" {
+	if logLevel == "INFO" {
 		lvl.Set(slog.LevelInfo)
 	}
-	if flags.LogLevel == "WARN" {
+	if logLevel == "WARN" {
 		lvl.Set(slog.LevelWarn)
 	}
-	if flags.LogLevel == "ERROR" {
+	if logLevel == "ERROR" {
 		lvl.Set(slog.LevelError)
 	}
 }


### PR DESCRIPTION
After the improvements, the logger initialization turned out to be before the flags were parsed. As a result, we have always used the INFO logging level.

In order to fix the situation, it was necessary to move the logger initialization to the place after parsing the command line flags.