### PR TITLE
feat: add new container security rules for NoNewPrivileges and SeccompProfile

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -56,6 +56,8 @@ type ContainerExcludeRules struct {
 	HostNetworkPorts       ContainerRuleExcludeList `mapstructure:"host-network-ports"`
 	Ports                  ContainerRuleExcludeList `mapstructure:"ports"`
 	ReadOnlyRootFilesystem ContainerRuleExcludeList `mapstructure:"read-only-root-filesystem"`
+	NoNewPrivileges        ContainerRuleExcludeList `mapstructure:"no-new-privileges"`
+	SeccompProfile         ContainerRuleExcludeList `mapstructure:"seccomp-profile"`
 	ImageDigest            ContainerRuleExcludeList `mapstructure:"image-digest"`
 	Resources              ContainerRuleExcludeList `mapstructure:"resources"`
 	SecurityContext        ContainerRuleExcludeList `mapstructure:"security-context"`

--- a/pkg/linters/container/README.md
+++ b/pkg/linters/container/README.md
@@ -1,13 +1,17 @@
 ## Description
 
 Checks containers inside the template spec. This linter protects against the next cases:
- - containers with the duplicated names
- - containers with the duplicated env variables
- - misconfigured images repository and digest
- - imagePullPolicy is "Always" (should be unspecified or "IfNotPresent")
- - ephemeral storage is not defined in .resources
- - SecurityContext is not defined
- - container uses port <= 1024
+
+- containers with the duplicated names
+- containers with the duplicated env variables
+- misconfigured images repository and digest
+- imagePullPolicy is "Always" (should be unspecified or "IfNotPresent")
+- ephemeral storage is not defined in .resources
+- SecurityContext is not defined
+- ReadOnlyRootFilesystem is not set to true (prevents write access to container root filesystem)
+- AllowPrivilegeEscalation is not set to false (prevents privilege escalation attacks)
+- Seccomp profile is not properly configured (ensures default seccomp filtering is enabled)
+- container uses port <= 1024
 - Checks for probes defined in containers.
 
 ## Settings example
@@ -25,6 +29,16 @@ linters-settings:
         - kind: Deployment
           name: deckhouse
           container: init-downloaded-modules
+      # exclude if object kind, object name and containers name are equal
+      no-new-privileges:
+        - kind: Deployment
+          name: privileged-deployment
+          container: init-container
+      # exclude if object kind, object name and containers name are equal
+      seccomp-profile:
+        - kind: DaemonSet
+          name: system-daemon
+          container: system-container
       # exclude if object kind, object name and containers name are equal
       resources:
         - kind: Deployment

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -59,6 +59,10 @@ func (l *Container) applyContainerRules(object storage.StoreObject, errorList *e
 		rules.NewNameDuplicatesRule().ContainerNameDuplicates,
 		rules.NewCheckReadOnlyRootFilesystemRule(l.cfg.ExcludeRules.ReadOnlyRootFilesystem.Get()).
 			ObjectReadOnlyRootFilesystem,
+		rules.NewNoNewPrivilegesRule(l.cfg.ExcludeRules.NoNewPrivileges.Get()).
+			ContainerNoNewPrivileges,
+		rules.NewSeccompProfileRule(l.cfg.ExcludeRules.SeccompProfile.Get()).
+			ContainerSeccompProfile,
 		rules.NewHostNetworkPortsRule(l.cfg.ExcludeRules.HostNetworkPorts.Get()).ObjectHostNetworkPorts,
 
 		// old with module names skipping

--- a/pkg/linters/container/rules/container_no_new_privileges.go
+++ b/pkg/linters/container/rules/container_no_new_privileges.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	NoNewPrivilegesRuleName = "no-new-privileges"
+)
+
+func NewNoNewPrivilegesRule(excludeRules []pkg.ContainerRuleExclude) *NoNewPrivilegesRule {
+	return &NoNewPrivilegesRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: NoNewPrivilegesRuleName,
+		},
+		ContainerRule: pkg.ContainerRule{
+			ExcludeRules: excludeRules,
+		},
+	}
+}
+
+type NoNewPrivilegesRule struct {
+	pkg.RuleMeta
+	pkg.ContainerRule
+}
+
+// ContainerNoNewPrivileges checks that containers have allowPrivilegeEscalation set to false
+// This prevents privilege escalation attacks by ensuring containers cannot gain additional privileges
+// Reference: CIS Kubernetes Benchmark 5.2.5
+func (r *NoNewPrivilegesRule) ContainerNoNewPrivileges(object storage.StoreObject, containers []corev1.Container, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName()).WithFilePath(object.ShortPath())
+
+	switch object.Unstructured.GetKind() {
+	case "Deployment", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob":
+	default:
+		return
+	}
+
+	for i := range containers {
+		c := &containers[i]
+
+		if !r.Enabled(object, c) {
+			// TODO: add metrics
+			continue
+		}
+
+		if c.SecurityContext == nil {
+			errorList.WithObjectID(object.Identity() + " ; container = " + c.Name).
+				Error("Container's SecurityContext is missing - cannot verify allowPrivilegeEscalation setting")
+			continue
+		}
+
+		if c.SecurityContext.AllowPrivilegeEscalation == nil {
+			errorList.WithObjectID(object.Identity() + " ; container = " + c.Name).
+				Error("Container's SecurityContext missing parameter AllowPrivilegeEscalation - should be set to false to prevent privilege escalation")
+			continue
+		}
+
+		if *c.SecurityContext.AllowPrivilegeEscalation {
+			errorList.WithObjectID(object.Identity() + " ; container = " + c.Name).
+				Error("Container's SecurityContext has `AllowPrivilegeEscalation: true`, but it must be `false` to prevent privilege escalation attacks")
+		}
+	}
+}

