### PR TITLE
feat: add critical field validation

### DIFF
--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -57,6 +57,7 @@ const (
 
 type DeckhouseModule struct {
 	Name         string              `json:"name"`
+	Critical     bool                `json:"critical,omitempty"`
 	Namespace    string              `json:"namespace"`
 	Weight       uint32              `json:"weight,omitempty"`
 	Tags         []string            `json:"tags"`
@@ -145,6 +146,10 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 	// ru description is not required
 	if yml.Descriptions.English == "" {
 		errorList.Warn("Module `descriptions.en` field is required")
+	}
+
+	if yml.Critical && yml.Weight == 0 {
+		errorList.Error("Field 'weight' must be zero for critical modules")
 	}
 }
 

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -113,3 +113,94 @@ func TestValidateRequirements(t *testing.T) {
 	invalidRequirements.validateRequirements(errorList)
 	assert.True(t, errorList.ContainsErrors(), "Expected errors for invalid requirements")
 }
+
+func TestCheckDefinitionFile_CriticalAndWeight(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)
+
+	// 1. Critical: true, Weight: 0 (should produce error)
+	err := os.WriteFile(moduleFilePath, []byte(`
+name: test-critical
+critical: true
+weight: 0
+stage: Experimental
+descriptions:
+  en: "Test description"
+`), 0600)
+	require.NoError(t, err)
+
+	rule := NewDefinitionFileRule(false)
+	errorList := errors.NewLintRuleErrorsList()
+	rule.CheckDefinitionFile(tempDir, errorList)
+	assert.True(t, errorList.ContainsErrors(), "Expected error for critical module with zero weight")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "Field 'weight' must be zero for critical modules")
+
+	// 2. Critical: true, Weight: 10 (should not produce error)
+	err = os.WriteFile(moduleFilePath, []byte(`
+name: test-critical
+critical: true
+weight: 10
+stage: Experimental
+descriptions:
+  en: "Test description"
+`), 0600)
+	require.NoError(t, err)
+
+	errorList = errors.NewLintRuleErrorsList()
+	rule.CheckDefinitionFile(tempDir, errorList)
+	assert.False(t, errorList.ContainsErrors(), "Expected no error for critical module with non-zero weight")
+
+	// 3. Invalid stage value (should produce error)
+	err = os.WriteFile(moduleFilePath, []byte(`
+name: test-stage
+stage: InvalidStage
+descriptions:
+  en: "Test description"
+`), 0600)
+	require.NoError(t, err)
+
+	errorList = errors.NewLintRuleErrorsList()
+	rule.CheckDefinitionFile(tempDir, errorList)
+	assert.True(t, errorList.ContainsErrors(), "Expected error for invalid stage value")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "Field 'stage' is not one of the following values")
+
+	// 4. Invalid requirements (invalid deckhouse version, should produce error)
+	err = os.WriteFile(moduleFilePath, []byte(`
+name: test-req
+stage: Experimental
+descriptions:
+  en: "Test description"
+requirements:
+  deckhouse: "invalid-version"
+`), 0600)
+	require.NoError(t, err)
+
+	errorList = errors.NewLintRuleErrorsList()
+	rule.CheckDefinitionFile(tempDir, errorList)
+	assert.True(t, errorList.ContainsErrors(), "Expected error for invalid deckhouse version in requirements")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "Invalid Deckhouse version requirement")
+
+	// 5. Missing descriptions.en (should produce warning)
+	err = os.WriteFile(moduleFilePath, []byte(`
+name: test-desc
+stage: Experimental
+`), 0600)
+	require.NoError(t, err)
+
+	errorList = errors.NewLintRuleErrorsList()
+	rule.CheckDefinitionFile(tempDir, errorList)
+	warnings := []string{}
+	for _, e := range errorList.GetErrors() {
+		if e.Level == 0 { // pkg.Warn
+			warnings = append(warnings, e.Text)
+		}
+	}
+	assert.NotEmpty(t, warnings, "Expected warning for missing descriptions.en")
+	found := false
+	for _, w := range warnings {
+		if w == "Module `descriptions.en` field is required" {
+			found = true
+		}
+	}
+	assert.True(t, found, "Expected warning text for missing descriptions.en")
+}

--- a/pkg/linters/templates/rules/ingress.go
+++ b/pkg/linters/templates/rules/ingress.go
@@ -70,7 +70,7 @@ func (r *IngressRule) CheckSnippetsRule(object storage.StoreObject, errorList *e
 		return
 	}
 
-	for key, value := range ingress.ObjectMeta.GetAnnotations() {
+	for key, value := range ingress.GetAnnotations() {
 		if key == "nginx.ingress.kubernetes.io/configuration-snippet" {
 			if !strings.Contains(value, "add_header Strict-Transport-Security") {
 				errorList.WithObjectID(object.Unstructured.GetName()).


### PR DESCRIPTION
Introduce a 'critical' field in DeckhouseModule with validation to ensure that critical modules have a weight of zero. Add corresponding tests for the new validation logic.