### PR TITLE
feat: rename initFunMap to initFuncMap and add comprehensive tests for Engine functionality

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,46 @@
+name: Update Go Coverage in README
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run tests and generate coverage report
+        run: |
+          go test ./... -coverprofile=coverage.out
+
+      - name: Extract coverage percentage
+        id: coverage
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print substr($3, 1, length($3)-1)}')
+          echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+
+      - name: Generate coverage badge
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print substr($3, 1, length($3)-1)}')
+          COLOR="#4c1"
+          VALUE=$COVERAGE
+          if (( $(echo "$COVERAGE < 80" | bc -l) )); then COLOR="#dfb317"; fi
+          if (( $(echo "$COVERAGE < 50" | bc -l) )); then COLOR="#e05d44"; fi
+          echo "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"120\" height=\"20\"><linearGradient id=\"b\" x2=\"0\" y2=\"100%\"><stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/><stop offset=\"1\" stop-opacity=\".1\"/></linearGradient><mask id=\"a\"><rect width=\"120\" height=\"20\" rx=\"3\" fill=\"#fff\"/></mask><g mask=\"url(#a)\"><rect width=\"70\" height=\"20\" fill=\"#555\"/><rect x=\"70\" width=\"50\" height=\"20\" fill=\"$COLOR\"/><rect width=\"120\" height=\"20\" fill=\"url(#b)\"/></g><g fill=\"#fff\" text-anchor=\"middle\" font-family=\"Verdana,Geneva,DejaVu Sans,sans-serif\" font-size=\"11\"><text x=\"35\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">coverage</text><text x=\"35\" y=\"14\">coverage</text><text id=\"percent\" x=\"95\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">$VALUE%</text><text id=\"percent\" x=\"95\" y=\"14\">$VALUE%</text></g></svg>" > coverage.svg
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update test coverage badge in README [skip ci]'
+          branch: ${{ github.ref_name }}
+          file_pattern: README.md coverage.svg

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -39,6 +39,7 @@ jobs:
           echo "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"120\" height=\"20\"><linearGradient id=\"b\" x2=\"0\" y2=\"100%\"><stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/><stop offset=\"1\" stop-opacity=\".1\"/></linearGradient><mask id=\"a\"><rect width=\"120\" height=\"20\" rx=\"3\" fill=\"#fff\"/></mask><g mask=\"url(#a)\"><rect width=\"70\" height=\"20\" fill=\"#555\"/><rect x=\"70\" width=\"50\" height=\"20\" fill=\"$COLOR\"/><rect width=\"120\" height=\"20\" fill=\"url(#b)\"/></g><g fill=\"#fff\" text-anchor=\"middle\" font-family=\"Verdana,Geneva,DejaVu Sans,sans-serif\" font-size=\"11\"><text x=\"35\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">coverage</text><text x=\"35\" y=\"14\">coverage</text><text id=\"percent\" x=\"95\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">$VALUE%</text><text id=\"percent\" x=\"95\" y=\"14\">$VALUE%</text></g></svg>" > coverage.svg
 
       - name: Commit and push changes
+        if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: update test coverage badge in README [skip ci]'

--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # dmt
 
+![Coverage](./coverage.svg)
+
 Deckhouse Module Tool - the swiss knife for your Deckhouse modules
 
-### How to use
+## How to use
 
-#### Lint
+### Lint
 
 You can run linter checks for a module:
+
 ```shell
 dmt lint /some/path/<your-module>
 ```
+
 or some pack of modules
+
 ```shell
 dmt lint /some/path/
 ```
+
 where `/some/path/` looks like this:
+
 ```shell
 ls -l /some/path/
 drwxrwxr-x 1 deckhouse deckhouse  4096 Nov 10 21:46 001-module-one
@@ -22,10 +29,10 @@ drwxrwxr-x 1 deckhouse deckhouse  4096 Nov 12 21:45 002-module-two
 drwxrwxr-x 1 deckhouse deckhouse  4096 Nov 10 21:46 003-module-three
 ```
 
-#### Gen
+### Gen
 
 Generate some automatic rules for you module
-<Coming soon>
+\<Coming soon\>
 
 ## Linters list
 
@@ -44,7 +51,7 @@ Generate some automatic rules for you module
 
 You can exclude linters or setup them via the config file `.dmtlint.yaml`
 
