### PR TITLE
feat: include file path in module validation error reporting

### DIFF
--- a/internal/manager/validate.go
+++ b/internal/manager/validate.go
@@ -12,7 +12,7 @@ import (
 
 func (m *Manager) validateModule(path string) error {
 	var errs error
-	errorList := m.errors.WithLinterID("module").WithRule("definition-file")
+	errorList := m.errors.WithLinterID("module").WithRule("definition-file").WithFilePath(path)
 	// validate module.yaml and Chart.yaml
 	chartYamlFile, err := module.ParseChartFile(path)
 	if err != nil {


### PR DESCRIPTION
We lost information about the module name in the validation error output. As a result, we don't know the module name and we don't know the path where the error occurred.

```plain
🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      

🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      

🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      

🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      

🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      

🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      

🐒 [definition-file (#module)]
     Message:     module.yaml `namespace` is empty
     Module:      
```

Adding a path to the output:

```plain
🐒 [definition-file (#module)]
     Message:      module.yaml `namespace` is empty
     Module:
     FilePath:     /deckhouse/modules/600-secret-copier

🐒 [definition-file (#module)]
     Message:      module.yaml `namespace` is empty
     Module:
     FilePath:     /deckhouse/modules/800-deckhouse-tools

🐒 [definition-file (#module)]
     Message:      module.yaml `namespace` is empty
     Module:
     FilePath:     /deckhouse/modules/810-documentation

🐒 [definition-file (#module)]
     Message:      module.yaml `namespace` is empty
     Module:
     FilePath:     /deckhouse/modules/140-user-authz
```
