### PR TITLE
Fix module namespace generation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters-settings:
       - ifElseChain
       - octalLiteral
       - whyNoLint
+      - unnamedResult
   godox:
     keywords:
       - FIXME

--- a/pkg/linters/container/rules/dns_policy.go
+++ b/pkg/linters/container/rules/dns_policy.go
@@ -64,7 +64,7 @@ func (r *DNSPolicyRule) ObjectDNSPolicy(object storage.StoreObject, errorList *e
 	validateDNSPolicy(dnsPolicy, hostNetwork, object, errorList)
 }
 
-func getDNSPolicyAndHostNetwork(object storage.StoreObject) (string, bool, error) { //nolint:gocritic // false positive
+func getDNSPolicyAndHostNetwork(object storage.StoreObject) (string, bool, error) {
 	converter := runtime.DefaultUnstructuredConverter
 
 	var dnsPolicy string

--- a/pkg/linters/images/images_rules.go
+++ b/pkg/linters/images/images_rules.go
@@ -76,7 +76,7 @@ func imageRegexp(s string) string {
 	return fmt.Sprintf("^(from:|FROM)(\\s+)(%s)", s)
 }
 
-func isImageNameUnacceptable(imageName string) (bool, string) { //nolint:gocritic // false positive
+func isImageNameUnacceptable(imageName string) (bool, string) {
 	for ciVariable, pattern := range regexPatterns {
 		matched, _ := regexp.MatchString(pattern, imageName)
 		if matched {
@@ -172,7 +172,7 @@ func (l *Images) lintOneDockerfile(moduleName, path, imagesPath string, errorLis
 	}
 }
 
-func isDockerfileInstructionUnacceptable(from string, final bool) (bool, string) { //nolint:gocritic // false positive
+func isDockerfileInstructionUnacceptable(from string, final bool) (bool, string) {
 	if from == "scratch" {
 		return false, ""
 	}

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -134,8 +134,9 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 		yml.Requirements.validateRequirements(errorList)
 	}
 
-	if yml.Descriptions.English == "" && yml.Descriptions.Russian == "" {
-		errorList.Warn("Module descriptions are empty")
+	// ru description is not required
+	if yml.Descriptions.English == "" {
+		errorList.Warn("Module `descriptions.en` field is required")
 	}
 }
 

--- a/pkg/linters/templates/rules/vpa.go
+++ b/pkg/linters/templates/rules/vpa.go
@@ -84,8 +84,6 @@ func IsPodController(kind string) bool {
 }
 
 // parseTargetsGroups resolves target resource indexes
-//
-//nolint:gocritic // false positive
 func parseTargetsGroups(md *module.Module, errorList *errors.LintRuleErrorsList) (
 	map[storage.ResourceIndex]struct{},
 	map[storage.ResourceIndex]set.Set,


### PR DESCRIPTION
Get module namespace from the module.yaml file and then, if empty, fallback to the `.namespace` file