### PR TITLE
fix: update error message to include UserAuthzClusterRolePath in RBAC placement validation

### DIFF
--- a/pkg/linters/rbac/rules/placement.go
+++ b/pkg/linters/rbac/rules/placement.go
@@ -196,7 +196,7 @@ func objectRBACPlacementClusterRole(m *module.Module, object storage.StoreObject
 		}
 
 	default:
-		errorList.Errorf("%s should be in %q or \"*/rbac-for-us.yaml\"", objectKind, RootRBACForUsPath)
+		errorList.Errorf("%s should be in %q or %q or \"*/rbac-for-us.yaml\"", objectKind, UserAuthzClusterRolePath, RootRBACForUsPath)
 	}
 }
 


### PR DESCRIPTION
This pull request makes a minor update to the `objectRBACPlacementClusterRole` function in `pkg/linters/rbac/rules/placement.go`. The change adds an additional valid path (`UserAuthzClusterRolePath`) to the error message for RBAC placement validation.