### PR TITLE
fix: Fixed image digests load for downloaded modules

### DIFF
--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -44,7 +44,7 @@ func helmFormatModuleImages(m *Module, rawValues map[string]any) (chartutil.Valu
 	vers = append(vers, "autoscaling.k8s.io/v1/VerticalPodAutoscaler")
 	caps.APIVersions = vers
 
-	digests, err := GetModulesImagesDigests(ToLowerCamel(m.GetName()), m.GetPath())
+	digests, err := GetModulesImagesDigests(m.GetName(), m.GetPath())
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func GetModulesImagesDigests(moduleName, modulePath string) (modulesDigests map[
 	}
 
 	allDigests := DefaultImagesDigests
-	allDigests[moduleName] = modulesDigests
+	allDigests[ToLowerCamel(moduleName)] = modulesDigests
 
 	return allDigests, nil
 }

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -2,8 +2,8 @@ package module
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 
@@ -68,23 +68,13 @@ func helmFormatModuleImages(m *Module, rawValues map[string]any) (chartutil.Valu
 }
 
 func GetModulesImagesDigests(moduleName, modulePath string) (modulesDigests map[string]any, err error) {
-	var (
-		search bool
-	)
-
 	modulesDigests, err = getModulesImagesDigestsFromLocalPath(modulePath)
 	if err != nil {
 		return nil, err
 	}
 
 	if modulesDigests == nil {
-		if fi, errs := os.Stat(filepath.Join(filepath.Dir(modulePath), imageDigestfile)); errs != nil || fi.Size() == 0 {
-			search = true
-		}
-
-		if search {
-			return DefaultImagesDigests, nil
-		}
+		return DefaultImagesDigests, nil
 	}
 
 	allDigests := DefaultImagesDigests


### PR DESCRIPTION
Changed behavior for loading image digests file:
- If found `imageDigestfile`  in module directory, load all values with default ones
- Otherwise load default generated only.