### PR TITLE
[linter] add conversion linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ linters-settings:
     skip-module-checks:
       - "340-extended-monitoring"
       - "030-cloud-provider-yandex"
+  conversions:
+    skip-check:
+    - flow-schema
+    first-version: 2
 warnings-only:
   - openapi
   - no-cyrillic

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/deckhouse/dmt/pkg/linters/conversions"
 	"github.com/deckhouse/dmt/pkg/linters/ingress"
 	k8s_resources "github.com/deckhouse/dmt/pkg/linters/k8s-resources"
 	moduleLinter "github.com/deckhouse/dmt/pkg/linters/module"
@@ -63,6 +64,7 @@ func NewManager(dirs []string, cfg *config.Config) *Manager {
 		monitoring.New(&cfg.LintersSettings.Monitoring),
 		ingress.New(&cfg.LintersSettings.Ingress),
 		moduleLinter.New(&cfg.LintersSettings.Module),
+		conversions.New(&cfg.LintersSettings.Conversions),
 	}
 
 	m.lintersMap = make(map[string]Linter)

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -13,6 +13,7 @@ type LintersSettings struct {
 	Monitoring   MonitoringSettings   `mapstructure:"monitoring"`
 	Ingress      IngressSettings      `mapstructure:"ingress"`
 	Module       ModuleSettings       `mapstructure:"module"`
+	Conversions  ConversionsSettings  `mapstructure:"conversions"`
 }
 
 type OpenAPISettings struct {
@@ -74,4 +75,11 @@ type IngressSettings struct {
 
 type ModuleSettings struct {
 	SkipCheckModuleYaml []string `mapstructure:"skip-check-module-yaml"`
+}
+
+type ConversionsSettings struct {
+	// skip all conversion checks for this modules
+	SkipCheckModule []string `mapstructure:"skip-check"`
+	// first conversion version to make conversion flow
+	FirstVersion int `mapstructure:"first-version"`
 }

--- a/pkg/linters/conversions/conversions.go
+++ b/pkg/linters/conversions/conversions.go
@@ -1,0 +1,47 @@
+package conversions
+
+import (
+	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+// Conversions linter
+type Conversions struct {
+	name, desc string
+	cfg        *config.ConversionsSettings
+}
+
+const ID = "conversions"
+
+var Cfg *config.ConversionsSettings
+
+func New(cfg *config.ConversionsSettings) *Conversions {
+	Cfg = cfg
+
+	return &Conversions{
+		name: ID,
+		desc: "Lint conversions rules",
+		cfg:  cfg,
+	}
+}
+
+func (*Conversions) Run(m *module.Module) (errors.LintRuleErrorsList, error) {
+	result := errors.LintRuleErrorsList{}
+
+	if m == nil {
+		return result, nil
+	}
+
+	result.Merge(checkModuleYaml(m.GetName(), m.GetPath()))
+
+	return result, nil
+}
+
+func (o *Conversions) Name() string {
+	return o.name
+}
+
+func (o *Conversions) Desc() string {
+	return o.desc
+}

--- a/pkg/linters/conversions/conversions.go
+++ b/pkg/linters/conversions/conversions.go
@@ -12,17 +12,24 @@ type Conversions struct {
 	cfg        *config.ConversionsSettings
 }
 
+type ConversionsSettings struct {
+	// skip all conversion checks for this modules
+	SkipCheckModule map[string]struct{}
+	// first conversion version to make conversion flow
+	FirstVersion int
+}
+
 const ID = "conversions"
 
-var Cfg *config.ConversionsSettings
+var cfg *ConversionsSettings
 
-func New(cfg *config.ConversionsSettings) *Conversions {
-	Cfg = cfg
+func New(inputCfg *config.ConversionsSettings) *Conversions {
+	cfg = remapConversionsConfig(inputCfg)
 
 	return &Conversions{
 		name: ID,
 		desc: "Lint conversions rules",
-		cfg:  cfg,
+		cfg:  inputCfg,
 	}
 }
 
@@ -44,4 +51,16 @@ func (o *Conversions) Name() string {
 
 func (o *Conversions) Desc() string {
 	return o.desc
+}
+
+func remapConversionsConfig(input *config.ConversionsSettings) *ConversionsSettings {
+	cfg := &ConversionsSettings{
+		FirstVersion: input.FirstVersion,
+	}
+
+	for _, module := range input.SkipCheckModule {
+		cfg.SkipCheckModule[module] = struct{}{}
+	}
+
+	return cfg
 }

--- a/pkg/linters/conversions/conversions.go
+++ b/pkg/linters/conversions/conversions.go
@@ -54,13 +54,13 @@ func (o *Conversions) Desc() string {
 }
 
 func remapConversionsConfig(input *config.ConversionsSettings) *ConversionsSettings {
-	cfg := &ConversionsSettings{
+	newCfg := &ConversionsSettings{
 		FirstVersion: input.FirstVersion,
 	}
 
 	for _, module := range input.SkipCheckModule {
-		cfg.SkipCheckModule[module] = struct{}{}
+		newCfg.SkipCheckModule[module] = struct{}{}
 	}
 
-	return cfg
+	return newCfg
 }

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -60,7 +60,20 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 	versions := make([]int, 0)
 
-	err = filepath.Walk(folder, func(path string, _ fs.FileInfo, _ error) error {
+	_ = filepath.Walk(folder, func(path string, _ fs.FileInfo, err error) error {
+		if err != nil {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"Walk error with file: %q",
+				path,
+			))
+
+			return nil
+		}
+
 		if !regexVersionFile.MatchString(filepath.Base(path)) {
 			return nil
 		}
@@ -91,18 +104,6 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 		return nil
 	})
-	if err != nil {
-		result.Add(errors.NewLintRuleError(
-			ID,
-			moduleName,
-			moduleName,
-			nil,
-			"Walk error in folder: %q",
-			folder,
-		))
-
-		return result
-	}
 
 	if len(versions) == 0 {
 		result.Add(errors.NewLintRuleError(

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -34,7 +34,8 @@ type description struct {
 func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 	result := errors.LintRuleErrorsList{}
 
-	if slices.Contains(Cfg.SkipCheckModule, moduleName) {
+	_, ok := cfg.SkipCheckModule[moduleName]
+	if ok {
 		return result
 	}
 
@@ -129,14 +130,14 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 	slices.Sort(versions)
 
-	if Cfg.FirstVersion != 0 && versions[0] != Cfg.FirstVersion {
+	if cfg.FirstVersion != 0 && versions[0] != cfg.FirstVersion {
 		result.Add(errors.NewLintRuleError(
 			ID,
 			moduleName,
 			moduleName,
 			nil,
 			"You need to start with version number: %d",
-			Cfg.FirstVersion,
+			cfg.FirstVersion,
 		))
 	}
 

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -191,7 +191,7 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 	slices.Sort(versions)
 
-	if versions[0] != Cfg.FirstVersion {
+	if Cfg.FirstVersion != 0 && versions[0] != Cfg.FirstVersion {
 		result.Add(errors.NewLintRuleError(
 			ID,
 			moduleName,

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -1,0 +1,219 @@
+package conversions
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	ConversionsFolder = "openapi/conversions"
+)
+
+var regexVersionFile = regexp.MustCompile("v([1-9]|[1-9][0-9]|[1-9][0-9][0-9]).yaml|v([1-9]|[1-9][0-9]|[1-9][0-9][0-9]).yml")
+
+type conversion struct {
+	Version     *int         `yaml:"version,omitempty"`
+	Description *description `yaml:"description,omitempty"`
+}
+
+type description struct {
+	English string `yaml:"en,omitempty"`
+	Russian string `yaml:"ru,omitempty"`
+}
+
+func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
+	result := errors.LintRuleErrorsList{}
+
+	if slices.Contains(Cfg.SkipCheckModule, moduleName) {
+		return result
+	}
+
+	folder := filepath.Join(filepath.Join(modulePath, ConversionsFolder))
+
+	stat, err := os.Stat(folder)
+	if err != nil && !os.IsNotExist(err) {
+		panic(err)
+	}
+
+	if os.IsNotExist(err) || !stat.IsDir() {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"Cannot stat conversions folder %q: %s",
+			ConversionsFolder, err.Error(),
+		))
+
+		return result
+	}
+
+	versions := make([]int, 0)
+
+	_ = filepath.Walk(folder, func(path string, info fs.FileInfo, _ error) error {
+		if !regexVersionFile.MatchString(filepath.Base(path)) {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"Cannot open file to read conversion %q: %s",
+				ConversionsFolder, err.Error(),
+			))
+
+			return nil
+		}
+
+		c := new(conversion)
+		err = yaml.NewDecoder(file).Decode(c)
+		if err != nil {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"Cannot decode yaml %q: %s",
+				ConversionsFolder, err.Error(),
+			))
+
+			return nil
+		}
+
+		if c.Description != nil {
+			if c.Description.Russian == "" {
+				result.Add(errors.NewLintRuleError(
+					ID,
+					moduleName,
+					moduleName,
+					nil,
+					"No description for conversion: russian",
+				))
+			}
+
+			if c.Description.English == "" {
+				result.Add(errors.NewLintRuleError(
+					ID,
+					moduleName,
+					moduleName,
+					nil,
+					"No description for conversion: russian",
+				))
+			}
+		}
+
+		if c.Version == nil {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"Version is empty, filename: %q",
+				filepath.Base(path),
+			))
+
+			return nil
+		}
+
+		versions = append(versions, *c.Version)
+
+		separated := strings.SplitN(filepath.Base(path), ".", 2)
+		if len(separated) <= 1 {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"Bad filename %q",
+				filepath.Base(path),
+			))
+
+			return nil
+		}
+
+		rawVersion := strings.TrimPrefix(separated[0], "v")
+
+		fileVersion, err := strconv.Atoi(rawVersion)
+		if err != nil {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"Cannot convert version from file name %q: %s",
+				filepath.Base(path), err.Error(),
+			))
+
+			return nil
+		}
+
+		if *c.Version != fileVersion {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"File name %q doesn't correspond with contained version %d",
+				filepath.Base(path), *c.Version,
+			))
+
+			return nil
+		}
+
+		return nil
+	})
+
+	if len(versions) == 0 {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"No versions in folder: %q",
+			folder,
+		))
+
+		return result
+	}
+
+	slices.Sort(versions)
+
+	if versions[0] != Cfg.FirstVersion {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"You need to start with version number: %d",
+			Cfg.FirstVersion,
+		))
+	}
+
+	for i := 1; i < len(versions); i++ {
+		if versions[i]-versions[i-1] > 1 {
+			result.Add(errors.NewLintRuleError(
+				ID,
+				moduleName,
+				moduleName,
+				nil,
+				"No sequential versions between %d and %d",
+				versions[i], versions[i-1],
+			))
+		}
+	}
+
+	return result
+}

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -42,6 +42,15 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 	stat, err := os.Stat(folder)
 	if err != nil && !os.IsNotExist(err) {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"Cannot stat conversions folder %q: %s",
+			conversionsFolder, err.Error(),
+		))
+
 		return result
 	}
 
