### PR TITLE
fixes parsing openapi spec for some modules

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -117,6 +117,9 @@ func NewModule(path string) (*Module, error) {
 			if pos := strings.Index(line, `:= include "helm_lib_module_`); pos > -1 {
 				line = line[:pos] + `:= "imageHash-` + name + `-container" }}`
 			}
+			if pos := strings.Index(line, `:= (include "helm_lib_module_`); pos > -1 {
+				line = line[:pos] + `:= "example.domain.com:tags"  | splitn ":" 2 }}`
+			}
 			if pos := strings.Index(line, "image: "); pos > -1 {
 				line = line[:pos] + "image: registry.example.com/deckhouse@imageHash-" + name + "-container"
 			}

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -169,6 +169,11 @@ func parseProperty(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseString(key, pattern string, result map[string]any) error {
+	// ignore cniSecretData key
+	if key == "cniSecretData" {
+		return nil
+	}
+
 	const limit = 8
 	if strings.Contains(key, "CPU") {
 		result[key] = "100m"


### PR DESCRIPTION
Fixed: #39 

1. I missed another case of using helm_lib_module_, which caused a digest generation error. There is no error on trivy now.
2. If we set the cniSecretData variable, it is expected that its value will be in base64 format. Since we generate random values for strings, this is not the case. As a result, the output was a string in an incorrect format, which helm could not reproduce. We had to exclude the variable from the spec so that new values could be generated in cloud-providers.