### PR TITLE
fix: improve parsing openapi enum keys

### DIFF
--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -181,7 +181,11 @@ func parseProperties(tempNode *spec.Schema) (map[string]any, error) {
 				result[key] = examples[0]
 			}
 		case len(prop.Enum) > 0:
-			result[key] = prop.Enum
+			if prop.Default != nil {
+				result[key] = prop.Default
+				continue
+			}
+			result[key] = prop.Enum[0]
 		case prop.Type.Contains(ObjectKey):
 			if prop.Default == nil {
 				continue


### PR DESCRIPTION
When parsing openapi spec, if we encounter an enum field, we take this value unchanged. While you expect the string data type to be used. As a result, we got an error.

These changes correct the situation. If a default value is set, it is used. Otherwise, the first value from the enumeration is taken.

Tested locally. Helm parsing errors are no longer observed.