### PR TITLE
Object identification in log messages

### DIFF
--- a/pkg/linters/container/container.go
+++ b/pkg/linters/container/container.go
@@ -34,7 +34,7 @@ func (*Container) Run(m *module.Module) (result errors.LintRuleErrorsList, err e
 	}
 
 	for _, object := range m.GetStorage() {
-		result.Merge(applyContainerRules(object))
+		result.Merge(applyContainerRules(m, object))
 	}
 
 	return result, nil

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -42,7 +42,7 @@ func applyContainerRules(m *module.Module, object storage.StoreObject) (result e
 	return result
 }
 
-func containersImagePullPolicy(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containersImagePullPolicy(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	if len(containers) == 0 {
 		return nil
 	}
@@ -58,7 +58,7 @@ func containersImagePullPolicy(module string, object storage.StoreObject, contai
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity()+"; container = "+c.Name,
-				module,
+				md,
 				c.ImagePullPolicy,
 				`Container imagePullPolicy should be unspecified or "Always"`,
 			)
@@ -67,24 +67,24 @@ func containersImagePullPolicy(module string, object storage.StoreObject, contai
 		return nil
 	}
 
-	return containerImagePullPolicyIfNotPresent(module, object, containers)
+	return containerImagePullPolicyIfNotPresent(md, object, containers)
 }
 
-func containerNameDuplicates(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerNameDuplicates(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	names := make(map[string]struct{})
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
 		}
 		if _, ok := names[containers[i].Name]; ok {
-			return errors.NewLintRuleError(ID, object.Identity(), module, nil, "Duplicate container name")
+			return errors.NewLintRuleError(ID, object.Identity(), md, nil, "Duplicate container name")
 		}
 		names[containers[i].Name] = struct{}{}
 	}
 	return nil
 }
 
