### PR TITLE
feat: add grafana dashboards exclusion settings and update related logic

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -163,7 +163,8 @@ type RBACExcludeRules struct {
 }
 
 type TemplatesSettings struct {
-	ExcludeRules TemplatesExcludeRules `mapstructure:"exclude-rules"`
+	ExcludeRules      TemplatesExcludeRules        `mapstructure:"exclude-rules"`
+	GrafanaDashboards GrafanaDashboardsExcludeList `mapstructure:"grafana-dashboards"`
 
 	Impact *pkg.Level `mapstructure:"impact"`
 }
@@ -173,6 +174,10 @@ type TemplatesExcludeRules struct {
 	PDBAbsent     KindRuleExcludeList    `mapstructure:"pdb"`
 	ServicePort   ServicePortExcludeList `mapstructure:"service-port"`
 	KubeRBACProxy StringRuleExcludeList  `mapstructure:"kube-rbac-proxy"`
+}
+
+type GrafanaDashboardsExcludeList struct {
+	Disable bool `mapstructure:"disable"`
 }
 
 type ServicePortExcludeList []ServicePortExclude

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -16,6 +16,9 @@ This linter has settings.
 ```yaml
 linters-settings:
   templates:
+    # disable grafana-dashboards rule
+    grafana-dashboards:
+      disable: true
     exclude-rules:
       # exclude if target ref equals one of
       vpa:

--- a/pkg/linters/templates/rules/grafana.go
+++ b/pkg/linters/templates/rules/grafana.go
@@ -32,12 +32,16 @@ const (
 )
 
 func NewGrafanaRule(cfg *config.TemplatesSettings) *GrafanaRule {
+	var exclude bool
+	if cfg != nil {
+		exclude = cfg.GrafanaDashboards.Disable
+	}
 	return &GrafanaRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: GrafanaRuleName,
 		},
 		BoolRule: pkg.BoolRule{
-			Exclude: cfg.GrafanaDashboards.Disable,
+			Exclude: exclude,
 		},
 	}
 }

--- a/pkg/linters/templates/rules/grafana.go
+++ b/pkg/linters/templates/rules/grafana.go
@@ -19,6 +19,7 @@ package rules
 import (
 	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 
 	"os"
@@ -30,19 +31,27 @@ const (
 	GrafanaRuleName = "grafana"
 )
 
-func NewGrafanaRule() *GrafanaRule {
+func NewGrafanaRule(cfg *config.TemplatesSettings) *GrafanaRule {
 	return &GrafanaRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: GrafanaRuleName,
+		},
+		BoolRule: pkg.BoolRule{
+			Exclude: cfg.GrafanaDashboards.Disable,
 		},
 	}
 }
 
 type GrafanaRule struct {
 	pkg.RuleMeta
+	pkg.BoolRule
 }
 
 func (r *GrafanaRule) ValidateGrafanaDashboards(m *module.Module, errorList *errors.LintRuleErrorsList) {
+	if !r.Enabled() {
+		return
+	}
+
 	errorList = errorList.WithFilePath(m.GetPath()).WithRule(r.GetName())
 
 	monitoringFilePath := filepath.Join(m.GetPath(), "templates", "monitoring.yaml")

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -60,7 +60,7 @@ func (l *Templates) Run(m *module.Module) {
 
 	// monitoring
 	prometheusRule := rules.NewPrometheusRule()
-	grafanaRule := rules.NewGrafanaRule()
+	grafanaRule := rules.NewGrafanaRule(l.cfg)
 
 	if err := dirExists(m.GetPath(), "monitoring"); err == nil {
 		grafanaRule.ValidateGrafanaDashboards(m, errorList)


### PR DESCRIPTION
This pull request introduces a new configuration option to disable the Grafana Dashboards rule in the linter settings. The changes include updates to the configuration structure, rule initialization, and documentation.

### Configuration Updates:
* [`pkg/config/linters_settings.go`](diffhunk://#diff-cb1fbdbfccd3fd0d8fe9d9006138fbcd1afcc3a701b37180c6fe50ed0c5c390fR167): Added `GrafanaDashboards` to `TemplatesSettings` and defined a new `GrafanaDashboardsExcludeList` type with a `Disable` field. This allows users to configure the exclusion of the Grafana Dashboards rule. [[1]](diffhunk://#diff-cb1fbdbfccd3fd0d8fe9d9006138fbcd1afcc3a701b37180c6fe50ed0c5c390fR167) [[2]](diffhunk://#diff-cb1fbdbfccd3fd0d8fe9d9006138fbcd1afcc3a701b37180c6fe50ed0c5c390fR179-R182)

### Rule Implementation:
* [`pkg/linters/templates/rules/grafana.go`](diffhunk://#diff-3fe3fb3fd8d0aebf10b250e828e19d5a96048b937772ad11bea56c8b2aa0fac1L33-R58): Updated the `NewGrafanaRule` function to accept the `TemplatesSettings` configuration and use the `Disable` field to set the `Exclude` property of the rule. Modified the `GrafanaRule` struct to include `pkg.BoolRule` and added a check in `ValidateGrafanaDashboards` to skip validation if the rule is disabled. [[1]](diffhunk://#diff-3fe3fb3fd8d0aebf10b250e828e19d5a96048b937772ad11bea56c8b2aa0fac1L33-R58) [[2]](diffhunk://#diff-3fe3fb3fd8d0aebf10b250e828e19d5a96048b937772ad11bea56c8b2aa0fac1R22)

### Integration:
* [`pkg/linters/templates/templates.go`](diffhunk://#diff-e74497ff5ed853506275892288e4104a071a48b043d92212e69c2b2cb6afde71L63-R63): Updated the `Run` method to pass the configuration to the `NewGrafanaRule` function when initializing the Grafana Dashboards rule.

### Documentation:
* [`pkg/linters/templates/README.md`](diffhunk://#diff-fe96e971fbf2f1176581104100f486471b638f4fd89d77fa34580007c2005b76R19-R21): Added an example to the YAML configuration file demonstrating how to disable the Grafana Dashboards rule.