### PR TITLE
feat: change processing helm chart with remaping templates

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -176,20 +176,6 @@ func (m *Manager) PrintResult() {
 		)
 	})
 
-	//for _, e := range errs {
-	//	if e.LinterID != "container" {
-	//		continue
-	//	}
-	//	arr := strings.Split(e.ObjectID, " ; ")
-	//	fmt.Printf("%s:\n  - %s\n    %s\n    %s\n",
-	//		e.RuleID,
-	//		strings.ReplaceAll(arr[0], " =", ":"),
-	//		strings.ReplaceAll(arr[1], " =", ":"),
-	//		strings.ReplaceAll(arr[3], " =", ":"),
-	//	)
-	//}
-	//return
-
 	w := new(tabwriter.Writer)
 
 	const minWidth = 5

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -41,6 +41,9 @@ func applyDigests(digests, values map[string]any) {
 		"global": map[string]any{
 			"modulesImages": map[string]any{
 				"digests": digests,
+				"registry": map[string]any{
+					"base": "registry.example.com/deckhouse",
+				},
 			},
 		},
 	}
@@ -56,10 +59,19 @@ func helmFormatModuleImages(m *Module, rawValues map[string]any) (chartutil.Valu
 
 	digests := map[string]any{
 		"common": map[string]any{
-			"module": "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+			"init":      "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+			"container": "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
 		},
-		m.GetName(): map[string]any{
-			"module": "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+		"prompp": map[string]any{
+			"prompp": "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+		},
+		"module": map[string]any{
+			"container": "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+		},
+		"controlPlaneManager": map[string]any{
+			"kubeApiserver":         "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+			"kubeControllerManager": "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
+			"kubeScheduler":         "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc",
 		},
 	}
 

--- a/internal/module/openapi_test.go
+++ b/internal/module/openapi_test.go
@@ -355,6 +355,9 @@ func Test_applyDigests(t *testing.T) {
 				"global": map[string]any{
 					"modulesImages": map[string]any{
 						"digests": map[string]any{},
+						"registry": map[string]any{
+							"base": "registry.example.com/deckhouse",
+						},
 					},
 				},
 			},
@@ -373,6 +376,9 @@ func Test_applyDigests(t *testing.T) {
 					"modulesImages": map[string]any{
 						"digests": map[string]any{
 							"image1": "digest1",
+						},
+						"registry": map[string]any{
+							"base": "registry.example.com/deckhouse",
 						},
 					},
 				},

--- a/internal/module/templates/_module_image.tpl
+++ b/internal/module/templates/_module_image.tpl
@@ -1,0 +1,59 @@
+{{- /* Usage: {{ include "helm_lib_module_image" (list . "<container-name>") }} */ -}}
+{{- /* returns image name */ -}}
+{{- define "helm_lib_module_image" }}
+  {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $containerName := "container" }} {{- /* Container name */ -}}
+  {{- $moduleName := (include "helm_lib_module_camelcase_name" $context) }}
+  {{- $imageDigest := "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc" }}
+  {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
+  {{- /*  handle external modules registry */}}
+  {{- if index $context.Values $moduleName }}
+    {{- if index $context.Values $moduleName "registry" }}
+      {{- if index $context.Values $moduleName "registry" "base" }}
+        {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+        {{- $path := trimAll "/" $context.Chart.Name }}
+        {{- $registryBase = join "/" (list $host $path) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- printf "%s@%s" $registryBase $imageDigest }}
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_image_no_fail" (list . "<container-name>") }} */ -}}
+{{- /* returns image name if found */ -}}
+{{- define "helm_lib_module_image_no_fail" }}
+  {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $containerName := "container" }} {{- /* Container name */ -}}
+  {{- $moduleName := (include "helm_lib_module_camelcase_name" $context) }}
+  {{- $imageDigest := "sha256:d478cd82cb6a604e3a27383daf93637326d402570b2f3bec835d1f84c9ed0acc" }}
+  {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
+  {{- /*  handle external modules registry */}}
+  {{- if index $context.Values $moduleName }}
+    {{- if index $context.Values $moduleName "registry" }}
+      {{- if index $context.Values $moduleName "registry" "base" }}
+        {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+        {{- $path := trimAll "/" $context.Chart.Name }}
+        {{- $registryBase = join "/" (list $host $path) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- printf "%s@%s" $registryBase $imageDigest }}
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_common_image" (list . "<container-name>") }} */ -}}
+{{- /* returns image name from common module */ -}}
+{{- define "helm_lib_module_common_image" }}
+  {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $containerName := "container" }} {{- /* Container name */ -}}
+  {{- $imageDigest := index $context.Values.global.modulesImages.digests "common" $containerName }}
+  {{- printf "%s@%s" $context.Values.global.modulesImages.registry.base $imageDigest }}
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_common_image_no_fail" (list . "<container-name>") }} */ -}}
+{{- /* returns image name from common module if found */ -}}
+{{- define "helm_lib_module_common_image_no_fail" }}
+  {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $containerName := "container" }} {{- /* Container name */ -}}
+  {{- $imageDigest := index $context.Values.global.modulesImages.digests "common" $containerName }}
+  {{- printf "%s@%s" $context.Values.global.modulesImages.registry.base $imageDigest }}
+{{- end }}

--- a/internal/module/templates/_module_name.tpl
+++ b/internal/module/templates/_module_name.tpl
@@ -1,0 +1,3 @@
+{{- define "helm_lib_module_camelcase_name" -}}
+{{- $moduleName := "module" -}}
+{{- end -}}

--- a/internal/valuesvalidation/global-openapi/values.yaml
+++ b/internal/valuesvalidation/global-openapi/values.yaml
@@ -326,7 +326,6 @@ properties:
           Node will have role 'some-role' if it has label with prefix node-role.deckhouse.io/
           Do not use label with prefix node-role.deckhouse.io/ on workers nodes!
         x-examples:
-          - module: 2
           - system: 2
       kubernetesVersions:
         type: array

--- a/internal/valuesvalidation/global-openapi/values.yaml
+++ b/internal/valuesvalidation/global-openapi/values.yaml
@@ -326,6 +326,7 @@ properties:
           Node will have role 'some-role' if it has label with prefix node-role.deckhouse.io/
           Do not use label with prefix node-role.deckhouse.io/ on workers nodes!
         x-examples:
+          - module: 2
           - system: 2
       kubernetesVersions:
         type: array

--- a/pkg/linters/container/rules/container_image_digest_check.go
+++ b/pkg/linters/container/rules/container_image_digest_check.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rules
 
 import (
-	"regexp"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
@@ -51,8 +51,7 @@ func (r *ImageDigestRule) ContainerImageDigestCheck(object storage.StoreObject, 
 	for i := range containers {
 		c := &containers[i]
 
-		re := regexp.MustCompile(`(?P<repository>.+)([@:])imageHash[-a-z0-9A-Z]+$`)
-		match := re.FindStringSubmatch(c.Image)
+		match := strings.Split(c.Image, "@")
 		if len(match) == 0 {
 			errorList.WithObjectID(object.Identity() + "; container = " + c.Name).
 				Error("Cannot parse repository from image")
@@ -60,7 +59,7 @@ func (r *ImageDigestRule) ContainerImageDigestCheck(object storage.StoreObject, 
 			continue
 		}
 
-		repo, err := name.NewRepository(match[re.SubexpIndex("repository")])
+		repo, err := name.NewRepository(match[0])
 		if err != nil {
 			errorList.WithObjectID(object.Identity()+"; container = "+c.Name).
 				Errorf("Cannot parse repository from image: %s", c.Image)

--- a/pkg/linters/templates/rules/grafana.go
+++ b/pkg/linters/templates/rules/grafana.go
@@ -20,6 +20,7 @@ import (
 	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
+
 	"os"
 	"path/filepath"
 	"strings"

--- a/pkg/linters/templates/rules/prometheus_rules_test.go
+++ b/pkg/linters/templates/rules/prometheus_rules_test.go
@@ -2,7 +2,7 @@ package rules
 
 import "testing"
 
-func TestMe(t *testing.T) {
+func TestMe(_ *testing.T) {
 	aaa := `
 {{ $namespace := "d8-monitoring" }}
 


### PR DESCRIPTION
Previously, we had helmet template hacks that were implemented through string replacement. Quite sloppy, which led to a number of errors in the generation diagrams. Since we use the lint generation launch mode, we did not notice these errors. But this does not mean that this did not affect the work.

The current changes allow us to replace additional functions for generating an image digest in such a way that the templates change minimally. But in the end, we get the correct result for any modules and almost any diagrams. As an exception, controlPlaneManager was given here, which needed to describe global values. But for now this leads to the conclusion.

The logic of image digest verification for containers was also corrected. Now it works correctly for the results that we have when constructing a diagram. And now we have a number of new errors for this rule.