### PR TITLE
fix: update content matching logic in grafana and prometheus rules files

### DIFF
--- a/pkg/linters/templates/rules/grafana.go
+++ b/pkg/linters/templates/rules/grafana.go
@@ -71,15 +71,16 @@ func (r *GrafanaRule) ValidationGrafanaDashboards(m *module.Module, errorList *e
 		return
 	}
 
-	desiredContent := `{{- include "helm_lib_grafana_dashboard_definitions" . }}`
+	desiredContent := `include "helm_lib_grafana_dashboard_definitions`
 
-	if isContentMatching(string(content), desiredContent, m.GetNamespace(), false) {
+	if isContentMatching(content, desiredContent) {
 		return
 	}
 	if strings.Contains(string(content), `include "helm_lib_grafana_dashboard_definitions_recursion" (list .`) {
 		return
 	}
 
+	desiredContent = `{{- include "helm_lib_grafana_dashboard_definitions" . }}`
 	errorList.WithFilePath(monitoringFilePath).
 		Errorf("The content of the 'templates/monitoring.yaml' should be equal to:\n%s\nGot:\n%s", desiredContent, string(content))
 }


### PR DESCRIPTION
Since there are many ways to correctly describe the inclusion of templates, a change was made to check for its presence.

- we get rid of spaces in checked strings
- we only check for the presence of the substring ' include "helm_lib_prometheus_rules`
- for grafana, we check for the presence of the substring ' include "helm_lib_grafana_dashboard_definitions`