@@ -51,7 +60,7 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 			moduleName,
 			moduleName,
 			nil,
-			"Cannot stat conversions folder %q: %s",
+			"Conversions folder is not exist, at path %q: %s",
 			conversionsFolder, err.Error(),
 		))
 
@@ -165,29 +174,7 @@ func parseConversion(path string) (*conversion, error) {
 func conversionCheck(c *conversion, moduleName, path string) errors.LintRuleErrorsList {
 	result := errors.LintRuleErrorsList{}
 
-	if c.Description != nil {
-		if c.Description.Russian == "" {
-			result.Add(errors.NewLintRuleError(
-				ID,
-				moduleName,
-				moduleName,
-				nil,
-				"No description for conversion: russian, filename: %q",
-				filepath.Base(path),
-			))
-		}
-
-		if c.Description.English == "" {
-			result.Add(errors.NewLintRuleError(
-				ID,
-				moduleName,
-				moduleName,
-				nil,
-				"No description for conversion: russian, filename: %q",
-				filepath.Base(path),
-			))
-		}
-	}
+	result.Merge(descriptionCheck(c, moduleName, path))
 
 	if c.Version == nil {
 		result.Add(errors.NewLintRuleError(
@@ -200,6 +187,47 @@ func conversionCheck(c *conversion, moduleName, path string) errors.LintRuleErro
 		))
 
 		return result
+	}
+
+	return result
+}
+
+func descriptionCheck(c *conversion, moduleName, path string) errors.LintRuleErrorsList {
+	result := errors.LintRuleErrorsList{}
+
+	if c.Description == nil {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"Description is empty, filename: %q",
+			filepath.Base(path),
+		))
+
+		return result
+	}
+
+	if c.Description.Russian == "" {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"No description for conversion: russian, filename: %q",
+			filepath.Base(path),
+		))
+	}
+
+	if c.Description.English == "" {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"No description for conversion: russian, filename: %q",
+			filepath.Base(path),
+		))
 	}
 
 	return result

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -208,8 +208,8 @@ func conversionCheck(c *conversion, moduleName, path string) errors.LintRuleErro
 func compareWithFileName(c *conversion, moduleName, path string) errors.LintRuleErrorsList {
 	result := errors.LintRuleErrorsList{}
 
-	separated := strings.SplitN(filepath.Base(path), ".", 2)
-	if len(separated) <= 1 {
+	versions := regexVersionFile.FindStringSubmatch(filepath.Base(path))
+	if len(versions) <= 1 {
 		result.Add(errors.NewLintRuleError(
 			ID,
 			moduleName,
@@ -222,9 +222,7 @@ func compareWithFileName(c *conversion, moduleName, path string) errors.LintRule
 		return result
 	}
 
-	rawVersion := strings.TrimPrefix(separated[0], "v")
-
-	fileVersion, err := strconv.Atoi(rawVersion)
+	fileVersion, err := strconv.Atoi(versions[1])
 	if err != nil {
 		result.Add(errors.NewLintRuleError(
 			ID,

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	ConversionsFolder = "openapi/conversions"
+	conversionsFolder = "openapi/conversions"
 )
 
-var regexVersionFile = regexp.MustCompile("v([1-9]|[1-9][0-9]|[1-9][0-9][0-9]).yaml|v([1-9]|[1-9][0-9]|[1-9][0-9][0-9]).yml")
+var regexVersionFile = regexp.MustCompile(`^v[1-9][0-9]{0,2}\.ya?ml$`)
 
 type conversion struct {
 	Version     *int         `yaml:"version,omitempty"`
@@ -38,11 +38,11 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 		return result
 	}
 
-	folder := filepath.Join(modulePath, ConversionsFolder)
+	folder := filepath.Join(modulePath, conversionsFolder)
 
 	stat, err := os.Stat(folder)
 	if err != nil && !os.IsNotExist(err) {
-		panic(err)
+		return result
 	}
 
 	if os.IsNotExist(err) || !stat.IsDir() {
@@ -52,7 +52,7 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 			moduleName,
 			nil,
 			"Cannot stat conversions folder %q: %s",
-			ConversionsFolder, err.Error(),
+			conversionsFolder, err.Error(),
 		))
 
 		return result
@@ -137,13 +137,13 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 func parseConversion(path string) (*conversion, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open file to read conversion %q: %w", ConversionsFolder, err)
+		return nil, fmt.Errorf("cannot open file to read conversion %q: %w", conversionsFolder, err)
 	}
 
 	c := new(conversion)
 	err = yaml.NewDecoder(file).Decode(c)
 	if err != nil {
-		return nil, fmt.Errorf("cannot decode yaml %q: %w", ConversionsFolder, err)
+		return nil, fmt.Errorf("cannot decode yaml %q: %w", conversionsFolder, err)
 	}
 
 	return c, nil

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -88,6 +88,8 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 			return nil
 		}
 
+		// TODO: return error that name is matched and is dir
+
 		c, err := parseConversion(path)
 		if err != nil {
 			result.Add(errors.NewLintRuleError(

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -19,7 +19,7 @@ const (
 	conversionsFolder = "openapi/conversions"
 )
 
-var regexVersionFile = regexp.MustCompile(`^v[1-9][0-9]{0,2}\.ya?ml$`)
+var regexVersionFile = regexp.MustCompile(`^v([1-9]\d{0,2})\.ya?ml$`)
 
 type conversion struct {
 	Version     *int         `yaml:"version,omitempty"`
@@ -60,7 +60,7 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 	versions := make([]int, 0)
 
-	_ = filepath.Walk(folder, func(path string, _ fs.FileInfo, _ error) error {
+	err = filepath.Walk(folder, func(path string, _ fs.FileInfo, _ error) error {
 		if !regexVersionFile.MatchString(filepath.Base(path)) {
 			return nil
 		}
@@ -91,6 +91,18 @@ func checkModuleYaml(moduleName, modulePath string) errors.LintRuleErrorsList {
 
 		return nil
 	})
+	if err != nil {
+		result.Add(errors.NewLintRuleError(
+			ID,
+			moduleName,
+			moduleName,
+			nil,
+			"Walk error in folder: %q",
+			folder,
+		))
+
+		return result
+	}
 
 	if len(versions) == 0 {
 		result.Add(errors.NewLintRuleError(

--- a/pkg/linters/conversions/rules.go
+++ b/pkg/linters/conversions/rules.go
@@ -228,7 +228,7 @@ func descriptionCheck(c *conversion, moduleName, path string) errors.LintRuleErr
 			moduleName,
 			moduleName,
 			nil,
-			"No description for conversion: russian, filename: %q",
+			"No description for conversion: english, filename: %q",
 			filepath.Base(path),
 		))
 	}


### PR DESCRIPTION
Add conversion linter

Checks:
1) 'openapi/conversions' folder exists
2) for every file in folder 'openapi/conversions' with name pattern 'v0.yaml' or 'v0.yml'
2.1) file not empty
2.2) version is not empty
2.3) filename correspond with version in file
2.4) description filled for ru and eng
3) parsed versions from files exists
4) first version equals 'first-version' rule in '.dmtlint .yaml'. if rule equals 0 or not filled - skip this check
5) check sequence of conversion versions, if it has break sequential versions like '2,3,5,6' - linter throw error

Rules:
```yaml
# linter name
  conversions:
# skip conversions check for modules list
    skip-check:
    - flow-schema
# start checks from this version
    first-version: 2
```