### PR TITLE
Add custom module chart loader

### DIFF
--- a/internal/module/loader.go
+++ b/internal/module/loader.go
@@ -1,0 +1,110 @@
+package module
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/ignore"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// kind of fork from helmv3: pkg/chart/loader/directory.go
+// but with Chart.yaml injection
+
+var utf8bom = []byte{0xEF, 0xBB, 0xBF}
+
+// LoadModuleAsChart loads a module as a chart
+// default helm loader couldn't be used without Chart.yaml, but deckhouse module
+// could exist without this file, deckhouse will create it automatically
+func LoadModuleAsChart(moduleName, dir string) (*chart.Chart, error) {
+	topdir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Just used for errors.
+	c := &chart.Chart{}
+
+	rules := ignore.Empty()
+	ifile := filepath.Join(topdir, ignore.HelmIgnore)
+	if _, err := os.Stat(ifile); err == nil {
+		r, err := ignore.ParseFile(ifile)
+		if err != nil {
+			return c, err
+		}
+		rules = r
+	}
+	rules.AddDefaults()
+
+	files := make([]*loader.BufferedFile, 0)
+	topdir += string(filepath.Separator)
+
+	chartFileExists := false
+
+	walk := func(name string, fi os.FileInfo, err error) error {
+		n := strings.TrimPrefix(name, topdir)
+		if n == "" {
+			// No need to process top level. Avoid bug with helmignore .* matching
+			// empty names. See issue 1779.
+			return nil
+		}
+
+		if n == "Chart.yaml" {
+			chartFileExists = true
+		}
+
+		// Normalize to / since it will also work on Windows
+		n = filepath.ToSlash(n)
+
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			// Directory-based ignore rules should involve skipping the entire
+			// contents of that directory.
+			if rules.Ignore(n, fi) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// If a .helmignore file matches, skip this file.
+		if rules.Ignore(n, fi) {
+			return nil
+		}
+
+		// Irregular files include devices, sockets, and other uses of files that
+		// are not regular files. In Go they have a file mode type bit set.
+		// See https://golang.org/pkg/os/#FileMode for examples.
+		if !fi.Mode().IsRegular() {
+			return fmt.Errorf("cannot load irregular file %s as it has file mode type bits set", name)
+		}
+
+		data, err := os.ReadFile(name)
+		if err != nil {
+			return errors.Wrapf(err, "error reading %s", n)
+		}
+
+		data = bytes.TrimPrefix(data, utf8bom)
+
+		files = append(files, &loader.BufferedFile{Name: n, Data: data})
+		return nil
+	}
+
+	if err = Walk(topdir, walk); err != nil {
+		return c, err
+	}
+
+	if !chartFileExists {
+		files = append(files, &loader.BufferedFile{
+			Name: "Chart.yaml",
+			Data: []byte(fmt.Sprintf("name: %s\nversion: 0.2.0\n", moduleName)),
+		})
+	}
+
+	return loader.LoadFiles(files)
+}

--- a/internal/module/loader.go
+++ b/internal/module/loader.go
@@ -3,13 +3,13 @@ package module
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/ignore"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/ignore"
 )
 
 // kind of fork from helmv3: pkg/chart/loader/directory.go
