### PR TITLE
feat: add parsing allOf

### DIFF
--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -169,19 +169,6 @@ func parseExamples(key string, prop *spec.Schema, result map[string]any) error {
 	}
 
 	if example != nil {
-		if prop.Type.Contains(ObjectKey) {
-			t, err := parseProperties(prop)
-			if err != nil {
-				return err
-			}
-			if err := mergo.Merge(&t, example, mergo.WithOverride); err != nil {
-				return err
-			}
-			result[key] = t
-
-			return nil
-		}
-
 		result[key] = example
 	}
 

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -220,7 +220,7 @@ func parseOneOf(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseAnyOf(key string, prop *spec.Schema, result map[string]any) error {
-	t, err := parseProperties(&prop.OneOf[0])
+	t, err := parseProperties(&prop.AnyOf[0])
 	if err != nil {
 		return err
 	}

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -210,10 +210,6 @@ func parseArray(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseOneOf(key string, prop *spec.Schema, result map[string]any) error {
-	if len(prop.OneOf) == 0 {
-		return nil
-	}
-
 	t, err := parseProperties(&prop.OneOf[0])
 	if err != nil {
 		return err
@@ -224,10 +220,6 @@ func parseOneOf(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseAnyOf(key string, prop *spec.Schema, result map[string]any) error {
-	if len(prop.OneOf) == 0 {
-		return nil
-	}
-
 	t, err := parseProperties(&prop.OneOf[0])
 	if err != nil {
 		return err

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -148,7 +148,7 @@ func parseProperty(key string, prop *spec.Schema, result map[string]any) error {
 	case prop.Type.Contains(ArrayObject) && prop.Items != nil && prop.Items.Schema != nil:
 		return parseArray(key, prop, result)
 	case prop.AllOf != nil:
-		// not implemented
+		return parseAllOf(key, prop, result)
 	case prop.OneOf != nil:
 		return parseOneOf(key, prop, result)
 	case prop.AnyOf != nil:
@@ -238,6 +238,19 @@ func parseOneOf(key string, prop *spec.Schema, result map[string]any) error {
 func parseAnyOf(key string, prop *spec.Schema, result map[string]any) error {
 	downwardSchema := deepcopy.Copy(prop).(*spec.Schema)
 	mergedSchema := mergeSchemas(downwardSchema, prop.AnyOf...)
+
+	t, err := parseProperties(mergedSchema)
+	if err != nil {
+		return err
+	}
+	result[key] = t
+
+	return nil
+}
+
+func parseAllOf(key string, prop *spec.Schema, result map[string]any) error {
+	downwardSchema := deepcopy.Copy(prop).(*spec.Schema)
+	mergedSchema := mergeSchemas(downwardSchema, prop.AllOf...)
 
 	t, err := parseProperties(mergedSchema)
 	if err != nil {

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -147,11 +147,11 @@ func parseProperty(key string, prop *spec.Schema, result map[string]any) error {
 		result[key] = prop.Default
 	case prop.Type.Contains(ArrayObject) && prop.Items != nil && prop.Items.Schema != nil:
 		return parseArray(key, prop, result)
-	case prop.AllOf != nil:
+	case len(prop.AllOf) > 0:
 		return parseAllOf(key, prop, result)
-	case prop.OneOf != nil:
+	case len(prop.OneOf) > 0:
 		return parseOneOf(key, prop, result)
-	case prop.AnyOf != nil:
+	case len(prop.AnyOf) > 0:
 		return parseAnyOf(key, prop, result)
 	}
 
@@ -223,10 +223,11 @@ func parseArray(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseOneOf(key string, prop *spec.Schema, result map[string]any) error {
-	downwardSchema := deepcopy.Copy(prop).(*spec.Schema)
-	mergedSchema := mergeSchemas(downwardSchema, prop.OneOf...)
+	if len(prop.OneOf) == 0 {
+		return nil
+	}
 
-	t, err := parseProperties(mergedSchema)
+	t, err := parseProperties(&prop.OneOf[0])
 	if err != nil {
 		return err
 	}
@@ -236,10 +237,11 @@ func parseOneOf(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseAnyOf(key string, prop *spec.Schema, result map[string]any) error {
-	downwardSchema := deepcopy.Copy(prop).(*spec.Schema)
-	mergedSchema := mergeSchemas(downwardSchema, prop.AnyOf...)
+	if len(prop.OneOf) == 0 {
+		return nil
+	}
 
-	t, err := parseProperties(mergedSchema)
+	t, err := parseProperties(&prop.OneOf[0])
 	if err != nil {
 		return err
 	}

--- a/internal/module/openapi_test.go
+++ b/internal/module/openapi_test.go
@@ -60,7 +60,7 @@ func Test_parseProperties(t *testing.T) {
 					},
 				},
 			},
-			want:    map[string]any{"exampleKey": map[string]any{"bar1": "example", "bar2": "text"}},
+			want:    map[string]any{"exampleKey": map[string]any{"bar1": "example"}},
 			wantErr: false,
 		},
 		{
@@ -99,7 +99,7 @@ func Test_parseProperties(t *testing.T) {
 					},
 				},
 			},
-			want:    map[string]any{"exampleKey": map[string]any{"bar1": "example", "bar2": "text"}},
+			want:    map[string]any{"exampleKey": map[string]any{"bar1": "example"}},
 			wantErr: false,
 		},
 		{
@@ -288,7 +288,7 @@ func Test_parseProperties(t *testing.T) {
 					},
 				},
 			},
-			want:    map[string]any{"oneOfKey": map[string]any{"oneOfNestedKey": "oneOfValue", "oneOfNestedKey2": "oneOfValue2"}},
+			want:    map[string]any{"oneOfKey": map[string]any{"oneOfNestedKey": "oneOfValue"}},
 			wantErr: false,
 		},
 		{
@@ -327,7 +327,7 @@ func Test_parseProperties(t *testing.T) {
 					},
 				},
 			},
-			want:    map[string]any{"anyOfKey": map[string]any{"anyOfNestedKey": "anyOfValue", "anyOfNestedKey2": "anyOfValue2"}},
+			want:    map[string]any{"anyOfKey": map[string]any{"anyOfNestedKey": "anyOfValue"}},
 			wantErr: false,
 		},
 		{

--- a/internal/module/openapi_test.go
+++ b/internal/module/openapi_test.go
@@ -330,6 +330,57 @@ func Test_parseProperties(t *testing.T) {
 			want:    map[string]any{"anyOfKey": map[string]any{"anyOfNestedKey": "anyOfValue", "anyOfNestedKey2": "anyOfValue2"}},
 			wantErr: false,
 		},
+		{
+			name: "schema with AllOf",
+			schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"allOfKey": {
+							SchemaProps: spec.SchemaProps{
+								AllOf: []spec.Schema{
+									{
+										SchemaProps: spec.SchemaProps{
+											Type: spec.StringOrArray{"object"},
+											Properties: map[string]spec.Schema{
+												"nestedKey1": {
+													SchemaProps: spec.SchemaProps{
+														Default: "nestedValue",
+													},
+												},
+												"nestedKey2": {
+													SchemaProps: spec.SchemaProps{
+														Pattern: "^[a-z]+$",
+													},
+												},
+											},
+										},
+									},
+									{
+										SchemaProps: spec.SchemaProps{
+											Type: spec.StringOrArray{"object"},
+											Properties: map[string]spec.Schema{
+												"nestedKey3": {
+													SchemaProps: spec.SchemaProps{
+														Default: "nestedValue",
+													},
+												},
+												"nestedKey4": {
+													SchemaProps: spec.SchemaProps{
+														Pattern: "^[a-z]+$",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    map[string]any{"allOfKey": map[string]any{"nestedKey1": "nestedValue", "nestedKey3": "nestedValue"}},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In previous versions of dmt, we didn't have allOf parsing.

These changes add support for allOf, putting the result together, according to the pattern.