### PR TITLE
feat: critical error on creating module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dmtlint.yml
 release-build
 dist
+/dmt

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -39,6 +39,8 @@ type Manager struct {
 	Modules []*module.Module
 
 	lintersMap map[string]Linter
+
+	errors errors.LintRuleErrorsList
 }
 
 func NewManager(dirs []string, cfg *config.Config) *Manager {
@@ -90,7 +92,13 @@ func NewManager(dirs []string, cfg *config.Config) *Manager {
 		logger.DebugF("Found `%s` module", moduleName)
 		mdl, err := module.NewModule(paths[i])
 		if err != nil {
-			logger.ErrorF("Cannot create module `%s`: %s", moduleName, err)
+			m.errors.Add(&errors.LintRuleError{
+				Text:     "cannot create module",
+				ID:       "manager",
+				Value:    err,
+				ObjectID: paths[i],
+				Module:   moduleName,
+			})
 			continue
 		}
 		m.Modules = append(m.Modules, mdl)
@@ -130,6 +138,8 @@ func (m *Manager) Run() errors.LintRuleErrorsList {
 	for er := range ch {
 		result.Merge(er)
 	}
+
+	result.Merge(m.errors)
 
 	return result
 }


### PR DESCRIPTION
When creating a module, we may encounter various errors. They are displayed as text in the logs, but do not affect the operation of the linter. As a result, we show the error but do not block the build if such an error occurs. And it won't be fixed.

A change is proposed; module creation errors are now added to the general list and are critical. That is, if an error occurs when creating a module, it will now be displayed in the general list in the same format, and the linter will exit with code 1.

Example:

```plain
🐒 [#manager]
        Message - cannot create module
        Object  - /deckhouse/modules/011-flow-schema
        Module  - 011-flow-schema
        Value   - error evaluating symlink /deckhouse/modules/011-flow-schema/charts/helm_lib: lstat /Users/devsyukov/src/github.com/deckhouse/deckhouse/deckhouse: no such file or directory
```

```fish
 ❯ echo $status
1
```