-func containerEnvVariablesDuplicates(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerEnvVariablesDuplicates(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -95,7 +95,7 @@ func containerEnvVariablesDuplicates(module string, object storage.StoreObject, 
 				return errors.NewLintRuleError(
 					ID,
 					object.Identity()+"; container = "+containers[i].Name,
-					module,
+					md,
 					variable.Name,
 					"Container has two env variables with same name",
 				)
@@ -129,7 +129,7 @@ func shouldSkipModuleContainer(md, container string) bool {
 	return false
 }
 
-func containerImageDigestCheck(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerImageDigestCheck(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -140,7 +140,7 @@ func containerImageDigestCheck(module string, object storage.StoreObject, contai
 		if len(match) == 0 {
 			return errors.NewLintRuleError(ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				module,
+				md,
 				nil,
 				"Cannot parse repository from image",
 			)
@@ -149,7 +149,7 @@ func containerImageDigestCheck(module string, object storage.StoreObject, contai
 		if err != nil {
 			return errors.NewLintRuleError(ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				module,
+				md,
 				nil,
 				"Cannot parse repository from image: %s", containers[i].Image,
 			)
@@ -158,7 +158,7 @@ func containerImageDigestCheck(module string, object storage.StoreObject, contai
 		if repo.Name() != defaultRegistry {
 			return errors.NewLintRuleError(ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				module,
+				md,
 				nil,
 				"All images must be deployed from the same default registry: %s current: %s",
 				defaultRegistry,
@@ -169,7 +169,7 @@ func containerImageDigestCheck(module string, object storage.StoreObject, contai
 	return nil
 }
 
-func containerImagePullPolicyIfNotPresent(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerImagePullPolicyIfNotPresent(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -180,7 +180,7 @@ func containerImagePullPolicyIfNotPresent(module string, object storage.StoreObj
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity()+"; container = "+containers[i].Name,
-			module,
+			md,
 			containers[i].ImagePullPolicy,
 			`Container imagePullPolicy should be unspecified or "IfNotPresent"`,
 		)
@@ -188,7 +188,7 @@ func containerImagePullPolicyIfNotPresent(module string, object storage.StoreObj
 	return nil
 }
 
-func containerStorageEphemeral(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerStorageEphemeral(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -198,7 +198,7 @@ func containerStorageEphemeral(module string, object storage.StoreObject, contai
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				module,
+				md,
 				nil,
 				"Ephemeral storage for container is not defined in Resources.Requests",
 			)
@@ -207,7 +207,7 @@ func containerStorageEphemeral(module string, object storage.StoreObject, contai
 	return nil
 }
 
-func containerSecurityContext(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerSecurityContext(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -216,7 +216,7 @@ func containerSecurityContext(module string, object storage.StoreObject, contain
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				module,
+				md,
 				nil,
 				"Container SecurityContext is not defined",
 			)
@@ -225,7 +225,7 @@ func containerSecurityContext(module string, object storage.StoreObject, contain
 	return nil
 }
 
-func containerPorts(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerPorts(md string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -236,7 +236,7 @@ func containerPorts(module string, object storage.StoreObject, containers []v1.C
 				return errors.NewLintRuleError(
 					ID,
 					object.Identity()+"; container = "+containers[i].Name,
-					module,
+					md,
 					p.ContainerPort,
 					"Container uses port <= 1024",
 				)

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -7,13 +7,14 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/internal/storage"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 const defaultRegistry = "registry.example.com/deckhouse"
 
-func applyContainerRules(object storage.StoreObject) (result errors.LintRuleErrorsList) {
+func applyContainerRules(m *module.Module, object storage.StoreObject) (result errors.LintRuleErrorsList) {
 	containers, err := object.GetContainers()
 	if err != nil {
 		return
@@ -29,19 +30,19 @@ func applyContainerRules(object storage.StoreObject) (result errors.LintRuleErro
 
 	result = errors.LintRuleErrorsList{}
 
-	result.Add(containerNameDuplicates(object, containers))
-	result.Add(containerEnvVariablesDuplicates(object, containers))
-	result.Add(containerImageDigestCheck(object, containers))
-	result.Add(containersImagePullPolicy(object, containers))
+	result.Add(containerNameDuplicates(m.GetName(), object, containers))
+	result.Add(containerEnvVariablesDuplicates(m.GetName(), object, containers))
+	result.Add(containerImageDigestCheck(m.GetName(), object, containers))
+	result.Add(containersImagePullPolicy(m.GetName(), object, containers))
 
-	result.Add(containerStorageEphemeral(object, containers))
-	result.Add(containerSecurityContext(object, containers))
-	result.Add(containerPorts(object, containers))
+	result.Add(containerStorageEphemeral(m.GetName(), object, containers))
+	result.Add(containerSecurityContext(m.GetName(), object, containers))
+	result.Add(containerPorts(m.GetName(), object, containers))
 
 	return result
 }
 
-func containersImagePullPolicy(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containersImagePullPolicy(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	if len(containers) == 0 {
 		return nil
 	}
@@ -57,7 +58,7 @@ func containersImagePullPolicy(object storage.StoreObject, containers []v1.Conta
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity()+"; container = "+c.Name,
-				c.Name,
+				module,
 				c.ImagePullPolicy,
 				`Container imagePullPolicy should be unspecified or "Always"`,
 			)
@@ -66,24 +67,24 @@ func containersImagePullPolicy(object storage.StoreObject, containers []v1.Conta
 		return nil
 	}
 
-	return containerImagePullPolicyIfNotPresent(object, containers)
+	return containerImagePullPolicyIfNotPresent(module, object, containers)
 }
 
-func containerNameDuplicates(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerNameDuplicates(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	names := make(map[string]struct{})
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
 		}
 		if _, ok := names[containers[i].Name]; ok {
-			return errors.NewLintRuleError(ID, object.Identity(), containers[i].Name, nil, "Duplicate container name")
+			return errors.NewLintRuleError(ID, object.Identity(), module, nil, "Duplicate container name")
 		}
 		names[containers[i].Name] = struct{}{}
 	}
 	return nil
 }
 
-func containerEnvVariablesDuplicates(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerEnvVariablesDuplicates(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -94,7 +95,7 @@ func containerEnvVariablesDuplicates(object storage.StoreObject, containers []v1
 				return errors.NewLintRuleError(
 					ID,
 					object.Identity()+"; container = "+containers[i].Name,
-					containers[i].Name,
+					module,
 					variable.Name,
 					"Container has two env variables with same name",
 				)
@@ -128,7 +129,7 @@ func shouldSkipModuleContainer(md, container string) bool {
 	return false
 }
 
-func containerImageDigestCheck(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerImageDigestCheck(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -139,7 +140,7 @@ func containerImageDigestCheck(object storage.StoreObject, containers []v1.Conta
 		if len(match) == 0 {
 			return errors.NewLintRuleError(ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				object.Unstructured.GetName(),
+				module,
 				nil,
 				"Cannot parse repository from image",
 			)
@@ -148,7 +149,7 @@ func containerImageDigestCheck(object storage.StoreObject, containers []v1.Conta
 		if err != nil {
 			return errors.NewLintRuleError(ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				object.Unstructured.GetName(),
+				module,
 				nil,
 				"Cannot parse repository from image: %s", containers[i].Image,
 			)
@@ -157,7 +158,7 @@ func containerImageDigestCheck(object storage.StoreObject, containers []v1.Conta
 		if repo.Name() != defaultRegistry {
 			return errors.NewLintRuleError(ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				object.Unstructured.GetName(),
+				module,
 				nil,
 				"All images must be deployed from the same default registry: %s current: %s",
 				defaultRegistry,
@@ -168,7 +169,7 @@ func containerImageDigestCheck(object storage.StoreObject, containers []v1.Conta
 	return nil
 }
 
-func containerImagePullPolicyIfNotPresent(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerImagePullPolicyIfNotPresent(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -179,7 +180,7 @@ func containerImagePullPolicyIfNotPresent(object storage.StoreObject, containers
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity()+"; container = "+containers[i].Name,
-			containers[i].Name,
+			module,
 			containers[i].ImagePullPolicy,
 			`Container imagePullPolicy should be unspecified or "IfNotPresent"`,
 		)
@@ -187,7 +188,7 @@ func containerImagePullPolicyIfNotPresent(object storage.StoreObject, containers
 	return nil
 }
 
-func containerStorageEphemeral(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerStorageEphemeral(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -197,7 +198,7 @@ func containerStorageEphemeral(object storage.StoreObject, containers []v1.Conta
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				containers[i].Name,
+				module,
 				nil,
 				"Ephemeral storage for container is not defined in Resources.Requests",
 			)
@@ -206,7 +207,7 @@ func containerStorageEphemeral(object storage.StoreObject, containers []v1.Conta
 	return nil
 }
 
-func containerSecurityContext(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerSecurityContext(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -215,7 +216,7 @@ func containerSecurityContext(object storage.StoreObject, containers []v1.Contai
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity()+"; container = "+containers[i].Name,
-				containers[i].Name,
+				module,
 				nil,
 				"Container SecurityContext is not defined",
 			)
@@ -224,7 +225,7 @@ func containerSecurityContext(object storage.StoreObject, containers []v1.Contai
 	return nil
 }
 
-func containerPorts(object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
+func containerPorts(module string, object storage.StoreObject, containers []v1.Container) *errors.LintRuleError {
 	for i := range containers {
 		if shouldSkipModuleContainer(object.Unstructured.GetName(), containers[i].Name) {
 			continue
@@ -235,7 +236,7 @@ func containerPorts(object storage.StoreObject, containers []v1.Container) *erro
 				return errors.NewLintRuleError(
 					ID,
 					object.Identity()+"; container = "+containers[i].Name,
-					containers[i].Name,
+					module,
 					p.ContainerPort,
 					"Container uses port <= 1024",
 				)

--- a/pkg/linters/images/rules/images.go
+++ b/pkg/linters/images/rules/images.go
@@ -209,7 +209,7 @@ func lintWerfFile(file *os.File, name, filePath, relativeFilePath string) []*err
 				errors.NewLintRuleError(
 					ID,
 					filePath,
-					ModuleLabel(name),
+					name,
 					w.From,
 					"Use `from:` or `fromImage:` and `final: false` directives instead of `artifact:` in the werf file",
 				),
@@ -232,8 +232,8 @@ func lintWerfFile(file *os.File, name, filePath, relativeFilePath string) []*err
 			lintErrors = append(lintErrors,
 				errors.NewLintRuleError(
 					ID,
+					filePath,
 					name,
-					fmt.Sprintf("module = %s, path = %s", name, relativeFilePath),
 					w.From,
 					"%s",
 					message,

--- a/pkg/linters/rbac/rbac.go
+++ b/pkg/linters/rbac/rbac.go
@@ -32,7 +32,7 @@ func (*Rbac) Run(m *module.Module) (result errors.LintRuleErrorsList, err error)
 		result.Add(roles.ObjectUserAuthzClusterRolePath(m, object))
 		result.Add(roles.ObjectRBACPlacement(m, object))
 		result.Add(roles.ObjectBindingSubjectServiceAccountCheck(m, object, m.GetObjectStore()))
-		result.Add(roles.ObjectRolesWildcard(object))
+		result.Add(roles.ObjectRolesWildcard(m, object))
 	}
 
 	return result, nil

--- a/pkg/linters/rbac/roles/binding-subject.go
+++ b/pkg/linters/rbac/roles/binding-subject.go
@@ -89,7 +89,7 @@ func ObjectBindingSubjectServiceAccountCheck(
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				subject.Name,
+				m.GetName(),
 				nil,
 				"%s bind to the wrong ServiceAccount (doesn't exist in the store)", objectKind,
 			)

--- a/pkg/linters/rbac/roles/placement.go
+++ b/pkg/linters/rbac/roles/placement.go
@@ -148,7 +148,7 @@ func objectRBACPlacementServiceAccount(m *module.Module, object storage.StoreObj
 				return errors.NewLintRuleError(
 					ID,
 					object.Identity(),
-					object.Unstructured.GetName(),
+					m.GetName(),
 					nil,
 					"ServiceAccount should be deployed to %q", m.GetNamespace(),
 				)
@@ -178,7 +178,7 @@ func objectRBACPlacementServiceAccount(m *module.Module, object storage.StoreObj
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			"Name of ServiceAccount should be equal to %q or %q",
 			serviceAccountName, expectedServiceAccountName,
@@ -187,7 +187,7 @@ func objectRBACPlacementServiceAccount(m *module.Module, object storage.StoreObj
 	return errors.NewLintRuleError(
 		ID,
 		object.Identity(),
-		object.Unstructured.GetName(),
+		m.GetName(),
 		nil,
 		"ServiceAccount should be in %q or \"*/rbac-for-us.yaml\"", RootRBACForUsPath,
 	)
@@ -204,7 +204,7 @@ func objectRBACPlacementClusterRole(kind string, m *module.Module, object storag
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"Name of %s in %q should start with %q",
 				kind, RootRBACForUsPath, name,
@@ -220,7 +220,7 @@ func objectRBACPlacementClusterRole(kind string, m *module.Module, object storag
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"Name of %s should start with %q",
 				kind, n,
@@ -230,7 +230,7 @@ func objectRBACPlacementClusterRole(kind string, m *module.Module, object storag
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			"%s should be in %q or \"*/rbac-for-us.yaml\"",
 			kind, RootRBACForUsPath,
@@ -259,7 +259,7 @@ func objectRBACPlacementRole(kind string, m *module.Module, object storage.Store
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			msgTemplate,
 			kind,
@@ -278,7 +278,7 @@ func handleRootRBACForUs(m *module.Module, object storage.StoreObject, objectNam
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s in %q should be deployed in namespace \"d8-monitoring\", \"d8-system\" or %q",
 				kind, RootRBACForUsPath, m.GetNamespace(),
@@ -289,7 +289,7 @@ func handleRootRBACForUs(m *module.Module, object storage.StoreObject, objectNam
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s in %q should be deployed in namespace \"default\" or \"kube-system\"",
 				kind, RootRBACForUsPath,
@@ -300,7 +300,7 @@ func handleRootRBACForUs(m *module.Module, object storage.StoreObject, objectNam
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s in %q should be deployed in namespace %q",
 				kind, RootRBACForUsPath, m.GetNamespace(),
@@ -318,7 +318,7 @@ func handleRootRBACToUs(m *module.Module, object storage.StoreObject, objectName
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			"%s in %q should start with %q",
 			kind, RootRBACToUsPath, prefix,
@@ -330,7 +330,7 @@ func handleRootRBACToUs(m *module.Module, object storage.StoreObject, objectName
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			"%s in %q should be deployed in namespace \"d8-system\", \"d8-monitoring\" or %q",
 			kind, RootRBACToUsPath, m.GetNamespace(),
@@ -359,7 +359,7 @@ func handleNestedRBACForUs(m *module.Module, object storage.StoreObject, shortPa
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s with prefix %q should be deployed in namespace %q",
 				kind, localPrefix, m.GetNamespace(),
@@ -370,7 +370,7 @@ func handleNestedRBACForUs(m *module.Module, object storage.StoreObject, shortPa
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s with prefix %q should be deployed in namespace \"d8-system\" or \"d8-monitoring\"",
 				kind, globalPrefix,
@@ -381,7 +381,7 @@ func handleNestedRBACForUs(m *module.Module, object storage.StoreObject, shortPa
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s with prefix %q should be deployed in namespace \"default\" or \"kube-system\"",
 				kind, systemPrefix,
@@ -391,7 +391,7 @@ func handleNestedRBACForUs(m *module.Module, object storage.StoreObject, shortPa
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			"%s in %q should start with %q or %q",
 			kind, shortPath, localPrefix, globalPrefix,
@@ -418,7 +418,7 @@ func handleNestedRBACToUs(m *module.Module, object storage.StoreObject, shortPat
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s with prefix %q should be deployed in namespace %q",
 				kind, globalPrefix, m.GetNamespace(),
@@ -429,7 +429,7 @@ func handleNestedRBACToUs(m *module.Module, object storage.StoreObject, shortPat
 			return errors.NewLintRuleError(
 				ID,
 				object.Identity(),
-				object.Unstructured.GetName(),
+				m.GetName(),
 				nil,
 				"%s with prefix %q should be deployed in namespace \"d8-system\" or \"d8-monitoring\"",
 				kind, globalPrefix,
@@ -439,7 +439,7 @@ func handleNestedRBACToUs(m *module.Module, object storage.StoreObject, shortPat
 		return errors.NewLintRuleError(
 			ID,
 			object.Identity(),
-			object.Unstructured.GetName(),
+			m.GetName(),
 			nil,
 			"%s should start with %q or %q", kind, localPrefix, globalPrefix,
 		)


### PR DESCRIPTION
After the changes, the module name is now displayed correctly in error messages:

```
🐒 [#rbac]
        Message - kind cloud-data-discoverer not allowed in "templates/cloud-data-discoverer/rbac-for-us.yaml"
        Object  - kind = ServiceAccount ; name = cloud-data-discoverer ; namespace = d8-cloud-provider-vsphere
        Module  - cloud-provider-vsphere
```

fixed: #38