### PR TITLE
fix: handle nil and empty cases in template rendering and parsing logic

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -216,6 +216,14 @@ func (e Engine) initFuncMap(t *template.Template) {
 	t.Funcs(funcMap)
 }
 
+// getRenderedContent returns the rendered content from the buffer with "<no value>" replaced
+func getRenderedContent(buf strings.Builder) string {
+	if buf.Len() == 0 {
+		return ""
+	}
+	return strings.ReplaceAll(buf.String(), "<no value>", "")
+}
+
 // render takes a map of templates/values and renders them.
 //
 //nolint:nonamedreturns // copy from helm
@@ -281,12 +289,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 
 			if e.LintMode && isRecoverableNilError {
 				logger.ErrorF("[LINT] Template %s encountered a nil pointer access during execution: %v. Using partially rendered output.", filename, executeErr)
-				// Use the content of the buffer as is (output before the error), then replace "<no value>"
-				if buf.Len() > 0 {
-					rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
-				} else {
-					rendered[filename] = ""
-				}
+				rendered[filename] = getRenderedContent(buf)
 			} else {
 				// For other errors, or if not in LintMode, this is a hard error.
 				return map[string]string{}, cleanupExecError(filename, executeErr)
@@ -296,11 +299,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 			// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
 			// is set. Since missing=error will never get here, we do not need to handle
 			// the Strict case.
-			if buf.Len() > 0 {
-				rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
-			} else {
-				rendered[filename] = ""
-			}
+			rendered[filename] = getRenderedContent(buf)
 		}
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -282,7 +282,11 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 			if e.LintMode && isRecoverableNilError {
 				logger.ErrorF("[LINT] Template %s encountered a nil pointer access during execution: %v. Using partially rendered output.", filename, executeErr)
 				// Use the content of the buffer as is (output before the error), then replace "<no value>"
-				rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
+				if buf.Len() > 0 {
+					rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
+				} else {
+					rendered[filename] = ""
+				}
 			} else {
 				// For other errors, or if not in LintMode, this is a hard error.
 				return map[string]string{}, cleanupExecError(filename, executeErr)
@@ -292,7 +296,11 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 			// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
 			// is set. Since missing=error will never get here, we do not need to handle
 			// the Strict case.
-			rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
+			if buf.Len() > 0 {
+				rendered[filename] = strings.ReplaceAll(buf.String(), "<no value>", "")
+			} else {
+				rendered[filename] = ""
+			}
 		}
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -217,7 +217,7 @@ func (e Engine) initFuncMap(t *template.Template) {
 }
 
 // getRenderedContent returns the rendered content from the buffer with "<no value>" replaced
