### PR TITLE
fix: get kind for rbac linter

### DIFF
--- a/pkg/linters/rbac/roles/placement.go
+++ b/pkg/linters/rbac/roles/placement.go
@@ -58,8 +58,8 @@ func ObjectRBACPlacement(m *module.Module, object storage.StoreObject) *errors.L
 		return nil
 	}
 
-	objectKind := object.Unstructured.GetName()
-	switch object.Unstructured.GetName() {
+	objectKind := object.Unstructured.GetKind()
+	switch objectKind {
 	case "ServiceAccount":
 		return objectRBACPlacementServiceAccount(m, object)
 	case "ClusterRole", "ClusterRoleBinding":


### PR DESCRIPTION
When running the linter, a large number of errors are displayed in rbac:

```
🐒 [#rbac]
	Message	- kind d8:cloud-provider-vsphere:cloud-controller-manager not allowed in "templates/cloud-controller-manager/rbac-for-us.yaml"
	Object	- kind = ClusterRole ; name = d8:cloud-provider-vsphere:cloud-controller-manager
	Module	- cloud-provider-vsphere
```

But in reality everything is correct.

The code checked the name of an object named Kind. You need to check the Kind of the object.