@@ -31,8 +31,8 @@ func LoadModuleAsChart(moduleName, dir string) (*chart.Chart, error) {
 
 	rules := ignore.Empty()
 	ifile := filepath.Join(topdir, ignore.HelmIgnore)
-	if _, err := os.Stat(ifile); err == nil {
-		r, err := ignore.ParseFile(ifile)
+	if _, err = os.Stat(ifile); err == nil {
+		r, err := ignore.ParseFile(ifile) //nolint:govet // copypaste from helmv3
 		if err != nil {
 			return c, err
 		}
@@ -86,7 +86,7 @@ func LoadModuleAsChart(moduleName, dir string) (*chart.Chart, error) {
 
 		data, err := os.ReadFile(name)
 		if err != nil {
-			return errors.Wrapf(err, "error reading %s", n)
+			return fmt.Errorf("error reading %s: %w", n, err)
 		}
 
 		data = bytes.TrimPrefix(data, utf8bom)
@@ -95,6 +95,7 @@ func LoadModuleAsChart(moduleName, dir string) (*chart.Chart, error) {
 		return nil
 	}
 
+	//nolint:gocritic // copypaste from helmv3
 	if err = Walk(topdir, walk); err != nil {
 		return c, err
 	}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -9,12 +9,10 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
-
 	"github.com/deckhouse/dmt/internal/storage"
 	"github.com/deckhouse/dmt/internal/werf"
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/chart"
 )
 
 const (
@@ -107,10 +105,11 @@ func NewModule(path string) (*Module, error) {
 		path:      path,
 	}
 
-	ch, err := loader.Load(path)
+	ch, err := LoadModuleAsChart(name, path)
 	if err != nil {
 		return nil, err
 	}
+
 	reHelmModule := regexp.MustCompile(`{{ include "helm_lib_module_(?:image|common_image).* }}`)
 	reImageDigest := regexp.MustCompile(`\$\.Values\.global\.modulesImages\.digests\.\S*`)
 	for i := range ch.Templates {
@@ -175,7 +174,6 @@ func getModuleName(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	return ch.Name, nil
 }
 

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -9,10 +9,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/deckhouse/dmt/internal/storage"
-	"github.com/deckhouse/dmt/internal/werf"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/chart"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/internal/werf"
 )
 
 const (

--- a/internal/module/sympath.go
+++ b/internal/module/sympath.go
@@ -1,0 +1,101 @@
+package module
+
+// fork from helmv3: internal/sympath/walk.go
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/pkg/errors"
+)
+
+// Walk walks the file tree rooted at root, calling walkFn for each file or directory
+// in the tree, including root. All errors that arise visiting files and directories
+// are filtered by walkFn. The files are walked in lexical order, which makes the
+// output deterministic but means that for very large directories Walk can be
+// inefficient. Walk follows symbolic links.
+func Walk(root string, walkFn filepath.WalkFunc) error {
+	info, err := os.Lstat(root)
+	if err != nil {
+		err = walkFn(root, nil, err)
+	} else {
+		err = symwalk(root, info, walkFn)
+	}
+	if err == filepath.SkipDir {
+		return nil
+	}
+	return err
+}
+
+// readDirNames reads the directory named by dirname and returns
+// a sorted list of directory entries.
+func readDirNames(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// symwalk recursively descends path, calling walkFn.
+func symwalk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	// Recursively walk symlinked directories.
+	if IsSymlink(info) {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return errors.Wrapf(err, "error evaluating symlink %s", path)
+		}
+		log.Printf("found symbolic link in path: %s resolves to %s. Contents of linked file included and used", path, resolved)
+		if info, err = os.Lstat(resolved); err != nil {
+			return err
+		}
+		if err := symwalk(path, info, walkFn); err != nil && err != filepath.SkipDir {
+			return err
+		}
+		return nil
+	}
+
+	if err := walkFn(path, info, nil); err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return nil
+	}
+
+	names, err := readDirNames(path)
+	if err != nil {
+		return walkFn(path, info, err)
+	}
+
+	for _, name := range names {
+		filename := filepath.Join(path, name)
+		fileInfo, err := os.Lstat(filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil && !errors.Is(err, filepath.SkipDir) {
+				return err
+			}
+		} else {
+			err = symwalk(filename, fileInfo, walkFn)
+			if err != nil {
+				if (!fileInfo.IsDir() && !IsSymlink(fileInfo)) || !errors.Is(err, filepath.SkipDir) {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// IsSymlink is used to determine if the fileinfo is a symbolic link.
+func IsSymlink(fi os.FileInfo) bool {
+	return fi.Mode()&os.ModeSymlink != 0
+}

--- a/pkg/linters/conversions/conversions.go
+++ b/pkg/linters/conversions/conversions.go
@@ -55,7 +55,8 @@ func (o *Conversions) Desc() string {
 
 func remapConversionsConfig(input *config.ConversionsSettings) *ConversionsSettings {
 	newCfg := &ConversionsSettings{
-		FirstVersion: input.FirstVersion,
+		FirstVersion:    input.FirstVersion,
+		SkipCheckModule: make(map[string]struct{}),
 	}
 
 	for _, module := range input.SkipCheckModule {


### PR DESCRIPTION
We have an error like:
```
🐒 [#manager]
        Message - cannot create module `600-namespace-configurator`
        Object  - /deckhouse/modules/600-namespace-configurator
        Module  - 600-namespace-configurator
        Value   - Chart.yaml file is missing
```

because Deckhouse doesn't require the Chart.yaml file. It will create it automatically. But chart parsing requires this file, so we have to implement out custom loader, based on helm DirLoader.



Also fixes the error:
```
🐒 [#conversions]
        Message - Conversions folder is not exist, at path "openapi/conversions": stat /deckhouse/modules/600-namespace-configurator/openapi/conversions: no such file or directory
        Object  - namespace-configurator
        Module  - namespace-configurator
```