### PR TITLE
Add verbose error

### DIFF
--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -108,7 +108,7 @@ func ComposeValuesFromSchemas(m *Module, globalSchema *spec.Schema) (chartutil.V
 
 	moduleValues, err := values.GetModuleValues(m.GetPath())
 	if err != nil {
-		return nil, fmt.Errorf("cannot find openapi values schema for module %q: %v", m.GetName(), err)
+		return nil, fmt.Errorf("cannot find openapi values schema for module %q: %w", m.GetName(), err)
 	}
 
 	moduleSchema := *moduleValues

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -108,7 +108,7 @@ func ComposeValuesFromSchemas(m *Module, globalSchema *spec.Schema) (chartutil.V
 
 	moduleValues, err := values.GetModuleValues(m.GetPath())
 	if err != nil {
-		return nil, fmt.Errorf("cannot find openapi values schema for module %s", m.GetName())
+		return nil, fmt.Errorf("cannot find openapi values schema for module %s: %v", m.GetName(), err)
 	}
 
 	moduleSchema := *moduleValues

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -108,7 +108,7 @@ func ComposeValuesFromSchemas(m *Module, globalSchema *spec.Schema) (chartutil.V
 
 	moduleValues, err := values.GetModuleValues(m.GetPath())
 	if err != nil {
-		return nil, fmt.Errorf("cannot find openapi values schema for module %s: %v", m.GetName(), err)
+		return nil, fmt.Errorf("cannot find openapi values schema for module %q: %v", m.GetName(), err)
 	}
 
 	moduleSchema := *moduleValues


### PR DESCRIPTION
```
🐒 [(#manager)]
     Message:      cannot create module `xxx`
     Module:       xxxx
     Value:        cannot find openapi values schema for module xxx
     FilePath:     /deckhouse/modules/xxx
```

have no information about the error. Add some verbosity