### PR TITLE
fix: panic with relative paths

### DIFF
--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/fatih/color"
+	"github.com/mitchellh/go-homedir"
 
 	"github.com/deckhouse/dmt/internal/flags"
 	"github.com/deckhouse/dmt/internal/logger"
@@ -45,7 +47,21 @@ func main() {
 			return
 		}
 
-		runLint(dirs)
+		var parsedDirs []string
+		for _, dir := range dirs {
+			d, err := homedir.Expand(dir)
+			if err != nil {
+				logger.ErrorF("Error expanding directory: %v", err)
+				continue
+			}
+			d, err = filepath.Abs(d)
+			if err != nil {
+				logger.ErrorF("Error expanding directory: %v\n", err)
+				continue
+			}
+			parsedDirs = append(parsedDirs, d)
+		}
+		runLint(parsedDirs)
 	case "gen":
 		flags.GeneralParse(gen)
 	default:


### PR DESCRIPTION
When using relative paths, we had panics during processing. The problem is that we pass paths without processing as is. And openapi has additional processing of these paths.

Added conversion of module paths to absolute paths.