### PR TITLE
feat: add image name validation rule for werf files

### DIFF
--- a/pkg/linters/images/rules/images.go
+++ b/pkg/linters/images/rules/images.go
@@ -28,6 +28,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -357,4 +358,92 @@ type werfFile struct {
 	Image    string `json:"image" yaml:"image"`
 	From     string `json:"from" yaml:"from"`
 	Final    *bool  `json:"final" yaml:"final"`
+}
+
+func checkImageNames(moduleName, path string) errors.LintRuleErrorsList {
+	result := errors.LintRuleErrorsList{}
+
+	imagesPath := filepath.Join(path, ImagesDir)
+
+	if !IsExistsOnFilesystem(imagesPath) {
+		return result
+	}
+
+	err := filepath.Walk(imagesPath, func(fullPath string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if fsutils.IsDir(fullPath) {
+			return nil
+		}
+
+		if filepath.Base(fullPath) == "werf.inc.yaml" {
+			lines, err := checkImageNamesFromFile(fullPath)
+			path, _ := filepath.Rel(imagesPath, fullPath)
+			if err != nil {
+				result.Add(errors.NewLintRuleError(
+					ID,
+					path,
+					moduleName,
+					nil,
+					"Cannot read file: %s",
+					err.Error(),
+				))
+				return nil
+			}
+			if len(lines) > 0 {
+				result.Add(errors.NewLintRuleError(
+					ID,
+					path,
+					moduleName,
+					nil,
+					"Image name format should be like `image: {{ .ModuleName }}/{{ .ImageName }}[-something]` in file: %s\n\t\t  broken lines:\n\t\t  %s",
+					path,
+					strings.Join(lines, "\n\t\t  "),
+				))
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			imagesPath,
+			moduleName,
+			nil,
+			"Cannot read directory structure: %s",
+			err.Error(),
+		))
+
+		return result
+	}
+
+	return result
+}
+
+func checkImageNamesFromFile(path string) ([]string, error) {
+	var lines []string
+	file, err := os.Open(path)
+	if err != nil {
+		return lines, err
+	}
+	defer file.Close()
+
+	r := regexp.MustCompile(`^image:\s*\{\{\s*\$?\.ModuleName\s*\}\}/\{\{\s*\$?\.ImageName\s*\}\}`)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "image:") {
+			if !r.MatchString(line) {
+				lines = append(lines, line)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return lines, err
+	}
+
+	return lines, nil
 }

--- a/pkg/linters/images/rules/images.go
+++ b/pkg/linters/images/rules/images.go
@@ -398,8 +398,7 @@ func checkImageNames(moduleName, path string) errors.LintRuleErrorsList {
 					path,
 					moduleName,
 					nil,
-					"Image name format should be like `image: {{ .ModuleName }}/{{ .ImageName }}[-something]` in file: %s\n\t\t  broken lines:\n\t\t  %s",
-					path,
+					"Image name format should be like `image: {{ .ModuleName }}/{{ .ImageName }}[-something]`\n\t\t  broken lines:\n\t\t  %s",
 					strings.Join(lines, "\n\t\t  "),
 				))
 			}
@@ -433,13 +432,13 @@ func checkImageNamesFromFile(path string) ([]string, error) {
 
 	r := regexp.MustCompile(`^image:\s*\{\{\s*\$?\.ModuleName\s*\}\}/\{\{\s*\$?\.ImageName\s*\}\}`)
 	scanner := bufio.NewScanner(file)
-        lineNumber := 0
+	lineNumber := 0
 	for scanner.Scan() {
-	        lineNumber++
+		lineNumber++
 		line := scanner.Text()
 		if strings.HasPrefix(line, "image:") {
 			if !r.MatchString(line) {
-				lines = append(lines, fmt.Sprintf("%s (Line: %d)", line, lineNumber))
+				lines = append(lines, line)
 			}
 		}
 	}

--- a/pkg/linters/images/rules/images.go
+++ b/pkg/linters/images/rules/images.go
@@ -433,11 +433,13 @@ func checkImageNamesFromFile(path string) ([]string, error) {
 
 	r := regexp.MustCompile(`^image:\s*\{\{\s*\$?\.ModuleName\s*\}\}/\{\{\s*\$?\.ImageName\s*\}\}`)
 	scanner := bufio.NewScanner(file)
+        lineNumber := 0
 	for scanner.Scan() {
+	        lineNumber++
 		line := scanner.Text()
 		if strings.HasPrefix(line, "image:") {
 			if !r.MatchString(line) {
-				lines = append(lines, line)
+				lines = append(lines, fmt.Sprintf("%s (Line: %d)", line, lineNumber))
 			}
 		}
 	}

--- a/pkg/linters/images/rules/rules.go
+++ b/pkg/linters/images/rules/rules.go
@@ -86,6 +86,7 @@ func IsExistsOnFilesystem(parts ...string) bool {
 func ApplyImagesRules(m *module.Module) errors.LintRuleErrorsList {
 	result := errors.LintRuleErrorsList{}
 	result.Merge(CheckImageNamesInDockerAndWerfFiles(m.GetName(), m.GetPath()))
+	result.Merge(checkImageNames(m.GetName(), m.GetPath()))
 	result.Merge(chartModuleRule(m.GetName(), m.GetPath()))
 
 	return result


### PR DESCRIPTION
fixed: #60 

example output:

```plain
🐒 [#images]
        Message - Image name format should be like `image: {{ .ModuleName }}/{{ .ImageName }}[-something]` in file: terraform-manager-yandex/werf.inc.yaml
                  broken lines:
                  image: terraform-provider-yandex
        Object  - terraform-manager-yandex/werf.inc.yaml
        Module  - terraform-manager
```