-func getRenderedContent(buf strings.Builder) string {
+func getRenderedContent(buf *strings.Builder) string {
 	if buf.Len() == 0 {
 		return ""
 	}
@@ -289,7 +289,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 
 			if e.LintMode && isRecoverableNilError {
 				logger.ErrorF("[LINT] Template %s encountered a nil pointer access during execution: %v. Using partially rendered output.", filename, executeErr)
-				rendered[filename] = getRenderedContent(buf)
+				rendered[filename] = getRenderedContent(&buf)
 			} else {
 				// For other errors, or if not in LintMode, this is a hard error.
 				return map[string]string{}, cleanupExecError(filename, executeErr)
@@ -299,7 +299,7 @@ func (e Engine) render(tpls map[string]renderable) (rendered map[string]string, 
 			// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
 			// is set. Since missing=error will never get here, we do not need to handle
 			// the Strict case.
-			rendered[filename] = getRenderedContent(buf)
+			rendered[filename] = getRenderedContent(&buf)
 		}
 	}
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -339,7 +339,7 @@ func TestGetRenderedContent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf strings.Builder
 			buf.WriteString(tt.input)
-			result := getRenderedContent(buf)
+			result := getRenderedContent(&buf)
 			if result != tt.expected {
 				t.Errorf("getRenderedContent() = %q, want %q", result, tt.expected)
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -298,5 +299,50 @@ Sub: ` + expectedSubOutput
 
 	if got := out["main-chart/templates/main.yaml"]; got != expectedMainOutput {
 		t.Errorf("Rendered main chart content does not match. Expected %q, got %q", expectedMainOutput, got)
+	}
+}
+
+func TestGetRenderedContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty buffer",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "buffer with no value",
+			input:    "<no value>",
+			expected: "",
+		},
+		{
+			name:     "buffer with multiple no values",
+			input:    "prefix <no value> suffix <no value>",
+			expected: "prefix  suffix ",
+		},
+		{
+			name:     "buffer with normal content",
+			input:    "normal content",
+			expected: "normal content",
+		},
+		{
+			name:     "buffer with mixed content",
+			input:    "normal <no value> content",
+			expected: "normal  content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			buf.WriteString(tt.input)
+			result := getRenderedContent(buf)
+			if result != tt.expected {
+				t.Errorf("getRenderedContent() = %q, want %q", result, tt.expected)
+			}
+		})
 	}
 }

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -213,13 +213,22 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 			return nil
 		}
 		slice, isSlice := def.([]any)
-		if !isSlice {
-			return nil
+		if isSlice {
+			if len(slice) == 0 {
+				return nil
+			}
+			def = slice[0]
+		} else {
+			mapSlice, isMapSlice := def.([]map[string]any)
+			if isMapSlice {
+				if len(mapSlice) == 0 {
+					return nil
+				}
+				def = mapSlice[0]
+			} else {
+				return nil
+			}
 		}
-		if len(slice) == 0 {
-			return nil
-		}
-		def = slice[0]
 	}
 	ex, ok := def.(map[string]any)
 	if !ok {
@@ -235,12 +244,9 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 			return err
 		}
 		result[key] = t
-
 		return nil
 	}
-
 	result[key] = def
-
 	return nil
 }
 

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -226,6 +226,7 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 				}
 				def = mapSlice[0]
 			} else {
+				// Skip non-slice and non-map-slice default values as they are not supported in this context
 				return nil
 			}
 		}

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -214,7 +214,11 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 		if reflect.TypeOf(def).Kind() != reflect.Slice {
 			return nil
 		}
-		def = reflect.ValueOf(def).Index(0).Interface()
+		slice := reflect.ValueOf(def)
+		if slice.Len() == 0 {
+			return nil
+		}
+		def = slice.Index(0).Interface()
 	}
 	ex, ok := def.(map[string]any)
 	if !ok {

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -209,8 +209,10 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 	if !ok {
 		return nil
 	}
-	// if we have multiple examples, we take the first one
 	if extension == ExamplesDefault {
+		if def == nil {
+			return nil
+		}
 		if reflect.TypeOf(def).Kind() != reflect.Slice {
 			return nil
 		}

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -212,8 +212,8 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 		if def == nil {
 			return nil
 		}
-		slice, ok := def.([]any)
-		if !ok {
+		slice, isSlice := def.([]any)
+		if !isSlice {
 			return nil
 		}
 		if len(slice) == 0 {

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -18,7 +18,6 @@ package module
 
 import (
 	"fmt"
-	"reflect"
 
 	"dario.cat/mergo"
 	"github.com/go-openapi/spec"
@@ -213,14 +212,14 @@ func parseDefault(key string, prop *spec.Schema, extension string, result map[st
 		if def == nil {
 			return nil
 		}
-		if reflect.TypeOf(def).Kind() != reflect.Slice {
+		slice, ok := def.([]any)
+		if !ok {
 			return nil
 		}
-		slice := reflect.ValueOf(def)
-		if slice.Len() == 0 {
+		if len(slice) == 0 {
 			return nil
 		}
-		def = slice.Index(0).Interface()
+		def = slice[0]
 	}
 	ex, ok := def.(map[string]any)
 	if !ok {

--- a/pkg/linters/openapi/rules/enum.go
+++ b/pkg/linters/openapi/rules/enum.go
@@ -128,11 +128,7 @@ func validateEnumValue(value string) error {
 	if value == "" {
 		return nil
 	}
-
 	vv := []rune(value)
-	if len(value) == 0 {
-		return nil
-	}
 	if unicode.IsLetter(vv[0]) && !unicode.IsUpper(vv[0]) {
 		return fmt.Errorf("value '%s' must start with Capital letter", value)
 	}

--- a/pkg/linters/openapi/rules/enum.go
+++ b/pkg/linters/openapi/rules/enum.go
@@ -130,7 +130,7 @@ func validateEnumValue(value string) error {
 	}
 
 	vv := []rune(value)
-	if len(vv) == 0 {
+	if len(value) == 0 {
 		return nil
 	}
 	if unicode.IsLetter(vv[0]) && !unicode.IsUpper(vv[0]) {

--- a/pkg/linters/openapi/rules/enum.go
+++ b/pkg/linters/openapi/rules/enum.go
@@ -130,6 +130,9 @@ func validateEnumValue(value string) error {
 	}
 
 	vv := []rune(value)
+	if len(vv) == 0 {
+		return nil
+	}
 	if unicode.IsLetter(vv[0]) && !unicode.IsUpper(vv[0]) {
 		return fmt.Errorf("value '%s' must start with Capital letter", value)
 	}

--- a/pkg/linters/openapi/rules/keys.go
+++ b/pkg/linters/openapi/rules/keys.go
@@ -67,7 +67,7 @@ func newKeyValidator(cfg *config.OpenAPISettings) keyValidator {
 
 func (kn keyValidator) run(absoluteKey string, value any) error {
 	parts := strings.Split(absoluteKey, ".")
-	if len(parts) == 0 || parts[len(parts)-1] != "enum" {
+	if parts[len(parts)-1] != "enum" {
 		return nil
 	}
 

--- a/pkg/linters/openapi/rules/keys.go
+++ b/pkg/linters/openapi/rules/keys.go
@@ -67,7 +67,7 @@ func newKeyValidator(cfg *config.OpenAPISettings) keyValidator {
 
 func (kn keyValidator) run(absoluteKey string, value any) error {
 	parts := strings.Split(absoluteKey, ".")
-	if parts[len(parts)-1] != "enum" {
+	if len(parts) == 0 || parts[len(parts)-1] != "enum" {
 		return nil
 	}
 


### PR DESCRIPTION
This pull request includes several changes to improve error handling and robustness in the codebase. The most important updates address cases where empty values or slices could lead to unexpected behavior, ensuring proper handling of edge cases.

### Error Handling Improvements:

* [`internal/engine/engine.go`](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4R285-R289): Updated the `render` function to handle cases where the buffer is empty by setting `rendered[filename]` to an empty string instead of attempting replacements, ensuring graceful handling of nil pointer errors and missing values. [[1]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4R285-R289) [[2]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4R299-R303)
* [`internal/module/openapi.go`](diffhunk://#diff-f4f4faf78e21038c359f92fe954b378a74cdf870ace1502d5a32a34449ef61ccL217-R221): Modified the `parseDefault` function to check if a slice is empty before accessing its first element, preventing runtime errors when processing empty slices.

### Edge Case Handling:

* [`pkg/linters/openapi/rules/enum.go`](diffhunk://#diff-35a69a4f7a96d83575cf3696643724dc4d62feda14f68d50d99888fda2890b85R133-R135): Enhanced the `validateEnumValue` function to return early if the input value is an empty string, avoiding unnecessary validations and errors.
* [`pkg/linters/openapi/rules/keys.go`](diffhunk://#diff-eaf2e91e927bf3eb552e884363b9ef435f641642e03015cee57420d9a4883799L70-R70): Adjusted the `run` method in the `keyValidator` to handle cases where the `parts` slice is empty, ensuring safe access to its elements.