### PR TITLE
refactor: simplify string parsing by encoding keys in base64

### DIFF
--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -17,6 +17,7 @@ limitations under the License.
 package module
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -197,11 +198,6 @@ func parseProperty(key string, prop *spec.Schema, result map[string]any) error {
 }
 
 func parseString(key, pattern string, result map[string]any) error {
-	// ignore cniSecretData key
-	if key == "cniSecretData" {
-		return nil
-	}
-
 	if key == "name" {
 		result[key] = "name"
 		return nil
@@ -223,13 +219,7 @@ func parseString(key, pattern string, result map[string]any) error {
 		}
 		result[key] = r
 	} else {
-		const pattern = "[a-zA-Z0-9]{8}"
-		result[key] = "string"
-		r, err := reggen.Generate(pattern, limit)
-		if err != nil {
-			return err
-		}
-		result[key] = r
+		result[key] = base64.StdEncoding.EncodeToString([]byte(key))
 	}
 
 	return nil


### PR DESCRIPTION
We use some variables of the string type to store data in base64 format. This value is decoded in templates. And if it's not base64, we get an error.

For such cases, we will generate string values by key name, encoding it in base64 format. And if decoding is used in the template, there will be no errors.

Such a change allows you to simplify the processing of openapi by removing the hardcode for the variable value.