### PR TITLE
fix error level behavior

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -70,10 +70,11 @@ type Manager struct {
 }
 
 func NewManager(dirs []string, rootConfig *config.RootConfig) *Manager {
+	managerLevel := pkg.Error
 	m := &Manager{
 		cfg: rootConfig,
 
-		errors: errors.NewLintRuleErrorsList(),
+		errors: errors.NewLintRuleErrorsList().WithMaxLevel(&managerLevel),
 	}
 
 	var paths []string

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -85,11 +85,13 @@ func NewManager(dirs []string, rootConfig *config.RootConfig) *Manager {
 			logger.ErrorF("Failed to expand home dir: %v", err)
 			continue
 		}
+
 		result, err := getModulePaths(dir)
 		if err != nil {
 			logger.ErrorF("Error getting module paths: %v", err)
 			continue
 		}
+
 		paths = append(paths, result...)
 	}
 
@@ -171,8 +173,8 @@ func (m *Manager) PrintResult() {
 
 	slices.SortFunc(errs, func(a, b pkg.LinterError) int {
 		return cmp.Or(
-			cmp.Compare(a.LinterID, b.LinterID),
 			cmp.Compare(a.ModuleID, b.ModuleID),
+			cmp.Compare(a.LinterID, b.LinterID),
 			cmp.Compare(a.RuleID, b.RuleID),
 		)
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,10 +30,18 @@ type ModuleConfig struct {
 	LintersSettings LintersSettings `mapstructure:"linters-settings"`
 }
 
-func assignIfNotEmpty(v, input *pkg.Level) {
+func calculateImpact(v, input *pkg.Level) *pkg.Level {
 	if input != nil {
-		*v = *input
+		return input
 	}
+
+	if v != nil {
+		return v
+	}
+
+	lvl := pkg.Error
+
+	return &lvl
 }
 
 func NewDefaultRootConfig(dirs []string) (*RootConfig, error) {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -34,22 +34,22 @@ type LintersSettings struct {
 }
 
 func (cfg *LintersSettings) MergeGlobal(lcfg *global.Linters) {
-	assignIfNotEmpty(&cfg.OpenAPI.Impact, lcfg.OpenAPI.Impact)
-	assignIfNotEmpty(&cfg.NoCyrillic.Impact, lcfg.NoCyrillic.Impact)
-	assignIfNotEmpty(&cfg.License.Impact, lcfg.License.Impact)
-	assignIfNotEmpty(&cfg.Container.Impact, lcfg.Container.Impact)
-	assignIfNotEmpty(&cfg.Templates.Impact, lcfg.Templates.Impact)
-	assignIfNotEmpty(&cfg.Images.Impact, lcfg.Images.Impact)
-	assignIfNotEmpty(&cfg.Rbac.Impact, lcfg.Rbac.Impact)
-	assignIfNotEmpty(&cfg.Hooks.Impact, lcfg.Hooks.Impact)
-	assignIfNotEmpty(&cfg.Module.Impact, lcfg.Module.Impact)
+	cfg.OpenAPI.Impact = calculateImpact(cfg.OpenAPI.Impact, lcfg.OpenAPI.Impact)
+	cfg.NoCyrillic.Impact = calculateImpact(cfg.NoCyrillic.Impact, lcfg.NoCyrillic.Impact)
+	cfg.License.Impact = calculateImpact(cfg.License.Impact, lcfg.License.Impact)
+	cfg.Container.Impact = calculateImpact(cfg.Container.Impact, lcfg.Container.Impact)
+	cfg.Templates.Impact = calculateImpact(cfg.Templates.Impact, lcfg.Templates.Impact)
+	cfg.Images.Impact = calculateImpact(cfg.Images.Impact, lcfg.Images.Impact)
+	cfg.Rbac.Impact = calculateImpact(cfg.Rbac.Impact, lcfg.Rbac.Impact)
+	cfg.Hooks.Impact = calculateImpact(cfg.Hooks.Impact, lcfg.Hooks.Impact)
+	cfg.Module.Impact = calculateImpact(cfg.Module.Impact, lcfg.Module.Impact)
 }
 
 type ContainerSettings struct {
 	SkipContainers []string              `mapstructure:"skip-containers"`
 	ExcludeRules   ContainerExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type ContainerExcludeRules struct {
@@ -69,7 +69,7 @@ type ContainerExcludeRules struct {
 type HooksSettings struct {
 	Ingress HooksIngressRuleSetting `mapstructure:"ingress"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type HooksIngressRuleSetting struct {
@@ -82,14 +82,14 @@ type ImageSettings struct {
 	SkipDistrolessImageCheck []string `mapstructure:"skip-distroless-image-check"`
 	SkipNamespaceCheck       []string `mapstructure:"skip-namespace-check"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type LicenseSettings struct {
 	CopyrightExcludes []string            `mapstructure:"copyright-excludes"`
 	ExcludeRules      LicenseExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type LicenseExcludeRules struct {
@@ -103,7 +103,7 @@ type ModuleSettings struct {
 	DefinitionFile ModuleDefinitionFileRuleSettings `mapstructure:"definition-file"`
 	Conversions    ConversionsRuleSettings          `mapstructure:"conversions"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type ModuleOSSRuleSettings struct {
@@ -126,7 +126,7 @@ type NoCyrillicSettings struct {
 
 	NoCyrillicExcludeRules NoCyrillicExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type NoCyrillicExcludeRules struct {
@@ -136,7 +136,7 @@ type NoCyrillicExcludeRules struct {
 type OpenAPISettings struct {
 	OpenAPIExcludeRules OpenAPIExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type OpenAPIExcludeRules struct {
@@ -151,7 +151,7 @@ type RbacSettings struct {
 	SkipObjectCheckBinding []string            `mapstructure:"skip-object-check-binding"`
 	ExcludeRules           RBACExcludeRules    `mapstructure:"exclude-rules"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type RBACExcludeRules struct {
@@ -163,7 +163,7 @@ type TemplatesSettings struct {
 	SkipVPAChecks []string              `mapstructure:"skip-vpa-checks"`
 	ExcludeRules  TemplatesExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact pkg.Level `mapstructure:"impact"`
+	Impact *pkg.Level `mapstructure:"impact"`
 }
 
 type TemplatesExcludeRules struct {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -119,9 +119,9 @@ func (l *LintRuleErrorsList) copy() *LintRuleErrorsList {
 	}
 }
 
-func (l *LintRuleErrorsList) WithMaxLevel(level pkg.Level) *LintRuleErrorsList {
+func (l *LintRuleErrorsList) WithMaxLevel(level *pkg.Level) *LintRuleErrorsList {
 	list := l.copy()
-	list.maxLevel = &level
+	list.maxLevel = level
 
 	return list
 }

--- a/pkg/level.go
+++ b/pkg/level.go
@@ -19,8 +19,7 @@ package pkg
 type Level int
 
 const (
-	Init Level = iota
-	Warn
+	Warn Level = iota
 	Error
 	Critical
 )


### PR DESCRIPTION
Add max level for manager (to have error level permanently)

Error handling behavior:
1) if has no global or module value - Error lvl
2) if has no global value, but has module value - set from module
3) if has global value and module value - set from global
4) if has global value, but has no module value - set from global

Error sorting behavior:
1) Sort by module
2) Sort by linter
3) Sort by rule