### PR TITLE
fix: error message for image check

### DIFF
--- a/pkg/linters/helm/rules/images.go
+++ b/pkg/linters/helm/rules/images.go
@@ -192,9 +192,9 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) *errors.Lint
 						return errors.NewLintRuleError(
 							ID,
 							name,
-							fmt.Sprintf("module = %s, image = %s", name, relativeFilePath),
-							nil,
+							fmt.Sprintf("module = %s, path = %s", name, relativeFilePath),
 							fromTrimmed,
+							"%s",
 							message,
 						)
 					}
@@ -220,9 +220,9 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) *errors.Lint
 			return errors.NewLintRuleError(
 				ID,
 				name,
-				name,
-				fmt.Sprintf("module = %s, image = %s", name, relativeFilePath),
+				fmt.Sprintf("module = %s, path = %s", name, relativeFilePath),
 				fromInstruction,
+				"%s",
 				message,
 			)
 		}


### PR DESCRIPTION
While checking the module template, we got a validation error in the helm linter:

```plain
🐒 [#helm]
    Message    - ealen/echo-server:0.7.0%!!(MISSING)(EXTRA string=Last `FROM` instruction should use one of our $BASE_DISTROLESS images)
    Object    - echoserver
    Module    - echoserver
    Value    - module = echoserver, image = echoserver/Dockerfile
```

Which is not correct and it is necessary to correct the format of the output of these errors.
It is likely that the reason is the incorrect use of the error generation function.

After the changes, the error is displayed:

```plain
🐒 [#helm]
	Message	- Last `FROM` instruction should use one of our $BASE_DISTROLESS images
	Object	- echoserver
	Module	- module = echoserver, path = echoserver/Dockerfile
	Value	- ealen/echo-server:0.7.0
```