### PR TITLE
fix: update file path handling in GetFiles function

### DIFF
--- a/internal/fsutils/getfiles.go
+++ b/internal/fsutils/getfiles.go
@@ -38,7 +38,7 @@ func GetFiles(rootPath string, skipSymlink bool, filters ...fFn) []string {
 			return nil
 		}
 
-		if filterPass(path, filters...) {
+		if filterPass(Rel(rootPath, path), filters...) {
 			result = append(result, path)
 		}
 


### PR DESCRIPTION
When filtering files for Openapi, we take the full path, but in the regexp we check the relative one. We fix the error by passing the required path.