### PR TITLE
fix: remove validation for 'heritage' label in CRD rule

### DIFF
--- a/pkg/linters/openapi/rules/crds.go
+++ b/pkg/linters/openapi/rules/crds.go
@@ -105,7 +105,6 @@ func (r *DeckhouseCRDsRule) Run(moduleName, path string, errorList *errors.LintR
 			continue
 		}
 
-		r.validateLabel(&crd, "heritage", "deckhouse", errorList, shortPath)
 		r.validateLabel(&crd, "module", moduleName, errorList, shortPath)
 	}
 }

--- a/pkg/linters/openapi/rules/crds_test.go
+++ b/pkg/linters/openapi/rules/crds_test.go
@@ -67,55 +67,6 @@ spec:
 			wantErrors: []string{`CRD specified using deprecated api version, wanted "apiextensions.k8s.io/v1"`},
 		},
 		{
-			name:       "missing heritage label",
-			moduleName: "test-module",
-			content: `apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: test.deckhouse.io
-  labels:
-    module: test-module
-spec:
-  group: deckhouse.io
-  names:
-    kind: Test
-    plural: tests
-  scope: Cluster
-  versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object`,
-			wantErrors: []string{`CRD should contain "heritage = deckhouse" label`},
-		},
-		{
-			name:       "wrong heritage label",
-			moduleName: "test-module",
-			content: `apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: test.deckhouse.io
-  labels:
-    heritage: wrong
-    module: test-module
-spec:
-  group: deckhouse.io
-  names:
-    kind: Test
-    plural: tests
-  scope: Cluster
-  versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object`,
-			wantErrors: []string{`CRD should contain "heritage = deckhouse" label, but got "heritage = wrong"`},
-		},
-		{
 			name:       "missing module label",
 			moduleName: "test-module",
 			content: `apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
This pull request includes a small change to the `DeckhouseCRDsRule` linter in the `pkg/linters/openapi/rules/crds.go` file. The change removes the validation of the "heritage" label for CRDs, simplifying the label validation logic.