### PR TITLE
feat: add module validation logic in manager

### DIFF
--- a/internal/fsutils/fsutils.go
+++ b/internal/fsutils/fsutils.go
@@ -157,16 +157,3 @@ func FilterFileByExtensions(exts ...string) func(_, path string) bool {
 		return false
 	}
 }
-
-func ReadFile(filePath string) ([]byte, error) {
-	_, err := os.Stat(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-	return bytes, nil
-}

--- a/internal/fsutils/fsutils.go
+++ b/internal/fsutils/fsutils.go
@@ -164,9 +164,9 @@ func ReadFile(filePath string) ([]byte, error) {
 		return nil, err
 	}
 
-	yamlFile, err := os.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
-	return yamlFile, nil
+	return bytes, nil
 }

--- a/internal/fsutils/fsutils.go
+++ b/internal/fsutils/fsutils.go
@@ -157,3 +157,16 @@ func FilterFileByExtensions(exts ...string) func(_, path string) bool {
 		return false
 	}
 }
+
+func ReadFile(filePath string) ([]byte, error) {
+	_, err := os.Stat(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	yamlFile, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return yamlFile, nil
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -95,9 +95,9 @@ func NewManager(dir string, rootConfig *config.RootConfig) *Manager {
 		logger.ErrorF("Failed to get global values: %v", err)
 		return m
 	}
+	errorList := m.errors.WithLinterID("manager")
 	for i := range paths {
 		moduleName := filepath.Base(paths[i])
-		errorList := m.errors.WithLinterID("manager").WithFilePath(paths[i]).WithModule(moduleName)
 		logger.DebugF("Found `%s` module", moduleName)
 		if err := m.validateModule(paths[i]); err != nil {
 			// linting errors are already logged
@@ -106,6 +106,7 @@ func NewManager(dir string, rootConfig *config.RootConfig) *Manager {
 		mdl, err := module.NewModule(paths[i], &vals, globalValues)
 		if err != nil {
 			errorList.
+				WithFilePath(paths[i]).WithModule(moduleName).
 				WithValue(err.Error()).
 				Errorf("cannot create module `%s`", moduleName)
 			continue

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -97,7 +97,7 @@ func NewManager(dir string, rootConfig *config.RootConfig) *Manager {
 	}
 	for i := range paths {
 		moduleName := filepath.Base(paths[i])
-		m.errors = m.errors.WithLinterID("manager").WithFilePath(paths[i]).WithModule(moduleName)
+		errorList := m.errors.WithLinterID("manager").WithFilePath(paths[i]).WithModule(moduleName)
 		logger.DebugF("Found `%s` module", moduleName)
 		if err := m.validateModule(paths[i]); err != nil {
 			// linting errors are already logged
@@ -105,7 +105,7 @@ func NewManager(dir string, rootConfig *config.RootConfig) *Manager {
 		}
 		mdl, err := module.NewModule(paths[i], &vals, globalValues)
 		if err != nil {
-			m.errors.
+			errorList.
 				WithValue(err.Error()).
 				Errorf("cannot create module `%s`", moduleName)
 			continue

--- a/internal/manager/validate.go
+++ b/internal/manager/validate.go
@@ -1,0 +1,183 @@
+package manager
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/deckhouse/dmt/internal/module"
+)
+
+type moduleYaml struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+type chartYaml struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+func (m *Manager) validateModule(path string) error {
+	var errs error
+	m.errors = m.errors.WithLinterID("module").WithRule("definition-file")
+	// validate module.yaml and Chart.yaml
+	chartYamlFile, err := parseChartFile(path)
+	if err != nil {
+		err = fmt.Errorf("failed to parse Chart.yaml: %w", err)
+		errs = errors.Join(errs, err)
+		m.errors.Error(err.Error())
+	}
+	moduleYamlFile, err := parseModuleConfigFile(path)
+	if err != nil {
+		err = fmt.Errorf("failed to parse module.yaml: %w", err)
+		errs = errors.Join(errs, err)
+		m.errors.Error(err.Error())
+	}
+	if chartYamlFile != nil {
+		if chartYamlFile.Name == "" {
+			err := fmt.Errorf("property `name` in Chart.yaml is empty")
+			errs = errors.Join(errs, err)
+			m.errors.Error(err.Error())
+		}
+		if chartYamlFile.Version == "" {
+			err := fmt.Errorf("property `version` in Chart.yaml is empty")
+			errs = errors.Join(errs, err)
+			m.errors.Error(err.Error())
+		}
+	}
+	if moduleYamlFile != nil {
+		if moduleYamlFile.Name == "" {
+			err := fmt.Errorf("module.yaml `name` is empty")
+			errs = errors.Join(errs, err)
+			m.errors.Error(err.Error())
+		}
+		if moduleYamlFile.Namespace == "" {
+			err := fmt.Errorf("module.yaml `namespace` is empty")
+			errs = errors.Join(errs, err)
+			m.errors.Error(err.Error())
+		}
+	}
+	if moduleYamlFile != nil && chartYamlFile != nil {
+		if chartYamlFile.Name != "" && moduleYamlFile.Name != "" && chartYamlFile.Name != moduleYamlFile.Name {
+			err := fmt.Errorf("module.yaml name (%s) does not match Chart.yaml name (%s)", moduleYamlFile.Name, chartYamlFile.Name)
+			errs = errors.Join(errs, err)
+			m.errors.Errorf(err.Error())
+		}
+	}
+
+	// validate namespace
+	if moduleYamlFile == nil && chartYamlFile != nil {
+		if getNamespace(path) == "" {
+			err := fmt.Errorf("file Chart.yaml is present, but .namespace file is missing")
+			errs = errors.Join(errs, err)
+			m.errors.Errorf(err.Error())
+		}
+	}
+
+	// validate openapi directory
+
+	if err := validateOpenAPIDir(path); err != nil {
+		errs = errors.Join(errs, err)
+		m.errors.Error(err.Error())
+	}
+
+	return errs
+}
+
+func parseModuleConfigFile(path string) (*moduleYaml, error) {
+	moduleFilename := filepath.Join(path, module.ModuleConfigFilename)
+	yamlFile, err := readFile(moduleFilename)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var deckhouseModule moduleYaml
+	err = yaml.Unmarshal(yamlFile, &deckhouseModule)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deckhouseModule, nil
+}
+
+func parseChartFile(path string) (*chartYaml, error) {
+	chartFilename := filepath.Join(path, module.ChartConfigFilename)
+	yamlFile, err := readFile(chartFilename)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var chart chartYaml
+	err = yaml.Unmarshal(yamlFile, &chart)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chart, nil
+}
+
+func readFile(filePath string) ([]byte, error) {
+	_, err := os.Stat(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	yamlFile, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return yamlFile, nil
+}
+
+func getNamespace(path string) string {
+	content, err := os.ReadFile(filepath.Join(path, ".namespace"))
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimRight(string(content), " \t\n")
+}
+
+func validateOpenAPIDir(path string) error {
+	openAPIDir := filepath.Join(path, "openapi")
+	_, err := os.Stat(openAPIDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("OpenAPI dir does not exist")
+		}
+
+		return fmt.Errorf("failed to access OpenAPI dir: %w", err)
+	}
+
+	var errs error
+	valuesFile := filepath.Join(openAPIDir, "values.yaml")
+	_, err = os.Stat(valuesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			errs = errors.Join(errs, fmt.Errorf("OpenAPI dir does not contain values.yaml"))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("failed to access OpenAPI values.yaml: %w", err))
+		}
+	}
+
+	configValuesFile := filepath.Join(openAPIDir, "config-values.yaml")
+	_, err = os.Stat(configValuesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			errs = errors.Join(errs, fmt.Errorf("OpenAPI dir does not contain config-values.yaml"))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("failed to access OpenAPI config-values.yaml: %w", err))
+		}
+	}
+
+	return errs
+}

--- a/internal/manager/validate.go
+++ b/internal/manager/validate.go
@@ -41,8 +41,7 @@ func (m *Manager) validateModule(path string) error {
 	if moduleYamlFile != nil {
 		if moduleYamlFile.Name == "" {
 			err := fmt.Errorf("module.yaml `name` is empty")
-			errs = errors.Join(errs, err)
-			m.errors.Error(err.Error())
+			m.errors.Warn(err.Error())
 		}
 		if moduleYamlFile.Namespace == "" {
 			err := fmt.Errorf("module.yaml `namespace` is empty")
@@ -55,6 +54,23 @@ func (m *Manager) validateModule(path string) error {
 			errs = errors.Join(errs, err)
 			m.errors.Errorf(err.Error())
 		}
+	}
+
+	var moduleName string
+	if moduleYamlFile != nil {
+		if moduleYamlFile.Name != "" {
+			moduleName = moduleYamlFile.Name
+		}
+	}
+	if moduleName == "" && chartYamlFile != nil {
+		if chartYamlFile.Name != "" {
+			moduleName = chartYamlFile.Name
+		}
+	}
+	if moduleName == "" {
+		err := fmt.Errorf("module `name` property is empty")
+		errs = errors.Join(errs, err)
+		m.errors.Errorf(err.Error())
 	}
 
 	// validate namespace

--- a/internal/manager/validate.go
+++ b/internal/manager/validate.go
@@ -12,38 +12,38 @@ import (
 
 func (m *Manager) validateModule(path string) error {
 	var errs error
-	m.errors = m.errors.WithLinterID("module").WithRule("definition-file")
+	errorList := m.errors.WithLinterID("module").WithRule("definition-file")
 	// validate module.yaml and Chart.yaml
 	chartYamlFile, err := module.ParseChartFile(path)
 	if err != nil {
 		err = fmt.Errorf("failed to parse Chart.yaml: %w", err)
 		errs = errors.Join(errs, err)
-		m.errors.Error(err.Error())
+		errorList.Error(err.Error())
 	}
 	moduleYamlFile, err := module.ParseModuleConfigFile(path)
 	if err != nil {
 		err = fmt.Errorf("failed to parse module.yaml: %w", err)
 		errs = errors.Join(errs, err)
-		m.errors.Error(err.Error())
+		errorList.Error(err.Error())
 	}
 	if chartYamlFile != nil {
 		if chartYamlFile.Name == "" {
 			err := errors.New("property `name` in Chart.yaml is empty")
 			errs = errors.Join(errs, err)
-			m.errors.Error(err.Error())
+			errorList.Error(err.Error())
 		}
 		if chartYamlFile.Version == "" {
 			err := errors.New("property `version` in Chart.yaml is empty")
 			errs = errors.Join(errs, err)
-			m.errors.Error(err.Error())
+			errorList.Error(err.Error())
 		}
 	}
 	if moduleYamlFile != nil {
 		if moduleYamlFile.Name == "" {
-			m.errors.Warn("module.yaml `name` is empty")
+			errorList.Warn("module.yaml `name` is empty")
 		}
 		if moduleYamlFile.Namespace == "" {
-			m.errors.Warn("module.yaml `namespace` is empty")
+			errorList.Warn("module.yaml `namespace` is empty")
 		}
 	}
 
@@ -52,25 +52,25 @@ func (m *Manager) validateModule(path string) error {
 		chartYamlFile.Name != moduleYamlFile.Name {
 		err := fmt.Errorf("module.yaml name (%s) does not match Chart.yaml name (%s)", moduleYamlFile.Name, chartYamlFile.Name)
 		errs = errors.Join(errs, err)
-		m.errors.Errorf(err.Error())
+		errorList.Errorf(err.Error())
 	}
 
 	moduleName := module.GetModuleName(moduleYamlFile, chartYamlFile)
 	if moduleName == "" && chartYamlFile == nil {
 		err := fmt.Errorf("module `name` property is empty")
 		errs = errors.Join(errs, err)
-		m.errors.Errorf(err.Error())
+		errorList.Errorf(err.Error())
 	}
 
 	if moduleYamlFile == nil && chartYamlFile != nil && getNamespace(path) == "" {
 		err := fmt.Errorf("file Chart.yaml is present, but .namespace file is missing")
 		errs = errors.Join(errs, err)
-		m.errors.Errorf(err.Error())
+		errorList.Errorf(err.Error())
 	}
 
 	if err := validateOpenAPIDir(path); err != nil {
 		errs = errors.Join(errs, err)
-		m.errors.Error(err.Error())
+		errorList.Error(err.Error())
 	}
 
 	return errs

--- a/internal/manager/validate.go
+++ b/internal/manager/validate.go
@@ -55,7 +55,7 @@ func (m *Manager) validateModule(path string) error {
 		m.errors.Errorf(err.Error())
 	}
 
-	moduleName := getModuleName(moduleYamlFile, chartYamlFile)
+	moduleName := module.GetModuleName(moduleYamlFile, chartYamlFile)
 	if moduleName == "" && chartYamlFile == nil {
 		err := fmt.Errorf("module `name` property is empty")
 		errs = errors.Join(errs, err)
@@ -74,16 +74,6 @@ func (m *Manager) validateModule(path string) error {
 	}
 
 	return errs
-}
-
-func getModuleName(moduleYamlFile *module.ModuleYaml, chartYamlFile *module.ChartYaml) string {
-	if moduleYamlFile != nil && moduleYamlFile.Name != "" {
-		return moduleYamlFile.Name
-	}
-	if chartYamlFile != nil && chartYamlFile.Name != "" {
-		return chartYamlFile.Name
-	}
-	return ""
 }
 
 func getNamespace(path string) string {

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -256,13 +256,13 @@ func ParseModuleConfigFile(path string) (*ModuleYaml, error) {
 	if err != nil {
 		return nil, err
 	}
-	var deckhouseModule ModuleYaml
-	err = yaml.Unmarshal(yamlFile, &deckhouseModule)
+	var moduleConfig ModuleYaml
+	err = yaml.Unmarshal(yamlFile, &moduleConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return &deckhouseModule, nil
+	return &moduleConfig, nil
 }
 
 func ParseChartFile(path string) (*ChartYaml, error) {

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -209,27 +209,18 @@ func newModuleFromPath(path string) (*Module, error) {
 	}
 
 	var info ModuleYaml
-	if moduleYamlConfig != nil {
-		if moduleYamlConfig.Name != "" {
-			info.Name = moduleYamlConfig.Name
-		}
-		if moduleYamlConfig.Namespace != "" {
-			info.Namespace = moduleYamlConfig.Namespace
-		}
-	}
-	if info.Name == "" && chartYamlConfig != nil {
-		if chartYamlConfig.Name != "" {
-			info.Name = chartYamlConfig.Name
-		}
+	info.Name = GetModuleName(moduleYamlConfig, chartYamlConfig)
+	if moduleYamlConfig != nil && moduleYamlConfig.Namespace != "" {
+		info.Namespace = moduleYamlConfig.Namespace
 	}
 
 	if info.Namespace == "" {
 		// fallback to the 'test' .namespace file
-		info.Namespace = getNamespace(path)
-	}
-
-	if info.Namespace == "" {
-		return nil, fmt.Errorf("module %q has no namespace", info.Name)
+		namespace := getNamespace(path)
+		if namespace != "" {
+			return nil, fmt.Errorf("module %q has no namespace", info.Name)
+		}
+		info.Namespace = namespace
 	}
 
 	moduleChart, err := LoadModuleAsChart(info.Name, path)
@@ -291,4 +282,14 @@ func ParseChartFile(path string) (*ChartYaml, error) {
 	}
 
 	return &chartYaml, nil
+}
+
+func GetModuleName(moduleYamlFile *ModuleYaml, chartYamlFile *ChartYaml) string {
+	if moduleYamlFile != nil && moduleYamlFile.Name != "" {
+		return moduleYamlFile.Name
+	}
+	if chartYamlFile != nil && chartYamlFile.Name != "" {
+		return chartYamlFile.Name
+	}
+	return ""
 }

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -29,7 +29,6 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 
-	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/internal/storage"
 	"github.com/deckhouse/dmt/internal/values"
 	"github.com/deckhouse/dmt/internal/werf"
@@ -217,7 +216,7 @@ func newModuleFromPath(path string) (*Module, error) {
 	if info.Namespace == "" {
 		// fallback to the 'test' .namespace file
 		namespace := getNamespace(path)
-		if namespace != "" {
+		if namespace == "" {
 			return nil, fmt.Errorf("module %q has no namespace", info.Name)
 		}
 		info.Namespace = namespace
@@ -250,7 +249,7 @@ func getNamespace(path string) string {
 
 func ParseModuleConfigFile(path string) (*ModuleYaml, error) {
 	moduleFilename := filepath.Join(path, ModuleConfigFilename)
-	yamlFile, err := fsutils.ReadFile(moduleFilename)
+	yamlFile, err := os.ReadFile(moduleFilename)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
@@ -268,7 +267,7 @@ func ParseModuleConfigFile(path string) (*ModuleYaml, error) {
 
 func ParseChartFile(path string) (*ChartYaml, error) {
 	chartFilename := filepath.Join(path, ChartConfigFilename)
-	yamlFile, err := fsutils.ReadFile(chartFilename)
+	yamlFile, err := os.ReadFile(chartFilename)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}

--- a/pkg/linters/module/rules/conversions.go
+++ b/pkg/linters/module/rules/conversions.go
@@ -120,7 +120,7 @@ func (r *ConversionsRule) CheckConversions(modulePath string, errorList *errors.
 
 	if os.IsNotExist(err) || !stat.IsDir() {
 		errorList.WithFilePath(conversionsFolder).
-			Errorf("Conversions folder is not exist: %s", err)
+			Errorf("Conversions folder is not exist")
 
 		return
 	}

--- a/pkg/linters/module/rules/conversions.go
+++ b/pkg/linters/module/rules/conversions.go
@@ -120,7 +120,7 @@ func (r *ConversionsRule) CheckConversions(modulePath string, errorList *errors.
 
 	if os.IsNotExist(err) || !stat.IsDir() {
 		errorList.WithFilePath(conversionsFolder).
-			Errorf("Conversions folder is not exist")
+			Error("Conversions folder is not exist")
 
 		return
 	}


### PR DESCRIPTION
We have situations where we try to create a module before launching linters. But the creation ends in an error due to the inability to assemble helm or openapi due to the lack of a number of configuration parameters.

In order to get more readable errors, we enable the check for the presence of the `name` and `namespace` fields in module.yaml, the `name` field in the Chart.yaml file, and the presence of the correct openapi directory. If an error occurs during validation, we do not create a module, and in logs we output errors of the form:

```
time=2025-04-02T11:50:21.808+03:00 level=INFO msg="DMT version: development"
time=2025-04-02T11:50:21.808+03:00 level=INFO msg="Dir: /Users/devsyukov/src/github.com/deckhouse/sds-local-volume"
time=2025-04-02T11:50:47.520+03:00 level=INFO msg= "Found 0 modules"
🐒 [definition-file (#module)]
     Message: module.yaml`name is empty
     Module:       
     FilePath:/Users/devsyukov/src/github.com/deckhouse/sds-local-volume

🐒 [definition-file (#module)]
     Message: module.yaml`namespace` is empty
     Module:       
     FilePath:/Users/devsyukov/src/github.com/deckhouse/sds-local-volume
```