-### Global settings:
+### Global settings
 
 ```yaml
 global:

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="a">
+    <rect width="120" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#a)">
+    <rect width="70" height="20" fill="#555"/>
+    <rect x="70" width="50" height="20" fill="#4c1"/>
+    <rect width="120" height="20" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="35" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="35" y="14">coverage</text>
+    <text id="percent" x="95" y="15" fill="#010101" fill-opacity=".3">0%</text>
+    <text id="percent" x="95" y="14">0%</text>
+  </g>
+</svg>

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -267,14 +267,29 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 			vals["Values"] = make(chartutil.Values)
 		}
 		var buf strings.Builder
-		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
-			return map[string]string{}, cleanupExecError(filename, err)
-		}
+		currentErr := t.ExecuteTemplate(&buf, filename, vals)
 
-		// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
-		// is set. Since missing=error will never get here, we do not need to handle
-		// the Strict case.
-		rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
+		if currentErr != nil {
+			// In LintMode, if a template execution error is due to trying to access a field on a nil object
+			// (e.g. .Values.missing.key where .Values.missing is nil),
+			// we should output an empty string for that template and continue, rather than failing.
+			// This mimics a more lenient approach for linting.
+			// The error message typically contains "nil pointer evaluating" or "invalid memory address or nil pointer dereference".
+			if e.LintMode && (strings.Contains(currentErr.Error(), ": nil pointer evaluating") || strings.Contains(currentErr.Error(), "invalid memory address or nil pointer dereference")) {
+				log.Printf("[LINT] Template %s execution failed due to nil pointer access: %v. Rendering as empty string.", filename, currentErr)
+				rendered[filename] = ""
+				// Continue to the next template file
+			} else {
+				// For other errors, or if not in LintMode, this is a hard error.
+				return map[string]string{}, cleanupExecError(filename, currentErr)
+			}
+		} else {
+			// No error during template execution.
+			// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
+			// is set. Since missing=error will never get here, we do not need to handle
+			// the Strict case.
+			rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
+		}
 	}
 
 	return rendered, nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -27,9 +27,10 @@ import (
 
 	"errors"
 
-	"github.com/deckhouse/dmt/internal/logger"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
+
+	"github.com/deckhouse/dmt/internal/logger"
 )
 
 // Engine is an implementation of the Helm rendering implementation for templates.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -178,7 +178,7 @@ func (e Engine) initFuncMap(t *template.Template) {
 		if val == nil {
 			if e.LintMode {
 				// Don't fail on missing required values when linting
-				logger.ErrorF("[ERROR] Missing required value: %s", warn)
+				logger.WarnF("[WARNING] Missing required value: %s", warn)
 				return "", nil
 			}
 			return val, errors.New(warnWrap(warn))
@@ -199,7 +199,7 @@ func (e Engine) initFuncMap(t *template.Template) {
 	funcMap["fail"] = func(msg string) (string, error) {
 		if e.LintMode {
 			// Don't fail when linting
-			logger.ErrorF("[ERROR] Fail: %s", msg)
+			logger.WarnF("[WARNING] Fail: %s", msg)
 			return "", nil
 		}
 		return "", errors.New(warnWrap(msg))

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -163,8 +163,8 @@ func tplFun(parent *template.Template, includedNames map[string]int, strict bool
 	}
 }
 
-// initFunMap creates the Engine's FuncMap and adds context-specific functions.
-func (e Engine) initFunMap(t *template.Template) {
+// initFuncMap creates the Engine's FuncMap and adds context-specific functions.
+func (e Engine) initFuncMap(t *template.Template) {
 	funcMap := funcMap()
 	includedNames := make(map[string]int)
 
@@ -240,7 +240,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 		t.Option("missingkey=zero")
 	}
 
-	e.initFunMap(t)
+	e.initFuncMap(t)
 
 	// We want to parse the templates in a predictable order. The order favors
 	// higher-level (in file system) templates over deeply nested templates.
@@ -263,6 +263,9 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 		// At render time, add information about the template that is being rendered.
 		vals := tpls[filename].vals
 		vals["Template"] = chartutil.Values{"Name": filename, "BasePath": tpls[filename].basePath}
+		if values, ok := vals["Values"]; !ok || values == nil {
+			vals["Values"] = make(map[string]any)
+		}
 		var buf strings.Builder
 		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {
 			return map[string]string{}, cleanupExecError(filename, err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -264,7 +264,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 		vals := tpls[filename].vals
 		vals["Template"] = chartutil.Values{"Name": filename, "BasePath": tpls[filename].basePath}
 		if values, ok := vals["Values"]; !ok || values == nil {
-			vals["Values"] = make(map[string]any)
+			vals["Values"] = make(chartutil.Values)
 		}
 		var buf strings.Builder
 		if err := t.ExecuteTemplate(&buf, filename, vals); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -18,7 +18,6 @@ package engine
 
 import (
 	"fmt"
-	"log"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -28,6 +27,7 @@ import (
 
 	"errors"
 
+	"github.com/deckhouse/dmt/internal/logger"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 )
@@ -177,7 +177,7 @@ func (e Engine) initFuncMap(t *template.Template) {
 		if val == nil {
 			if e.LintMode {
 				// Don't fail on missing required values when linting
-				log.Printf("[INFO] Missing required value: %s", warn)
+				logger.ErrorF("[ERROR] Missing required value: %s", warn)
 				return "", nil
 			}
 			return val, errors.New(warnWrap(warn))
@@ -185,7 +185,7 @@ func (e Engine) initFuncMap(t *template.Template) {
 			if val == "" {
 				if e.LintMode {
 					// Don't fail on missing required values when linting
-					log.Printf("[INFO] Missing required value: %s", warn)
+					logger.ErrorF("[ERROR] Missing required value: %s", warn)
 					return "", nil
 				}
 				return val, errors.New(warnWrap(warn))
@@ -198,7 +198,7 @@ func (e Engine) initFuncMap(t *template.Template) {
 	funcMap["fail"] = func(msg string) (string, error) {
 		if e.LintMode {
 			// Don't fail when linting
-			log.Printf("[INFO] Fail: %s", msg)
+			logger.ErrorF("[ERROR] Fail: %s", msg)
 			return "", nil
 		}
 		return "", errors.New(warnWrap(msg))
@@ -279,7 +279,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 			}
 
 			if e.LintMode && isRecoverableNilError {
-				log.Printf("[LINT] Template %s encountered a nil pointer access during execution: %v. Using partially rendered output.", filename, executeErr)
+				logger.ErrorF("[LINT] Template %s encountered a nil pointer access during execution: %v. Using partially rendered output.", filename, executeErr)
 				// Use the content of the buffer as is (output before the error), then replace "<no value>"
 				rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
 			} else {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,279 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+func TestNew(t *testing.T) {
+	engine := New()
+	if engine.Strict {
+		t.Error("Expected Strict to be false by default")
+	}
+	if engine.LintMode {
+		t.Error("Expected LintMode to be false by default")
+	}
+	if engine.EnableDNS {
+		t.Error("Expected EnableDNS to be false by default")
+	}
+}
+
+func TestRender(t *testing.T) {
+	engine := New()
+	vals := chartutil.Values{
+		"Values": map[string]any{
+			"foo": "bar",
+		},
+		"Release": map[string]any{
+			"Name": "test-release",
+		},
+	}
+
+	// Minimal chart
+	chrt := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+		},
+		Templates: []*chart.File{
+			{Name: "templates/NOTES.txt", Data: []byte("{{ .Values.foo }}")},
+		},
+	}
+
+	out, err := engine.Render(chrt, vals)
+	require.NoError(t, err, "Failed to render chart")
+
+	expectedContent := "bar"
+	require.Equal(t, 1, len(out), "Expected one rendered template")
+	require.Contains(t, out, "test-chart/templates/NOTES.txt", "Expected rendered output to contain the template")
+	require.Equal(t, expectedContent, out["test-chart/templates/NOTES.txt"], "Rendered content does not match expected output")
+}
+
+func TestRender_Strict(t *testing.T) {
+	engine := New()
+	engine.Strict = true
+	vals := chartutil.Values{
+		"Release": map[string]any{
+			"Name": "test-release",
+		},
+	} // Missing .Values.foo
+
+	chrt := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+		},
+		Templates: []*chart.File{
+			{Name: "templates/NOTES.txt", Data: []byte("{{ .Values.foo }}")},
+		},
+	}
+
+	_, err := engine.Render(chrt, vals)
+	require.Error(t, err, "Expected error when rendering with Strict mode and missing value")
+}
+
+func TestRender_LintMode(t *testing.T) {
+	engine := New()
+	engine.LintMode = true         // Enable LintMode
+	vals := make(chartutil.Values) // Initialize vals
+	vals["Release"] = map[string]any{
+		"Name": "test-release",
+	}
+
+	chrt := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+		},
+		Templates: []*chart.File{
+			// Template with a required value that is missing
+			{Name: "templates/config.yaml", Data: []byte("value: {{ required \"A valid foo is required!\" .Values.foo }}")},
+		},
+	}
+
+	out, err := engine.Render(chrt, vals)
+	require.NoError(t, err, "Render should not fail in LintMode even with missing required values")
+
+	// In LintMode, missing required values should result in an empty string (or default)
+	// and not an error. The specific output depends on the 'required' function's behavior in lintMode.
+	// Based on the provided engine.go, it returns ""
+	expectedContent := "value: "
+	require.Equal(t, expectedContent, out["test-chart/templates/config.yaml"], "Rendered content in LintMode does not match expected output")
+}
+
+func TestRender_Include(t *testing.T) {
+	engine := New()
+	vals := chartutil.Values{
+		"Values": map[string]any{
+			"message": "Hello from included template",
+		},
+		"Release": map[string]any{
+			"Name": "test-release",
+		},
+	}
+
+	chrt := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+		},
+		Templates: []*chart.File{
+			{Name: "templates/main.yaml", Data: []byte("Result: {{ include \"test-chart/templates/_helper.tpl\" . }}")},
+			{Name: "templates/_helper.tpl", Data: []byte("{{ .Values.message }}")},
+		},
+	}
+
+	out, err := engine.Render(chrt, vals)
+	require.NoError(t, err, "Failed to render chart with include")
+
+	expectedContent := "Result: Hello from included template"
+	require.Equal(t, expectedContent, out["test-chart/templates/main.yaml"], "Rendered content with include does not match expected output")
+}
+
+func TestRender_TplFunction(t *testing.T) {
+	engine := New()
+	vals := chartutil.Values{
+		"Values": map[string]any{
+			"dynamicTemplate": "Value is: {{ .innerValue }}",
+			"innerValue":      "some data",
+		},
+		"Release": map[string]any{
+			"Name": "test-release",
+		},
+	}
+
+	chrt := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "test-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+		},
+		Templates: []*chart.File{
+			{Name: "templates/config.yaml", Data: []byte("{{ tpl .Values.dynamicTemplate .Values }}")},
+		},
+	}
+
+	out, err := engine.Render(chrt, vals)
+	require.NoError(t, err, "Failed to render chart with tpl function")
+
+	expectedContent := "Value is: some data"
+	require.Equal(t, expectedContent, out["test-chart/templates/config.yaml"], "Rendered content with tpl function does not match expected output")
+}
+
+func TestRender_LibraryChart(t *testing.T) {
+	engine := New()
+	vals := chartutil.Values{
+		"Values": map[string]any{
+			"message": "Data from lib",
+		},
+		"Release": map[string]any{
+			"Name": "test-release",
+		},
+	}
+
+	// Main chart
+	mainChart := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "main-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+		},
+		Templates: []*chart.File{
+			// Corrected include path for library chart template
+			{Name: "templates/main.yaml", Data: []byte("{{ include \"main-chart/charts/library-chart/templates/_libhelper.tpl\" . }}")},
+			// This template should not be rendered directly if it's a helper
+			{Name: "templates/_nonhelper.yaml", Data: []byte("This should not be rendered directly")},
+		},
+	}
+
+	// Library chart
+	libChart := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "library-chart",
+			Version:    "0.1.0",
+			APIVersion: "v2",
+			Type:       "library", // Important: mark as library
+		},
+		Templates: []*chart.File{
+			{Name: "templates/_libhelper.tpl", Data: []byte("LIB: {{ .Values.message }}")},
+			{Name: "templates/somefile.yaml", Data: []byte("content from lib")}, // This should not be rendered
+		},
+	}
+	mainChart.AddDependency(libChart)
+
+	out, err := engine.Render(mainChart, vals)
+	require.NoError(t, err, "Failed to render chart with library dependency")
+
+	expectedContent := "LIB: Data from lib"
+	require.Equal(t, expectedContent, out["main-chart/templates/main.yaml"], "Rendered content from library chart does not match expected output")
+
+	// Ensure templates from library chart (non-helpers) are not in the output
+	if _, exists := out["library-chart/templates/somefile.yaml"]; exists {
+		t.Error("Non-helper template from library chart was rendered, but should not have been")
+	}
+	// The assertion now correctly expects "main-chart/templates/nonhelper.yaml" (old name) to not exist.
+	// And "_nonhelper.yaml" (new name) also won't exist in output because it's a partial.
+	if _, exists := out["main-chart/templates/nonhelper.yaml"]; exists {
+		t.Error("Non-helper template from main chart (nonhelper.yaml) was rendered, but should not have been as per test logic (now _nonhelper.yaml and thus a partial)")
+	}
+	if _, exists := out["main-chart/templates/_nonhelper.yaml"]; exists {
+		t.Error("Partial template _nonhelper.yaml from main chart was rendered directly, but should not have been.")
+	}
+}
+
+func TestRender_SubchartValues(t *testing.T) {
+	engine := New()
+	vals := chartutil.Values{
+		"Values": map[string]any{
+			"globalKey": "globalValue",
+			"sub-chart": map[string]any{ // Values for the subchart
+				"subKey": "subValue",
+			},
+		},
+		"Release": map[string]any{
+			"Name": "test-release",
+		},
+	}
+
+	mainChart := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "main-chart", Version: "0.1.0", APIVersion: "v2"},
+		Templates: []*chart.File{
+			{Name: "templates/main.yaml", Data: []byte(`Main: {{ .Values.globalKey }}
+{{ $subChartScope := dict "Values" (index .Values "sub-chart") "Chart" .Chart "Release" .Release "Capabilities" .Capabilities "Subcharts" .Subcharts -}}
+Sub: {{ include "main-chart/charts/sub-chart/templates/sub.yaml" $subChartScope }}`)},
+		},
+	}
+
+	subChart := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "sub-chart", Version: "0.1.0", APIVersion: "v2"},
+		Templates: []*chart.File{
+			{Name: "templates/sub.yaml", Data: []byte("{{ .Values.subKey }} and {{ .Values.globalKey }}")}, // globalKey should be empty here by default Helm scoping
+		},
+	}
+	mainChart.AddDependency(subChart)
+
+	out, err := engine.Render(mainChart, vals)
+	require.NoError(t, err, "Failed to render chart with subchart")
+
+	// Based on Helm's scoping, sub-chart will only see Values.sub-chart.*
+	// It will not see Values.globalKey unless explicitly passed or made global.
+	// The current engine.go logic for recAllTpls correctly scopes Values:
+	// else if vs, err := vals.Table("Values." + c.Name()); err == nil {
+	//    next["Values"] = vs
+	// }
+	// So, .Values.globalKey will not be available in sub.yaml's direct .Values scope.
+	expectedSubOutput := "subValue and " // globalKey is not in sub-chart's .Values
+	expectedMainOutput := `Main: globalValue
+Sub: ` + expectedSubOutput
+
+	if got := out["main-chart/templates/main.yaml"]; got != expectedMainOutput {
+		t.Errorf("Rendered main chart content does not match. Expected %q, got %q", expectedMainOutput, got)
+	}
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -239,17 +239,17 @@ func TestRender_LibraryChart(t *testing.T) {
 	require.Equal(t, expectedContent, out["main-chart/templates/main.yaml"], "Rendered content from library chart does not match expected output")
 
 	// Ensure templates from library chart (non-helpers) are not in the output
-	if _, exists := out["library-chart/templates/somefile.yaml"]; exists {
-		t.Error("Non-helper template from library chart was rendered, but should not have been")
-	}
+	_, exists := out["library-chart/templates/somefile.yaml"]
+	require.False(t, exists, "Non-helper template from library chart was rendered, but should not have been")
+
 	// The assertion now correctly expects "main-chart/templates/nonhelper.yaml" (old name) to not exist.
 	// And "_nonhelper.yaml" (new name) also won't exist in output because it's a partial.
-	if _, exists := out["main-chart/templates/nonhelper.yaml"]; exists {
-		t.Error("Non-helper template from main chart (nonhelper.yaml) was rendered, but should not have been as per test logic (now _nonhelper.yaml and thus a partial)")
-	}
-	if _, exists := out["main-chart/templates/_nonhelper.yaml"]; exists {
-		t.Error("Partial template _nonhelper.yaml from main chart was rendered directly, but should not have been.")
-	}
+	_, exists = out["main-chart/templates/nonhelper.yaml"]
+	require.False(t, exists, "Non-helper template from main chart (nonhelper.yaml) was rendered, but should not have been as per test logic (now _nonhelper.yaml and thus a partial)")
+
+	_, exists = out["main-chart/templates/_nonhelper.yaml"]
+	require.False(t, exists, "Partial template _nonhelper.yaml from main chart was rendered directly, but should not have been.")
+
 }
 
 func TestRender_SubchartValues(t *testing.T) {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -48,7 +48,7 @@ func TestRender(t *testing.T) {
 	require.NoError(t, err, "Failed to render chart")
 
 	expectedContent := "bar"
-	require.Equal(t, 1, len(out), "Expected one rendered template")
+	require.Len(t, out, 1, "Expected one rendered template")
 	require.Contains(t, out, "test-chart/templates/NOTES.txt", "Expected rendered output to contain the template")
 	require.Equal(t, expectedContent, out["test-chart/templates/NOTES.txt"], "Rendered content does not match expected output")
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -10,15 +10,9 @@ import (
 
 func TestNew(t *testing.T) {
 	engine := New()
-	if engine.Strict {
-		t.Error("Expected Strict to be false by default")
-	}
-	if engine.LintMode {
-		t.Error("Expected LintMode to be false by default")
-	}
-	if engine.EnableDNS {
-		t.Error("Expected EnableDNS to be false by default")
-	}
+	require.False(t, engine.Strict, "Expected Strict to be false by default")
+	require.False(t, engine.LintMode, "Expected LintMode to be false by default")
+	require.False(t, engine.EnableDNS, "Expected EnableDNS to be false by default")
 }
 
 func TestRender(t *testing.T) {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -249,7 +249,6 @@ func TestRender_LibraryChart(t *testing.T) {
 
 	_, exists = out["main-chart/templates/_nonhelper.yaml"]
 	require.False(t, exists, "Partial template _nonhelper.yaml from main chart was rendered directly, but should not have been.")
-
 }
 
 func TestRender_SubchartValues(t *testing.T) {

--- a/internal/engine/files_test.go
+++ b/internal/engine/files_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+// TestFilesAccess tests the access to chart files through templates
+func TestFilesAccess(t *testing.T) {
+	c := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:    "test-files",
+			Version: "1.0.0",
+		},
+		Files: []*chart.File{
+			{Name: "file1.txt", Data: []byte("contents of file1")},
+			{Name: "file2.txt", Data: []byte("contents of file2")},
+			{Name: "dir1/file3.txt", Data: []byte("contents of file3")},
+			{Name: "nested/file4.txt", Data: []byte("line1\nline2\nline3")},
+			{Name: "empty.txt", Data: []byte("")},
+		},
+		Templates: []*chart.File{
+			{Name: "templates/getfile.yaml", Data: []byte(`file1: {{ .Files.Get "file1.txt" }}`)},
+			{Name: "templates/getbytes.yaml", Data: []byte(`{{- $bytes := .Files.GetBytes "file1.txt" -}}
+bytes_len: {{ len $bytes }}`)},
+			{Name: "templates/glob.yaml", Data: []byte(`{{ range $path, $_ := .Files.Glob "*.txt" }}
+- {{ $path }}
+{{ end }}`)},
+			{Name: "templates/lines.yaml", Data: []byte(`{{ range .Files.Lines "nested/file4.txt" }}
+- {{ . }}
+{{ end }}`)},
+			{Name: "templates/asconfig.yaml", Data: []byte(`data: {{ .Files.AsConfig }}`)},
+			{Name: "templates/assecrets.yaml", Data: []byte(`data: {{ .Files.AsSecrets }}`)},
+		},
+	}
+
+	vals := map[string]any{}
+	v, err := chartutil.CoalesceValues(c, vals)
+	require.NoError(t, err)
+
+	e := New()
+	out, err := e.Render(c, v)
+	require.NoError(t, err)
+
+	// Test Get method
+	assert.Contains(t, out["test-files/templates/getfile.yaml"], "file1: contents of file1")
+
+	// Test GetBytes method
+	assert.Contains(t, out["test-files/templates/getbytes.yaml"], "bytes_len: 17")
+
+	// Test Glob method
+	assert.Contains(t, out["test-files/templates/glob.yaml"], "- file1.txt")
+	assert.Contains(t, out["test-files/templates/glob.yaml"], "- file2.txt")
+	assert.Contains(t, out["test-files/templates/glob.yaml"], "- empty.txt")
+
+	// Test Lines method
+	assert.Contains(t, out["test-files/templates/lines.yaml"], "- line1")
+	assert.Contains(t, out["test-files/templates/lines.yaml"], "- line2")
+	assert.Contains(t, out["test-files/templates/lines.yaml"], "- line3")
+
+	// Test AsConfig method
+	assert.Contains(t, out["test-files/templates/asconfig.yaml"], "file1.txt: contents of file1")
+	assert.Contains(t, out["test-files/templates/asconfig.yaml"], "file2.txt: contents of file2")
+
+	// Test AsSecrets method
+	expected1 := base64.StdEncoding.EncodeToString([]byte("contents of file1"))
+	expected2 := base64.StdEncoding.EncodeToString([]byte("contents of file2"))
+	assert.Contains(t, out["test-files/templates/assecrets.yaml"], "file1.txt: "+expected1)
+	assert.Contains(t, out["test-files/templates/assecrets.yaml"], "file2.txt: "+expected2)
+}

--- a/internal/engine/funcs.go
+++ b/internal/engine/funcs.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"text/template"
 
+	"maps"
+
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
 	"sigs.k8s.io/yaml"
@@ -79,9 +81,7 @@ func funcMap() template.FuncMap {
 		},
 	}
 
-	for k, v := range extra {
-		f[k] = v
-	}
+	maps.Copy(f, extra)
 
 	return f
 }

--- a/internal/engine/funcs_test.go
+++ b/internal/engine/funcs_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "simple map",
+			input:    map[string]interface{}{"key": "value"},
+			expected: "key: value",
+		},
+		{
+			name:     "nested map",
+			input:    map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			expected: "outer:\n  inner: value",
+		},
+		{
+			name:     "array",
+			input:    []string{"item1", "item2"},
+			expected: "- item1\n- item2",
+		},
+		{
+			name:     "empty map",
+			input:    map[string]interface{}{},
+			expected: "{}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toYAML(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToYAMLPretty(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "simple map",
+			input:    map[string]interface{}{"key": "value"},
+			expected: "key: value",
+		},
+		{
+			name:     "nested map",
+			input:    map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			expected: "outer:\n  inner: value",
+		},
+		{
+			name:     "array",
+			input:    []string{"item1", "item2"},
+			expected: "- item1\n- item2",
+		},
+		{
+			name:     "empty map",
+			input:    map[string]interface{}{},
+			expected: "{}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toYAMLPretty(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "simple map",
+			input:    "key: value",
+			expected: map[string]interface{}{"key": "value"},
+		},
+		{
+			name:     "nested map",
+			input:    "outer:\n  inner: value",
+			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+		},
+		{
+			name:     "invalid yaml",
+			input:    "invalid: : yaml:",
+			expected: map[string]interface{}{"Error": "error converting YAML to JSON: yaml: mapping values are not allowed in this context"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromYAML(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromYAMLArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []interface{}
+	}{
+		{
+			name:     "string array",
+			input:    "- item1\n- item2",
+			expected: []interface{}{"item1", "item2"},
+		},
+		{
+			name:     "nested array",
+			input:    "- - nested1\n  - nested2\n- item2",
+			expected: []interface{}{[]interface{}{"nested1", "nested2"}, "item2"},
+		},
+		{
+			name:     "invalid yaml array",
+			input:    "invalid: yaml array",
+			expected: []interface{}{"error unmarshaling JSON: json: cannot unmarshal object into Go value of type []interface {}"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromYAMLArray(tt.input)
+			// For the error case, we just check if there's an error string
+			if len(tt.expected) == 1 && tt.name == "invalid yaml array" {
+				assert.Len(t, result, 1)
+				assert.Contains(t, result[0].(string), "error")
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestToTOML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name: "simple map",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			expected: "key = \"value\"\n",
+		},
+		{
+			name: "nested map",
+			input: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+				},
+			},
+			expected: "[outer]\n  inner = \"value\"\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toTOML(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromTOML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "simple key-value",
+			input:    "key = \"value\"",
+			expected: map[string]interface{}{"key": "value"},
+		},
+		{
+			name:     "nested map",
+			input:    "[outer]\ninner = \"value\"",
+			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+		},
+		{
+			name:     "invalid toml",
+			input:    "invalid = toml =",
+			expected: map[string]interface{}{"Error": "toml: line 1 (last key \"invalid\"): expected value but found \"toml\" instead"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromTOML(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name: "simple map",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			expected: `{"key":"value"}`,
+		},
+		{
+			name: "nested map",
+			input: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+				},
+			},
+			expected: `{"outer":{"inner":"value"}}`,
+		},
+		{
+			name:     "array",
+			input:    []string{"item1", "item2"},
+			expected: `["item1","item2"]`,
+		},
+		{
+			name:     "empty map",
+			input:    map[string]interface{}{},
+			expected: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toJSON(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "simple map",
+			input:    `{"key":"value"}`,
+			expected: map[string]interface{}{"key": "value"},
+		},
+		{
+			name:     "nested map",
+			input:    `{"outer":{"inner":"value"}}`,
+			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+		},
+		{
+			name:     "invalid json",
+			input:    `{"key":"value"`,
+			expected: map[string]interface{}{"Error": "unexpected end of JSON input"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: map[string]interface{}{"Error": "unexpected end of JSON input"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromJSON(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromJSONArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []interface{}
+	}{
+		{
+			name:     "string array",
+			input:    `["item1","item2"]`,
+			expected: []interface{}{"item1", "item2"},
+		},
+		{
+			name:     "nested array",
+			input:    `[["nested1","nested2"],"item2"]`,
+			expected: []interface{}{[]interface{}{"nested1", "nested2"}, "item2"},
+		},
+		{
+			name:     "invalid json array",
+			input:    `["item1","item2"`,
+			expected: []interface{}{"unexpected end of JSON input"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []interface{}{"unexpected end of JSON input"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromJSONArray(tt.input)
+			if len(tt.expected) == 1 && (tt.name == "invalid json array" || tt.name == "empty string") {
+				assert.Len(t, result, 1)
+				assert.Equal(t, tt.expected[0], result[0])
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFuncMap(t *testing.T) {
+	fm := funcMap()
+
+	// Check that certain functions exist
+	expectedFuncs := []string{
+		"toToml", "fromToml", "toYaml", "toYamlPretty",
+		"fromYaml", "fromYamlArray", "toJson",
+		"fromJson", "fromJsonArray", "include", "tpl",
+		"required", "lookup", "b64dec", "b32dec",
+	}
+
+	for _, funcName := range expectedFuncs {
+		if _, ok := fm[funcName]; !ok {
+			t.Errorf("Expected function %q not found in funcMap", funcName)
+		}
+	}
+
+	// Check that env and expandenv are removed
+	removedFuncs := []string{"env", "expandenv"}
+	for _, funcName := range removedFuncs {
+		if _, ok := fm[funcName]; ok {
+			t.Errorf("Function %q should be removed but is present in funcMap", funcName)
+		}
+	}
+}
+
+// Test that placeholder functions return expected values
+func TestPlaceholderFunctions(t *testing.T) {
+	fm := funcMap()
+
+	// Test placeholder functions
+	includeFn, ok := fm["include"].(func(string, interface{}) string)
+	if !ok {
+		t.Fatalf("include function has wrong type")
+	}
+	assert.Equal(t, "not implemented", includeFn("", nil))
+
+	tplFn, ok := fm["tpl"].(func(string, interface{}) interface{})
+	if !ok {
+		t.Fatalf("tpl function has wrong type")
+	}
+	assert.Equal(t, "not implemented", tplFn("", nil))
+
+	requiredFn, ok := fm["required"].(func(string, interface{}) (interface{}, error))
+	if !ok {
+		t.Fatalf("required function has wrong type")
+	}
+	result, err := requiredFn("", nil)
+	assert.Equal(t, "not implemented", result)
+	assert.Nil(t, err)
+
+	lookupFn, ok := fm["lookup"].(func(string, string, string, string) (map[string]interface{}, error))
+	if !ok {
+		t.Fatalf("lookup function has wrong type")
+	}
+	m, err := lookupFn("", "", "", "")
+	assert.Equal(t, map[string]interface{}{}, m)
+	assert.Nil(t, err)
+
+	b64decFn, ok := fm["b64dec"].(func(string) (string, error))
+	if !ok {
+		t.Fatalf("b64dec function has wrong type")
+	}
+	b64result, b64err := b64decFn("")
+	assert.Equal(t, "b64decDecoded_String", b64result)
+	assert.Nil(t, b64err)
+
+	b32decFn, ok := fm["b32dec"].(func(string) (string, error))
+	if !ok {
+		t.Fatalf("b32dec function has wrong type")
+	}
+	b32result, b32err := b32decFn("")
+	assert.Equal(t, "b32decDecoded_String", b32result)
+	assert.Nil(t, b32err)
+}

--- a/internal/engine/funcs_test.go
+++ b/internal/engine/funcs_test.go
@@ -25,17 +25,17 @@ import (
 func TestToYAML(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{
 			name:     "simple map",
-			input:    map[string]interface{}{"key": "value"},
+			input:    map[string]any{"key": "value"},
 			expected: "key: value",
 		},
 		{
 			name:     "nested map",
-			input:    map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			input:    map[string]any{"outer": map[string]any{"inner": "value"}},
 			expected: "outer:\n  inner: value",
 		},
 		{
@@ -45,7 +45,7 @@ func TestToYAML(t *testing.T) {
 		},
 		{
 			name:     "empty map",
-			input:    map[string]interface{}{},
+			input:    map[string]any{},
 			expected: "{}",
 		},
 	}
@@ -61,17 +61,17 @@ func TestToYAML(t *testing.T) {
 func TestToYAMLPretty(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{
 			name:     "simple map",
-			input:    map[string]interface{}{"key": "value"},
+			input:    map[string]any{"key": "value"},
 			expected: "key: value",
 		},
 		{
 			name:     "nested map",
-			input:    map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			input:    map[string]any{"outer": map[string]any{"inner": "value"}},
 			expected: "outer:\n  inner: value",
 		},
 		{
@@ -81,7 +81,7 @@ func TestToYAMLPretty(t *testing.T) {
 		},
 		{
 			name:     "empty map",
-			input:    map[string]interface{}{},
+			input:    map[string]any{},
 			expected: "{}",
 		},
 	}
@@ -98,27 +98,27 @@ func TestFromYAML(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name:     "simple map",
 			input:    "key: value",
-			expected: map[string]interface{}{"key": "value"},
+			expected: map[string]any{"key": "value"},
 		},
 		{
 			name:     "nested map",
 			input:    "outer:\n  inner: value",
-			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			expected: map[string]any{"outer": map[string]any{"inner": "value"}},
 		},
 		{
 			name:     "invalid yaml",
 			input:    "invalid: : yaml:",
-			expected: map[string]interface{}{"Error": "error converting YAML to JSON: yaml: mapping values are not allowed in this context"},
+			expected: map[string]any{"Error": "error converting YAML to JSON: yaml: mapping values are not allowed in this context"},
 		},
 		{
 			name:     "empty string",
 			input:    "",
-			expected: map[string]interface{}{},
+			expected: map[string]any{},
 		},
 	}
 
@@ -134,27 +134,27 @@ func TestFromYAMLArray(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected []interface{}
+		expected []any
 	}{
 		{
 			name:     "string array",
 			input:    "- item1\n- item2",
-			expected: []interface{}{"item1", "item2"},
+			expected: []any{"item1", "item2"},
 		},
 		{
 			name:     "nested array",
 			input:    "- - nested1\n  - nested2\n- item2",
-			expected: []interface{}{[]interface{}{"nested1", "nested2"}, "item2"},
+			expected: []any{[]any{"nested1", "nested2"}, "item2"},
 		},
 		{
 			name:     "invalid yaml array",
 			input:    "invalid: yaml array",
-			expected: []interface{}{"error unmarshaling JSON: json: cannot unmarshal object into Go value of type []interface {}"},
+			expected: []any{"error unmarshaling JSON: json: cannot unmarshal object into Go value of type []interface {}"},
 		},
 		{
 			name:     "empty string",
 			input:    "",
-			expected: []interface{}{},
+			expected: []any{},
 		},
 	}
 
@@ -175,20 +175,20 @@ func TestFromYAMLArray(t *testing.T) {
 func TestToTOML(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{
 			name: "simple map",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"key": "value",
 			},
 			expected: "key = \"value\"\n",
 		},
 		{
 			name: "nested map",
-			input: map[string]interface{}{
-				"outer": map[string]interface{}{
+			input: map[string]any{
+				"outer": map[string]any{
 					"inner": "value",
 				},
 			},
@@ -208,27 +208,27 @@ func TestFromTOML(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name:     "simple key-value",
 			input:    "key = \"value\"",
-			expected: map[string]interface{}{"key": "value"},
+			expected: map[string]any{"key": "value"},
 		},
 		{
 			name:     "nested map",
 			input:    "[outer]\ninner = \"value\"",
-			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			expected: map[string]any{"outer": map[string]any{"inner": "value"}},
 		},
 		{
 			name:     "invalid toml",
 			input:    "invalid = toml =",
-			expected: map[string]interface{}{"Error": "toml: line 1 (last key \"invalid\"): expected value but found \"toml\" instead"},
+			expected: map[string]any{"Error": "toml: line 1 (last key \"invalid\"): expected value but found \"toml\" instead"},
 		},
 		{
 			name:     "empty string",
 			input:    "",
-			expected: map[string]interface{}{},
+			expected: map[string]any{},
 		},
 	}
 
@@ -243,20 +243,20 @@ func TestFromTOML(t *testing.T) {
 func TestToJSON(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{
 			name: "simple map",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"key": "value",
 			},
 			expected: `{"key":"value"}`,
 		},
 		{
 			name: "nested map",
-			input: map[string]interface{}{
-				"outer": map[string]interface{}{
+			input: map[string]any{
+				"outer": map[string]any{
 					"inner": "value",
 				},
 			},
@@ -269,7 +269,7 @@ func TestToJSON(t *testing.T) {
 		},
 		{
 			name:     "empty map",
-			input:    map[string]interface{}{},
+			input:    map[string]any{},
 			expected: `{}`,
 		},
 	}
@@ -286,27 +286,27 @@ func TestFromJSON(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name:     "simple map",
 			input:    `{"key":"value"}`,
-			expected: map[string]interface{}{"key": "value"},
+			expected: map[string]any{"key": "value"},
 		},
 		{
 			name:     "nested map",
 			input:    `{"outer":{"inner":"value"}}`,
-			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			expected: map[string]any{"outer": map[string]any{"inner": "value"}},
 		},
 		{
 			name:     "invalid json",
 			input:    `{"key":"value"`,
-			expected: map[string]interface{}{"Error": "unexpected end of JSON input"},
+			expected: map[string]any{"Error": "unexpected end of JSON input"},
 		},
 		{
 			name:     "empty string",
 			input:    "",
-			expected: map[string]interface{}{"Error": "unexpected end of JSON input"},
+			expected: map[string]any{"Error": "unexpected end of JSON input"},
 		},
 	}
 
@@ -322,27 +322,27 @@ func TestFromJSONArray(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected []interface{}
+		expected []any
 	}{
 		{
 			name:     "string array",
 			input:    `["item1","item2"]`,
-			expected: []interface{}{"item1", "item2"},
+			expected: []any{"item1", "item2"},
 		},
 		{
 			name:     "nested array",
 			input:    `[["nested1","nested2"],"item2"]`,
-			expected: []interface{}{[]interface{}{"nested1", "nested2"}, "item2"},
+			expected: []any{[]any{"nested1", "nested2"}, "item2"},
 		},
 		{
 			name:     "invalid json array",
 			input:    `["item1","item2"`,
-			expected: []interface{}{"unexpected end of JSON input"},
+			expected: []any{"unexpected end of JSON input"},
 		},
 		{
 			name:     "empty string",
 			input:    "",
-			expected: []interface{}{"unexpected end of JSON input"},
+			expected: []any{"unexpected end of JSON input"},
 		},
 	}
 
@@ -390,33 +390,33 @@ func TestPlaceholderFunctions(t *testing.T) {
 	fm := funcMap()
 
 	// Test placeholder functions
-	includeFn, ok := fm["include"].(func(string, interface{}) string)
+	includeFn, ok := fm["include"].(func(string, any) string)
 	if !ok {
 		t.Fatalf("include function has wrong type")
 	}
 	assert.Equal(t, "not implemented", includeFn("", nil))
 
-	tplFn, ok := fm["tpl"].(func(string, interface{}) interface{})
+	tplFn, ok := fm["tpl"].(func(string, any) any)
 	if !ok {
 		t.Fatalf("tpl function has wrong type")
 	}
 	assert.Equal(t, "not implemented", tplFn("", nil))
 
-	requiredFn, ok := fm["required"].(func(string, interface{}) (interface{}, error))
+	requiredFn, ok := fm["required"].(func(string, any) (any, error))
 	if !ok {
 		t.Fatalf("required function has wrong type")
 	}
 	result, err := requiredFn("", nil)
 	assert.Equal(t, "not implemented", result)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
-	lookupFn, ok := fm["lookup"].(func(string, string, string, string) (map[string]interface{}, error))
+	lookupFn, ok := fm["lookup"].(func(string, string, string, string) (map[string]any, error))
 	if !ok {
 		t.Fatalf("lookup function has wrong type")
 	}
 	m, err := lookupFn("", "", "", "")
-	assert.Equal(t, map[string]interface{}{}, m)
-	assert.Nil(t, err)
+	assert.Equal(t, map[string]any{}, m)
+	assert.NoError(t, err)
 
 	b64decFn, ok := fm["b64dec"].(func(string) (string, error))
 	if !ok {
@@ -424,7 +424,7 @@ func TestPlaceholderFunctions(t *testing.T) {
 	}
 	b64result, b64err := b64decFn("")
 	assert.Equal(t, "b64decDecoded_String", b64result)
-	assert.Nil(t, b64err)
+	assert.NoError(t, b64err)
 
 	b32decFn, ok := fm["b32dec"].(func(string) (string, error))
 	if !ok {
@@ -432,5 +432,5 @@ func TestPlaceholderFunctions(t *testing.T) {
 	}
 	b32result, b32err := b32decFn("")
 	assert.Equal(t, "b32decDecoded_String", b32result)
-	assert.Nil(t, b32err)
+	assert.NoError(t, b32err)
 }

--- a/internal/engine/funcs_test.go
+++ b/internal/engine/funcs_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToYAML(t *testing.T) {
@@ -408,7 +409,7 @@ func TestPlaceholderFunctions(t *testing.T) {
 	}
 	result, err := requiredFn("", nil)
 	assert.Equal(t, "not implemented", result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lookupFn, ok := fm["lookup"].(func(string, string, string, string) (map[string]any, error))
 	if !ok {
@@ -416,7 +417,7 @@ func TestPlaceholderFunctions(t *testing.T) {
 	}
 	m, err := lookupFn("", "", "", "")
 	assert.Equal(t, map[string]any{}, m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	b64decFn, ok := fm["b64dec"].(func(string) (string, error))
 	if !ok {
@@ -424,7 +425,7 @@ func TestPlaceholderFunctions(t *testing.T) {
 	}
 	b64result, b64err := b64decFn("")
 	assert.Equal(t, "b64decDecoded_String", b64result)
-	assert.NoError(t, b64err)
+	require.NoError(t, b64err)
 
 	b32decFn, ok := fm["b32dec"].(func(string) (string, error))
 	if !ok {
@@ -432,5 +433,5 @@ func TestPlaceholderFunctions(t *testing.T) {
 	}
 	b32result, b32err := b32decFn("")
 	assert.Equal(t, "b32decDecoded_String", b32result)
-	assert.NoError(t, b32err)
+	require.NoError(t, b32err)
 }

--- a/internal/module/camel_test.go
+++ b/internal/module/camel_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package module
+
+import (
+	"testing"
+)
+
+func TestAddWordBoundariesToNumbers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no numbers",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "with numbers",
+			input:    "abc123def",
+			expected: "abc 123 def",
+		},
+		{
+			name:     "with numbers no trailing letter",
+			input:    "abc123",
+			expected: "abc 123 ",
+		},
+		{
+			name:     "with numbers no leading letter",
+			input:    "123def",
+			expected: "123def",
+		},
+		{
+			name:     "multiple numbers",
+			input:    "abc123def456ghi",
+			expected: "abc 123 def 456 ghi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := addWordBoundariesToNumbers(tt.input)
+			if result != tt.expected {
+				t.Errorf("addWordBoundariesToNumbers(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToCamelInitCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		initCase bool
+		expected string
+	}{
+		{
+			name:     "empty string with init case true",
+			input:    "",
+			initCase: true,
+			expected: "",
+		},
+		{
+			name:     "empty string with init case false",
+			input:    "",
+			initCase: false,
+			expected: "",
+		},
+		{
+			name:     "simple string with init case true",
+			input:    "hello world",
+			initCase: true,
+			expected: "HelloWorld",
+		},
+		{
+			name:     "simple string with init case false",
+			input:    "hello world",
+			initCase: false,
+			expected: "helloWorld",
+		},
+		{
+			name:     "with underscores init case true",
+			input:    "hello_world",
+			initCase: true,
+			expected: "HelloWorld",
+		},
+		{
+			name:     "with hyphens init case false",
+			input:    "hello-world",
+			initCase: false,
+			expected: "helloWorld",
+		},
+		{
+			name:     "with dots init case true",
+			input:    "hello.world",
+			initCase: true,
+			expected: "HelloWorld",
+		},
+		{
+			name:     "with numbers init case true",
+			input:    "hello123world",
+			initCase: true,
+			expected: "Hello123World",
+		},
+		{
+			name:     "mixed case init case false",
+			input:    "HelloWorld",
+			initCase: false,
+			expected: "HelloWorld",
+		},
+		{
+			name:     "with spaces and uppercase init case true",
+			input:    "hello WORLD",
+			initCase: true,
+			expected: "HelloWORLD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toCamelInitCase(tt.input, tt.initCase)
+			if result != tt.expected {
+				t.Errorf("toCamelInitCase(%q, %v) = %q, expected %q", tt.input, tt.initCase, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToCamel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple string",
+			input:    "hello world",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "with underscores",
+			input:    "hello_world",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "with hyphens",
+			input:    "hello-world",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "with dots",
+			input:    "hello.world",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "already camel case",
+			input:    "HelloWorld",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "ID special case",
+			input:    "ID",
+			expected: "Id",
+		},
+		{
+			name:     "complex string with separators",
+			input:    "hello-world_example.test",
+			expected: "HelloWorldExampleTest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToCamel(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToCamel(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToLowerCamel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple string",
+			input:    "hello world",
+			expected: "helloWorld",
+		},
+		{
+			name:     "with underscores",
+			input:    "hello_world",
+			expected: "helloWorld",
+		},
+		{
+			name:     "with hyphens",
+			input:    "hello-world",
+			expected: "helloWorld",
+		},
+		{
+			name:     "with dots",
+			input:    "hello.world",
+			expected: "helloWorld",
+		},
+		{
+			name:     "already camel case with capital first letter",
+			input:    "HelloWorld",
+			expected: "helloWorld",
+		},
+		{
+			name:     "already lower camel case",
+			input:    "helloWorld",
+			expected: "helloWorld",
+		},
+		{
+			name:     "ID special case",
+			input:    "ID",
+			expected: "id",
+		},
+		{
+			name:     "complex string with separators",
+			input:    "hello-world_example.test",
+			expected: "helloWorldExampleTest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToLowerCamel(tt.input)
+			if result != tt.expected {
+				t.Errorf("ToLowerCamel(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCRD(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]any
+		expected bool
+	}{
+		{
+			name: "is CRD",
+			data: map[string]any{
+				"kind": "CustomResourceDefinition",
+			},
+			expected: true,
+		},
+		{
+			name: "is not CRD",
+			data: map[string]any{
+				"kind": "Deployment",
+			},
+			expected: false,
+		},
+		{
+			name: "no kind",
+			data: map[string]any{
+				"apiVersion": "v1",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty data",
+			data:     map[string]any{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsCRD(tt.data)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsDeckhouseCRD(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]any
+		expected bool
+	}{
+		{
+			name: "is Deckhouse CRD",
+			data: map[string]any{
+				"kind": "CustomResourceDefinition",
+				"metadata": map[string]any{
+					"name": "module.deckhouse.io",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "is not Deckhouse CRD",
+			data: map[string]any{
+				"kind": "CustomResourceDefinition",
+				"metadata": map[string]any{
+					"name": "module.example.com",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "not a CRD",
+			data: map[string]any{
+				"kind": "Deployment",
+			},
+			expected: false,
+		},
+		{
+			name: "no metadata",
+			data: map[string]any{
+				"kind": "CustomResourceDefinition",
+			},
+			expected: false,
+		},
+		{
+			name: "metadata not a map",
+			data: map[string]any{
+				"kind":     "CustomResourceDefinition",
+				"metadata": "not a map",
+			},
+			expected: false,
+		},
+		{
+			name: "no name in metadata",
+			data: map[string]any{
+				"kind": "CustomResourceDefinition",
+				"metadata": map[string]any{
+					"namespace": "default",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "name not a string",
+			data: map[string]any{
+				"kind": "CustomResourceDefinition",
+				"metadata": map[string]any{
+					"name": 123,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDeckhouseCRD(tt.data)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetFileYAMLContent(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("valid yaml", func(t *testing.T) {
+		yamlContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+`
+		filePath := filepath.Join(tempDir, "valid.yaml")
+		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		content, err := getFileYAMLContent(filePath)
+		require.NoError(t, err)
+		require.NotNil(t, content)
+
+		assert.Equal(t, "v1", content["apiVersion"])
+		assert.Equal(t, "Pod", content["kind"])
+		metadata, ok := content["metadata"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "test-pod", metadata["name"])
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		yamlContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  - invalid indentation here
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+`
+		filePath := filepath.Join(tempDir, "invalid.yaml")
+		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		content, err := getFileYAMLContent(filePath)
+		assert.Error(t, err)
+		assert.Nil(t, content)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, "nonexistent.yaml")
+
+		content, err := getFileYAMLContent(filePath)
+		assert.Error(t, err)
+		assert.Nil(t, content)
+	})
+}
+
+func TestParse(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("successful parse", func(t *testing.T) {
+		yamlContent := `
+key1: value1
+key2:
+  nestedKey: nestedValue
+key3:
+  - item1
+  - item2
+`
+		filePath := filepath.Join(tempDir, "valid.yaml")
+		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		var parsedKeys []string
+		testParser := func(key string, value any) error {
+			parsedKeys = append(parsedKeys, key)
+			return nil
+		}
+
+		err = Parse(testParser, filePath)
+		require.NoError(t, err)
+
+		// Check that the parser was called for the nested keys in the file
+		assert.Contains(t, parsedKeys, "key2.nestedKey")
+	})
+
+	t.Run("external CRD skip", func(t *testing.T) {
+		yamlContent := `
+kind: CustomResourceDefinition
+metadata:
+  name: example.other.io
+`
+		filePath := filepath.Join(tempDir, "external-crd.yaml")
+		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		called := false
+		testParser := func(key string, value any) error {
+			called = true
+			return nil
+		}
+
+		err = Parse(testParser, filePath)
+		require.NoError(t, err)
+
+		// Parser should not be called for external CRDs
+		assert.False(t, called)
+	})
+
+	t.Run("deckhouse CRD not skipped", func(t *testing.T) {
+		yamlContent := `
+kind: CustomResourceDefinition
+metadata:
+  name: module.deckhouse.io
+spec:
+  something: value
+`
+		filePath := filepath.Join(tempDir, "deckhouse-crd.yaml")
+		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		var parsedKeys []string
+		testParser := func(key string, value any) error {
+			parsedKeys = append(parsedKeys, key)
+			return nil
+		}
+
+		err = Parse(testParser, filePath)
+		require.NoError(t, err)
+
+		// Parser should be called for Deckhouse CRDs
+		assert.NotEmpty(t, parsedKeys)
+	})
+}
+
+func TestFileParser_ParseValue(t *testing.T) {
+	t.Run("parse map string", func(t *testing.T) {
+		var parsedKeys []string
+		testParser := func(key string, value any) error {
+			parsedKeys = append(parsedKeys, key)
+			return nil
+		}
+
+		fp := fileParser{parser: testParser}
+
+		data := map[string]any{
+			"nested": map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		}
+
+		err := fp.parseValue("root", data)
+		require.NoError(t, err)
+
+		assert.Contains(t, parsedKeys, "root.nested.key1")
+		assert.Contains(t, parsedKeys, "root.nested.key2")
+	})
+
+	t.Run("parse map any", func(t *testing.T) {
+		var parsedKeys []string
+		testParser := func(key string, value any) error {
+			parsedKeys = append(parsedKeys, key)
+			return nil
+		}
+
+		fp := fileParser{parser: testParser}
+
+		nestedMap := make(map[any]any)
+		nestedMap["key1"] = "value1"
+		nestedMap["key2"] = "value2"
+
+		data := map[any]any{
+			"nested": nestedMap,
+		}
+
+		err := fp.parseValue("root", data)
+		require.NoError(t, err)
+
+		assert.Contains(t, parsedKeys, "root.nested.key1")
+		assert.Contains(t, parsedKeys, "root.nested.key2")
+	})
+
+	t.Run("parse slice", func(t *testing.T) {
+		var parsedKeys []string
+		testParser := func(key string, value any) error {
+			parsedKeys = append(parsedKeys, key)
+			return nil
+		}
+
+		fp := fileParser{parser: testParser}
+
+		data := []any{"item1", "item2"}
+
+		err := fp.parseValue("root", data)
+		require.NoError(t, err)
+
+		// В текущей реализации parseSlice не вызывает parser для элементов слайса,
+		// поэтому здесь нет проверки на наличие ключей "root[0]" и "root[1]"
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		var parsedKeys []string
+		testParser := func(key string, value any) error {
+			parsedKeys = append(parsedKeys, key)
+			return nil
+		}
+
+		fp := fileParser{parser: testParser}
+
+		err := fp.parseValue("root", nil)
+		require.NoError(t, err)
+		assert.Empty(t, parsedKeys)
+	})
+}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -160,7 +160,7 @@ spec:
     image: nginx:latest
 `
 		filePath := filepath.Join(tempDir, "valid.yaml")
-		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		err := os.WriteFile(filePath, []byte(yamlContent), 0600)
 		require.NoError(t, err)
 
 		content, err := getFileYAMLContent(filePath)
@@ -187,11 +187,11 @@ spec:
     image: nginx:latest
 `
 		filePath := filepath.Join(tempDir, "invalid.yaml")
-		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		err := os.WriteFile(filePath, []byte(yamlContent), 0600)
 		require.NoError(t, err)
 
 		content, err := getFileYAMLContent(filePath)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, content)
 	})
 
@@ -199,7 +199,7 @@ spec:
 		filePath := filepath.Join(tempDir, "nonexistent.yaml")
 
 		content, err := getFileYAMLContent(filePath)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, content)
 	})
 }
@@ -217,11 +217,11 @@ key3:
   - item2
 `
 		filePath := filepath.Join(tempDir, "valid.yaml")
-		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		err := os.WriteFile(filePath, []byte(yamlContent), 0600)
 		require.NoError(t, err)
 
 		var parsedKeys []string
-		testParser := func(key string, value any) error {
+		testParser := func(key string, _ any) error {
 			parsedKeys = append(parsedKeys, key)
 			return nil
 		}
@@ -240,11 +240,11 @@ metadata:
   name: example.other.io
 `
 		filePath := filepath.Join(tempDir, "external-crd.yaml")
-		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		err := os.WriteFile(filePath, []byte(yamlContent), 0600)
 		require.NoError(t, err)
 
 		called := false
-		testParser := func(key string, value any) error {
+		testParser := func(_ string, _ any) error {
 			called = true
 			return nil
 		}
@@ -265,11 +265,11 @@ spec:
   something: value
 `
 		filePath := filepath.Join(tempDir, "deckhouse-crd.yaml")
-		err := os.WriteFile(filePath, []byte(yamlContent), 0644)
+		err := os.WriteFile(filePath, []byte(yamlContent), 0600)
 		require.NoError(t, err)
 
 		var parsedKeys []string
-		testParser := func(key string, value any) error {
+		testParser := func(key string, _ any) error {
 			parsedKeys = append(parsedKeys, key)
 			return nil
 		}
@@ -285,7 +285,7 @@ spec:
 func TestFileParser_ParseValue(t *testing.T) {
 	t.Run("parse map string", func(t *testing.T) {
 		var parsedKeys []string
-		testParser := func(key string, value any) error {
+		testParser := func(key string, _ any) error {
 			parsedKeys = append(parsedKeys, key)
 			return nil
 		}
@@ -308,7 +308,7 @@ func TestFileParser_ParseValue(t *testing.T) {
 
 	t.Run("parse map any", func(t *testing.T) {
 		var parsedKeys []string
-		testParser := func(key string, value any) error {
+		testParser := func(key string, _ any) error {
 			parsedKeys = append(parsedKeys, key)
 			return nil
 		}
@@ -332,7 +332,7 @@ func TestFileParser_ParseValue(t *testing.T) {
 
 	t.Run("parse slice", func(t *testing.T) {
 		var parsedKeys []string
-		testParser := func(key string, value any) error {
+		testParser := func(key string, _ any) error {
 			parsedKeys = append(parsedKeys, key)
 			return nil
 		}
@@ -350,7 +350,7 @@ func TestFileParser_ParseValue(t *testing.T) {
 
 	t.Run("nil value", func(t *testing.T) {
 		var parsedKeys []string
-		testParser := func(key string, value any) error {
+		testParser := func(key string, _ any) error {
 			parsedKeys = append(parsedKeys, key)
 			return nil
 		}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -201,7 +201,7 @@ func TestStoreObject_GetInitContainers(t *testing.T) {
 
 			initContainers, err := obj.GetInitContainers()
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				var containerNames []string
@@ -285,7 +285,7 @@ func TestStoreObject_GetContainers(t *testing.T) {
 
 			containers, err := obj.GetContainers()
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				var containerNames []string
@@ -389,7 +389,7 @@ func TestStoreObject_GetAllContainers(t *testing.T) {
 
 			allContainers, err := obj.GetAllContainers()
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				var containerNames []string
@@ -472,7 +472,7 @@ func TestStoreObject_GetPodSecurityContext(t *testing.T) {
 
 			securityContext, err := obj.GetPodSecurityContext()
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expected, securityContext)
@@ -564,7 +564,7 @@ func TestStoreObject_IsHostNetwork(t *testing.T) {
 
 			hostNetwork, err := obj.IsHostNetwork()
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expected, hostNetwork)

--- a/internal/values/values.go
+++ b/internal/values/values.go
@@ -89,11 +89,13 @@ func GetGlobalValues(rootDir string) (*spec.Schema, error) {
 	valuesBytes := globalValuesBytes
 
 	if rootDir != "" {
-		if configBytesT, valuesBytesT, err := readConfigFiles(rootDir); err == nil {
-			logger.InfoF("Using global values from `%s` directory", rootDir)
-			configBytes = configBytesT
-			valuesBytes = valuesBytesT
+		configBytesT, valuesBytesT, err := readConfigFiles(rootDir)
+		if err != nil {
+			return nil, err
 		}
+		logger.InfoF("Using global values from `%s` directory", rootDir)
+		configBytes = configBytesT
+		valuesBytes = valuesBytesT
 	}
 
 	schemas, err := prepareSchemas(configBytes, valuesBytes)

--- a/internal/values/values_test.go
+++ b/internal/values/values_test.go
@@ -1,0 +1,162 @@
+package values
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+func TestOverrideValues(t *testing.T) {
+	// Test nil vals
+	values := &chartutil.Values{"foo": "bar"}
+	err := OverrideValues(values, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if (*values)["foo"] != "bar" {
+		t.Errorf("expected values to be unchanged when vals is nil")
+	}
+
+	// Test override
+	values = &chartutil.Values{"foo": "bar"}
+	vals := &chartutil.Values{"baz": "qux"}
+	err = OverrideValues(values, vals)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if v, ok := (*values)["Values"]; !ok {
+		t.Errorf("expected 'Values' key to be present after override")
+	} else {
+		valsMap, ok := v.(chartutil.Values)
+		if !ok {
+			t.Errorf("expected 'Values' to be of type chartutil.Values")
+		}
+		if !reflect.DeepEqual(valsMap, *vals) {
+			t.Errorf("expected 'Values' to equal vals, got: %v", valsMap)
+		}
+	}
+}
+
+// Test for LoadSchemaFromBytes
+func TestLoadSchemaFromBytes(t *testing.T) {
+	validYAML := []byte("type: object\nproperties:\n  foo:\n    type: string\n")
+	schema, err := LoadSchemaFromBytes(validYAML)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if schema == nil {
+		t.Fatalf("expected schema, got nil")
+	}
+
+	invalidYAML := []byte("type: object\nproperties: [bad]")
+	_, err = LoadSchemaFromBytes(invalidYAML)
+	if err == nil {
+		t.Errorf("expected error for invalid YAML, got nil")
+	}
+}
+
+// Test for prepareSchemas
+func TestPrepareSchemas(t *testing.T) {
+	validYAML := []byte("type: object\nproperties:\n  foo:\n    type: string\n")
+	schemas, err := prepareSchemas(validYAML, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if schemas[ConfigValuesSchema] == nil {
+		t.Errorf("expected config schema to be present")
+	}
+
+	schemas, err = prepareSchemas(nil, validYAML)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if schemas[ValuesSchema] == nil {
+		t.Errorf("expected values schema to be present")
+	}
+	if schemas[HelmValuesSchema] == nil {
+		t.Errorf("expected helm values schema to be present")
+	}
+
+	schemas, err = prepareSchemas(validYAML, validYAML)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if schemas[ConfigValuesSchema] == nil || schemas[ValuesSchema] == nil || schemas[HelmValuesSchema] == nil {
+		t.Errorf("expected all schemas to be present")
+	}
+}
+
+// Test for GetGlobalValues
+func TestGetGlobalValues(t *testing.T) {
+	_, err := GetGlobalValues("")
+	if err != nil {
+		t.Errorf("expected no error for embedded, got: %v", err)
+	}
+
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "global-hooks", "openapi"), 0o755)
+	_ = os.WriteFile(filepath.Join(dir, "global-hooks", "openapi", "config-values.yaml"), []byte("type: object\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "global-hooks", "openapi", "values.yaml"), []byte("type: object\n"), 0o600)
+	_, err = GetGlobalValues(dir)
+	if err != nil {
+		t.Errorf("expected no error for valid files, got: %v", err)
+	}
+
+	dir2 := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir2, "global-hooks", "openapi"), 0o755)
+	// не создаём ни одного файла
+	_, err = GetGlobalValues(dir2)
+	if err == nil {
+		t.Errorf("expected error for missing files, got nil")
+	}
+
+	dir3 := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir3, "global-hooks", "openapi"), 0o755)
+	_ = os.WriteFile(filepath.Join(dir3, "global-hooks", "openapi", "config-values.yaml"), []byte("type: object\n"), 0o600)
+	_, err = GetGlobalValues(dir3)
+	if err == nil {
+		t.Errorf("expected error if one file is missing, got nil")
+	}
+}
+
+// Test for readConfigFiles
+func TestReadConfigFiles(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "global-hooks", "openapi"), 0o755)
+	_ = os.WriteFile(filepath.Join(dir, "global-hooks", "openapi", "config-values.yaml"), []byte("foo"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "global-hooks", "openapi", "values.yaml"), []byte("bar"), 0o600)
+	cfg, vals, err := readConfigFiles(dir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if string(cfg) != "foo" || string(vals) != "bar" {
+		t.Errorf("unexpected file contents: %s, %s", cfg, vals)
+	}
+
+	dir2 := t.TempDir()
+	_, _, err = readConfigFiles(dir2)
+	if err == nil {
+		t.Errorf("expected error for missing config, got nil")
+	}
+}
+
+// Test for GetModuleValues
+func TestGetModuleValues(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "openapi"), 0o755)
+	_ = os.WriteFile(filepath.Join(dir, "openapi", "config-values.yaml"), []byte("type: object\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "openapi", "values.yaml"), []byte("type: object\n"), 0o600)
+	_, err := GetModuleValues(dir)
+	if err != nil {
+		t.Errorf("expected no error for valid files, got: %v", err)
+	}
+
+	dir2 := t.TempDir()
+	_, err = GetModuleValues(dir2)
+	if err == nil {
+		t.Errorf("expected error for missing files, got nil")
+	}
+}

--- a/pkg/linters/no-cyrillic/rules/files.go
+++ b/pkg/linters/no-cyrillic/rules/files.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/deckhouse/dmt/internal/fsutils"
-	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
@@ -62,7 +61,11 @@ type FilesRule struct {
 	skipSelfRe *regexp.Regexp
 }
 
-func (r *FilesRule) CheckFile(m *module.Module, fileName string, errorList *errors.LintRuleErrorsList) {
+type moduleInterface interface {
+	GetPath() string
+}
+
+func (r *FilesRule) CheckFile(m moduleInterface, fileName string, errorList *errors.LintRuleErrorsList) {
 	errorList = errorList.WithRule(r.GetName())
 
 	fName := fsutils.Rel(m.GetPath(), fileName)

--- a/pkg/linters/no-cyrillic/rules/files_test.go
+++ b/pkg/linters/no-cyrillic/rules/files_test.go
@@ -185,5 +185,5 @@ func TestGetFileContent(t *testing.T) {
 
 	// Test reading non-existent file
 	_, err = os.ReadFile(filepath.Join(tempDir, "nonexistent.txt"))
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/linters/no-cyrillic/rules/files_test.go
+++ b/pkg/linters/no-cyrillic/rules/files_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+// mockModuleInterface implements just enough interface to test the linter
+type mockModuleInterface interface {
+	GetPath() string
+}
+
+// mockModule implements the mockModuleInterface for testing
+type mockModule struct {
+	path string
+}
+
+func (m *mockModule) GetPath() string {
+	return m.path
+}
+
+// mockCheckFile is a helper function to call CheckFile with our mock module
+func mockCheckFile(rule *FilesRule, m mockModuleInterface, fileName string, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(rule.GetName())
+
+	fName := fsutils.Rel(m.GetPath(), fileName)
+	if !rule.Enabled(fName) {
+		return
+	}
+
+	if rule.skipDocRe.MatchString(fileName) {
+		return
+	}
+
+	if rule.skipI18NRe.MatchString(fileName) {
+		return
+	}
+
+	if rule.skipSelfRe.MatchString(fileName) {
+		return
+	}
+
+	lines, err := readFileLines(fileName)
+	if err != nil {
+		errorList.Error(err.Error())
+		return
+	}
+
+	cyrMsg, hasCyr := checkCyrillicLettersInArray(lines)
+	if hasCyr {
+		errorList.WithFilePath(fName).WithValue(cyrMsg).
+			Error("has cyrillic letters")
+	}
+}
+
+// helper function for testing
+func readFileLines(filename string) ([]string, error) {
+	fileBytes, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	sliceData := strings.Split(string(fileBytes), "\n")
+	return sliceData, nil
+}
+
+
+
+func TestNewFilesRule(t *testing.T) {
+	excludeFiles := []pkg.StringRuleExclude{
+		"exclude.txt",
+	}
+	excludeDirs := []pkg.PrefixRuleExclude{
+		"exclude_dir/",
+	}
+
+	rule := NewFilesRule(excludeFiles, excludeDirs)
+
+	assert.Equal(t, "files", rule.GetName())
+	assert.Equal(t, excludeFiles, rule.ExcludeStringRules)
+	assert.Equal(t, excludeDirs, rule.ExcludePrefixRules)
+	assert.NotNil(t, rule.skipDocRe)
+	assert.NotNil(t, rule.skipI18NRe)
+	assert.NotNil(t, rule.skipSelfRe)
+}
+
+func TestCheckFile(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create test files
+	normalFile := filepath.Join(tempDir, "normal.txt")
+	err := os.WriteFile(normalFile, []byte("This is English text."), 0644)
+	require.NoError(t, err)
+
+	cyrillicFile := filepath.Join(tempDir, "cyrillic.txt")
+	err = os.WriteFile(cyrillicFile, []byte("This contains Cyrillic: Привет"), 0644)
+	require.NoError(t, err)
+
+	docRuFile := filepath.Join(tempDir, "doc-ru-test.yml")
+	err = os.WriteFile(docRuFile, []byte("This contains Cyrillic: Привет"), 0644)
+	require.NoError(t, err)
+
+	ruMdFile := filepath.Join(tempDir, "test_RU.md")
+	err = os.WriteFile(ruMdFile, []byte("This contains Cyrillic: Привет"), 0644)
+	require.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(tempDir, "i18n"), 0755)
+	require.NoError(t, err)
+	i18nFile := filepath.Join(tempDir, "i18n", "strings.txt")
+	err = os.WriteFile(i18nFile, []byte("This contains Cyrillic: Привет"), 0644)
+	require.NoError(t, err)
+
+	selfFile := filepath.Join(tempDir, "no_cyrillic.go")
+	err = os.WriteFile(selfFile, []byte("This contains Cyrillic: Привет"), 0644)
+	require.NoError(t, err)
+
+	excludedFile := filepath.Join(tempDir, "exclude.txt")
+	err = os.WriteFile(excludedFile, []byte("This contains Cyrillic: Привет"), 0644)
+	require.NoError(t, err)
+
+	// Setup mock module for testing
+	mod := &mockModule{path: tempDir}
+
+	// Setup rule
+	excludeFiles := []pkg.StringRuleExclude{
+		"exclude.txt",
+	}
+	excludeDirs := []pkg.PrefixRuleExclude{}
+	rule := NewFilesRule(excludeFiles, excludeDirs)
+
+	// Test normal file (no Cyrillic)
+	t.Run("NormalFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, normalFile, errorList)
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	// Test file with Cyrillic
+	t.Run("CyrillicFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, cyrillicFile, errorList)
+		errs := errorList.GetErrors()
+		// Just check that an error is produced for files with Cyrillic
+		assert.NotEmpty(t, errs, "Should report error for Cyrillic content")
+		if len(errs) > 0 {
+			assert.Contains(t, errs[0].Text, "has cyrillic letters")
+		}
+	})
+
+	// Test excluded file by regex (doc-ru)
+	t.Run("DocRuFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, docRuFile, errorList)
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	// Test excluded RU.md file pattern
+	t.Run("RUMdFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, ruMdFile, errorList)
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	// Test excluded file by regex (i18n)
+	t.Run("I18nFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, i18nFile, errorList)
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	// Test excluded file by regex (self)
+	t.Run("SelfFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, selfFile, errorList)
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	// Test excluded file by rule
+	t.Run("ExcludedFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, excludedFile, errorList)
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	// Test non-existent file
+	t.Run("NonExistentFile", func(t *testing.T) {
+		errorList := errors.NewLintRuleErrorsList()
+		mockCheckFile(rule, mod, filepath.Join(tempDir, "nonexistent.txt"), errorList)
+		errs := errorList.GetErrors()
+		assert.NotEmpty(t, errs, "Should report error for non-existent file")
+		if len(errs) > 0 {
+			assert.Contains(t, errs[0].Text, "no such file or directory")
+		}
+	})
+}
+
+func TestGetFileContent(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create a test file
+	testFile := filepath.Join(tempDir, "test.txt")
+	content := "line1\nline2\nline3"
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	// Test reading existing file
+	fileBytes, err := os.ReadFile(testFile)
+	assert.NoError(t, err)
+	lines := strings.Split(string(fileBytes), "\n")
+	assert.Equal(t, []string{"line1", "line2", "line3"}, lines)
+
+	// Test reading non-existent file
+	_, err = os.ReadFile(filepath.Join(tempDir, "nonexistent.txt"))
+	assert.Error(t, err)
+}

--- a/pkg/linters/templates/rules/prometheus_rules_test.go
+++ b/pkg/linters/templates/rules/prometheus_rules_test.go
@@ -116,7 +116,7 @@ key: value
 			result, err := marshalStorageObject(tt.input)
 
 			if tt.expectingError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedYAML, string(result))


### PR DESCRIPTION
This pull request introduces several key updates, including a new GitHub Actions workflow for updating test coverage badges, improvements to the Helm engine implementation, and enhancements to documentation and testing. Below are the most significant changes grouped by theme.

### CI/CD Enhancements:
* Added a new GitHub Actions workflow (`.github/workflows/coverage-badge.yml`) to automatically update the test coverage badge in the `README.md` file. This includes steps to run tests, generate a coverage report, and dynamically create a badge based on the coverage percentage.

### Documentation Improvements:
* Updated the `README.md` to include a dynamic coverage badge and improved formatting for sections like "Lint" and "Gen". [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R54)

### Helm Engine Enhancements:
* Replaced the `log` package with a custom `logger` package for better logging consistency and improved log message formatting in the `internal/engine/engine.go` file. [[1]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L21) [[2]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L180-R189) [[3]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L201-R202)
* Enhanced template rendering in `internal/engine/engine.go` to handle recoverable nil pointer errors gracefully during linting, ensuring partial output is used instead of failing completely.
* Renamed `initFunMap` to `initFuncMap` to align with Go naming conventions. [[1]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L166-R168) [[2]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L243-R244)

### Testing Enhancements:
* Added comprehensive unit tests in `internal/engine/engine_test.go` to validate various Helm engine functionalities, including strict mode, lint mode, template inclusion, subchart values, and more.
* Introduced tests for file access methods in `internal/engine/files_test.go`, covering `.Files.Get`, `.Files.Glob`, `.Files.Lines`, `.Files.AsConfig`, and `.Files.AsSecrets`.

### Codebase Simplification:
* Simplified the `funcMap` implementation in `internal/engine/funcs.go` by using `maps.Copy` to merge function maps, improving readability and reducing redundancy. [[1]](diffhunk://#diff-a3ff1aba0af9179ed8875dad64012f9670ae8b7e00f006c12efe49dd05e264b2R25-R26) [[2]](diffhunk://#diff-a3ff1aba0af9179ed8875dad64012f9670ae8b7e00f006c12efe49dd05e264b2L82-R84)