--- a/pkg/linters/container/rules/container_no_new_privileges_test.go
+++ b/pkg/linters/container/rules/container_no_new_privileges_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+func TestNoNewPrivilegesRule_ContainerNoNewPrivileges(t *testing.T) {
+	tests := []struct {
+		name           string
+		kind           string
+		containers     []corev1.Container
+		expectedErrors []string
+	}{
+		{
+			name: "unsupported kind should be ignored",
+			kind: "Service",
+			containers: []corev1.Container{{
+				Name: "test",
+			}},
+			expectedErrors: []string{},
+		},
+		{
+			name: "missing security context should error",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+			}},
+			expectedErrors: []string{
+				"Container's SecurityContext is missing - cannot verify allowPrivilegeEscalation setting",
+			},
+		},
+		{
+			name: "missing allowPrivilegeEscalation should error",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: boolPtr(true),
+				},
+			}},
+			expectedErrors: []string{
+				"Container's SecurityContext missing parameter AllowPrivilegeEscalation - should be set to false to prevent privilege escalation",
+			},
+		},
+		{
+			name: "allowPrivilegeEscalation true should error",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(true),
+				},
+			}},
+			expectedErrors: []string{
+				"Container's SecurityContext has `AllowPrivilegeEscalation: true`, but it must be `false` to prevent privilege escalation attacks",
+			},
+		},
+		{
+			name: "allowPrivilegeEscalation false should pass",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+				},
+			}},
+			expectedErrors: []string{},
+		},
+		{
+			name: "multiple containers with mixed settings",
+			kind: "Pod",
+			containers: []corev1.Container{
+				{
+					Name: "good-container",
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolPtr(false),
+					},
+				},
+				{
+					Name: "bad-container",
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolPtr(true),
+					},
+				},
+				{
+					Name: "missing-context",
+				},
+			},
+			expectedErrors: []string{
+				"Container's SecurityContext has `AllowPrivilegeEscalation: true`, but it must be `false` to prevent privilege escalation attacks",
+				"Container's SecurityContext is missing - cannot verify allowPrivilegeEscalation setting",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewNoNewPrivilegesRule([]pkg.ContainerRuleExclude{})
+			errorList := errors.NewLintRuleErrorsList()
+
+			obj := storage.StoreObject{
+				Path: "test.yaml",
+				Unstructured: unstructured.Unstructured{
+					Object: map[string]any{
+						"kind":     tt.kind,
+						"metadata": map[string]any{"name": "test-obj"},
+					},
+				},
+			}
+
+			rule.ContainerNoNewPrivileges(obj, tt.containers, errorList)
+			errs := errorList.GetErrors()
+
+			if len(tt.expectedErrors) == 0 {
+				assert.Empty(t, errs, "Expected no errors")
+			} else {
+				assert.Len(t, errs, len(tt.expectedErrors), "Expected %d errors", len(tt.expectedErrors))
+				for i, expectedError := range tt.expectedErrors {
+					assert.Contains(t, errs[i].Text, expectedError, "Error %d should contain expected text", i)
+				}
+			}
+		})
+	}
+}
+
+func TestNoNewPrivilegesRule_WithExclusions(t *testing.T) {
+	excludeRules := []pkg.ContainerRuleExclude{
+		{
+			Kind:      "Deployment",
+			Name:      "excluded-deployment",
+			Container: "excluded-container",
+		},
+	}
+
+	rule := NewNoNewPrivilegesRule(excludeRules)
+	errorList := errors.NewLintRuleErrorsList()
+
+	obj := storage.StoreObject{
+		Path: "test.yaml",
+		Unstructured: unstructured.Unstructured{
+			Object: map[string]any{
+				"kind":     "Deployment",
+				"metadata": map[string]any{"name": "excluded-deployment"},
+			},
+		},
+	}
+
+	containers := []corev1.Container{{
+		Name: "excluded-container",
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(true), // This would normally fail
+		},
+	}}
+
+	rule.ContainerNoNewPrivileges(obj, containers, errorList)
+	errs := errorList.GetErrors()
+
+	assert.Empty(t, errs, "Excluded container should not generate errors")
+}
+
+// Helper function to create bool pointers
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/linters/container/rules/container_seccomp_profile.go
+++ b/pkg/linters/container/rules/container_seccomp_profile.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	SeccompProfileRuleName = "seccomp-profile"
+)
+
+func NewSeccompProfileRule(excludeRules []pkg.ContainerRuleExclude) *SeccompProfileRule {
+	return &SeccompProfileRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: SeccompProfileRuleName,
+		},
+		ContainerRule: pkg.ContainerRule{
+			ExcludeRules: excludeRules,
+		},
+	}
+}
+
+type SeccompProfileRule struct {
+	pkg.RuleMeta
+	pkg.ContainerRule
+}
+
+// ContainerSeccompProfile checks that containers use the default seccomp profile and don't disable seccomp
+// This ensures containers are protected by the default seccomp profile which filters system calls
+// Reference: CIS Kubernetes Benchmark 5.7.2, OWASP Kubernetes Security Cheat Sheet
+func (r *SeccompProfileRule) ContainerSeccompProfile(object storage.StoreObject, containers []corev1.Container, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName()).WithFilePath(object.ShortPath())
+
+	switch object.Unstructured.GetKind() {
+	case "Deployment", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob":
+	default:
+		return
+	}
+
+	// Check pod-level seccomp profile first
+	podSeccompProfile, err := r.getPodSeccompProfile(object)
+	if err != nil {
+		errorList.WithObjectID(object.Identity()).
+			Errorf("Failed to get pod seccomp profile: %v", err)
+		return
+	}
+
+	for i := range containers {
+		c := &containers[i]
+
+		if !r.Enabled(object, c) {
+			// TODO: add metrics
+			continue
+		}
+
+		// Check container-level seccomp profile
+		containerSeccompProfile := r.getContainerSeccompProfile(c)
+
+		// Determine effective seccomp profile (container-level overrides pod-level)
+		effectiveProfile := containerSeccompProfile
+		if effectiveProfile == nil {
+			effectiveProfile = podSeccompProfile
+		}
+
+		r.validateSeccompProfile(effectiveProfile, object, c, errorList)
+	}
+}
+
+// getPodSeccompProfile extracts seccomp profile from pod security context
+func (*SeccompProfileRule) getPodSeccompProfile(object storage.StoreObject) (*corev1.SeccompProfile, error) {
+	securityContext, err := object.GetPodSecurityContext()
+	if err != nil {
+		return nil, err
+	}
+
+	if securityContext == nil {
+		return nil, nil
+	}
+
+	return securityContext.SeccompProfile, nil
+}
+
+// getContainerSeccompProfile extracts seccomp profile from container security context
+func (*SeccompProfileRule) getContainerSeccompProfile(container *corev1.Container) *corev1.SeccompProfile {
+	if container.SecurityContext == nil {
+		return nil
+	}
+
+	return container.SecurityContext.SeccompProfile
+}
+
+// validateSeccompProfile validates the effective seccomp profile
+func (*SeccompProfileRule) validateSeccompProfile(profile *corev1.SeccompProfile, object storage.StoreObject, container *corev1.Container, errorList *errors.LintRuleErrorsList) {
+	objectID := object.Identity() + " ; container = " + container.Name
+
+	if profile == nil {
+		// No seccomp profile specified - this is acceptable as Kubernetes will use the default
+		// RuntimeDefault profile in newer versions, but we'll warn for explicit configuration
+		errorList.WithObjectID(objectID).
+			Warn("No seccomp profile specified - consider explicitly setting seccompProfile.type to 'RuntimeDefault' for better security posture")
+		return
+	}
+
+	switch profile.Type {
+	case corev1.SeccompProfileTypeRuntimeDefault:
+		// This is the recommended secure default - no error
+		return
+
+	case corev1.SeccompProfileTypeUnconfined:
+		// Unconfined disables seccomp filtering, which is a security risk
+		errorList.WithObjectID(objectID).
+			Error("Container has seccompProfile.type set to 'Unconfined' which disables seccomp filtering and poses security risks - use 'RuntimeDefault' instead")
+
+	case corev1.SeccompProfileTypeLocalhost:
+		// Custom profile - warn about proper validation
+		if profile.LocalhostProfile == nil || *profile.LocalhostProfile == "" {
+			errorList.WithObjectID(objectID).
+				Error("Container has seccompProfile.type set to 'Localhost' but localhostProfile is empty")
+		} else {
+			errorList.WithObjectID(objectID).
+				Warn("Container uses custom seccomp profile - ensure it's properly configured and maintained")
+		}
+
+	default:
+		errorList.WithObjectID(objectID).
+			Errorf("Container has unknown seccompProfile.type: %s", profile.Type)
+	}
+}

--- a/pkg/linters/container/rules/container_seccomp_profile_test.go
+++ b/pkg/linters/container/rules/container_seccomp_profile_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+func TestSeccompProfileRule_ContainerSeccompProfile(t *testing.T) {
+	tests := []struct {
+		name             string
+		kind             string
+		podSpec          map[string]any
+		containers       []corev1.Container
+		expectedMessages []string
+	}{
+		{
+			name:             "unsupported kind should be ignored",
+			kind:             "Service",
+			containers:       []corev1.Container{{Name: "test"}},
+			expectedMessages: []string{},
+		},
+		{
+			name: "no seccomp profile should warn",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+			}},
+			expectedMessages: []string{
+				"No seccomp profile specified - consider explicitly setting seccompProfile.type to 'RuntimeDefault' for better security posture",
+			},
+		},
+		{
+			name: "RuntimeDefault profile should pass",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+			}},
+			expectedMessages: []string{},
+		},
+		{
+			name: "Unconfined profile should error",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeUnconfined,
+					},
+				},
+			}},
+			expectedMessages: []string{
+				"Container has seccompProfile.type set to 'Unconfined' which disables seccomp filtering and poses security risks - use 'RuntimeDefault' instead",
+			},
+		},
+		{
+			name: "Localhost profile with valid path should warn",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type:             corev1.SeccompProfileTypeLocalhost,
+						LocalhostProfile: stringPtr("/path/to/profile.json"),
+					},
+				},
+			}},
+			expectedMessages: []string{
+				"Container uses custom seccomp profile - ensure it's properly configured and maintained",
+			},
+		},
+		{
+			name: "Localhost profile without path should error",
+			kind: "Deployment",
+			containers: []corev1.Container{{
+				Name: "test-container",
+				SecurityContext: &corev1.SecurityContext{
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeLocalhost,
+					},
+				},
+			}},
+			expectedMessages: []string{
+				"Container has seccompProfile.type set to 'Localhost' but localhostProfile is empty",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewSeccompProfileRule([]pkg.ContainerRuleExclude{})
+			errorList := errors.NewLintRuleErrorsList()
+
+			objData := map[string]any{
+				"kind":     tt.kind,
+				"metadata": map[string]any{"name": "test-obj"},
+			}
+
+			if tt.podSpec != nil {
+				objData["spec"] = map[string]any{
+					"template": map[string]any{
+						"spec": tt.podSpec,
+					},
+				}
+			}
+
+			obj := storage.StoreObject{
+				Path:         "test.yaml",
+				Unstructured: unstructured.Unstructured{Object: objData},
+			}
+
+			rule.ContainerSeccompProfile(obj, tt.containers, errorList)
+			errs := errorList.GetErrors()
+
+			if len(tt.expectedMessages) == 0 {
+				assert.Empty(t, errs, "Expected no messages")
+			} else {
+				assert.Len(t, errs, len(tt.expectedMessages), "Expected %d messages", len(tt.expectedMessages))
+				for i, expectedMessage := range tt.expectedMessages {
+					assert.Contains(t, errs[i].Text, expectedMessage, "Message %d should contain expected text", i)
+				}
+			}
+		})
+	}
+}
+
+func TestSeccompProfileRule_PodLevelProfile(t *testing.T) {
+	rule := NewSeccompProfileRule([]pkg.ContainerRuleExclude{})
+	errorList := errors.NewLintRuleErrorsList()
+
+	// Pod with RuntimeDefault at pod level
+	objData := map[string]any{
+		"kind":     "Pod",
+		"metadata": map[string]any{"name": "test-pod"},
+		"spec": map[string]any{
+			"securityContext": map[string]any{
+				"seccompProfile": map[string]any{
+					"type": "RuntimeDefault",
+				},
+			},
+		},
+	}
+
+	obj := storage.StoreObject{
+		Path:         "test.yaml",
+		Unstructured: unstructured.Unstructured{Object: objData},
+	}
+
+	containers := []corev1.Container{{
+		Name: "test-container",
+		// No container-level seccomp profile, should inherit from pod
+	}}
+
+	rule.ContainerSeccompProfile(obj, containers, errorList)
+	errs := errorList.GetErrors()
+
+	// Should pass without errors since pod-level RuntimeDefault is inherited
+	assert.Empty(t, errs, "Pod-level RuntimeDefault should be inherited and pass validation")
+}
+
+func TestSeccompProfileRule_ContainerOverridesPod(t *testing.T) {
+	rule := NewSeccompProfileRule([]pkg.ContainerRuleExclude{})
+	errorList := errors.NewLintRuleErrorsList()
+
+	// Pod with RuntimeDefault, but container overrides with Unconfined
+	objData := map[string]any{
+		"kind":     "Pod",
+		"metadata": map[string]any{"name": "test-pod"},
+		"spec": map[string]any{
+			"securityContext": map[string]any{
+				"seccompProfile": map[string]any{
+					"type": "RuntimeDefault",
+				},
+			},
+		},
+	}
+
+	obj := storage.StoreObject{
+		Path:         "test.yaml",
+		Unstructured: unstructured.Unstructured{Object: objData},
+	}
+
+	containers := []corev1.Container{{
+		Name: "test-container",
+		SecurityContext: &corev1.SecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeUnconfined,
+			},
+		},
+	}}
+
+	rule.ContainerSeccompProfile(obj, containers, errorList)
+	errs := errorList.GetErrors()
+
+	assert.Len(t, errs, 1, "Should have one error for Unconfined override")
+	assert.Contains(t, errs[0].Text, "Unconfined", "Should error about Unconfined profile")
+}
+
+func TestSeccompProfileRule_WithExclusions(t *testing.T) {
+	excludeRules := []pkg.ContainerRuleExclude{
+		{
+			Kind:      "Deployment",
+			Name:      "excluded-deployment",
+			Container: "excluded-container",
+		},
+	}
+
+	rule := NewSeccompProfileRule(excludeRules)
+	errorList := errors.NewLintRuleErrorsList()
+
+	obj := storage.StoreObject{
+		Path: "test.yaml",
+		Unstructured: unstructured.Unstructured{
+			Object: map[string]any{
+				"kind":     "Deployment",
+				"metadata": map[string]any{"name": "excluded-deployment"},
+			},
+		},
+	}
+
+	containers := []corev1.Container{{
+		Name: "excluded-container",
+		SecurityContext: &corev1.SecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeUnconfined, // Would normally fail
+			},
+		},
+	}}
+
+	rule.ContainerSeccompProfile(obj, containers, errorList)
+	errs := errorList.GetErrors()
+
+	assert.Empty(t, errs, "Excluded container should not generate errors")
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
- Introduced NoNewPrivilegesRule to ensure containers do not allow privilege escalation.
- Added SeccompProfileRule to validate seccomp profiles for containers, ensuring proper security configurations.
- Updated linters settings to include new exclusion rules for NoNewPrivileges and SeccompProfile.
