### PR TITLE
feat: add accessibility validation for module.yaml files

### DIFF
--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -4,6 +4,53 @@
 - Check that openapi conversions have human-readable description
 - Check oss info in the `oss.yaml` file.
 - Check license header in files.
+- Validates `accessibility` section in `module.yaml` files.
+
+### Accessibility Validation
+
+The linter validates the optional `accessibility` section in `module.yaml` files:
+
+#### Valid Editions
+
+- `ce` - Community Edition
+- `fe` - Free Edition  
+- `ee` - Enterprise Edition
+- `se` - Standard Edition
+- `se-plus` - Standard Edition Plus
+- `be` - Business Edition
+- `_default` - Default behavior override
+
+#### Valid Bundles
+
+- `Minimal` - Minimal bundle
+- `Managed` - Managed bundle
+- `Default` - Default bundle
+
+#### Validation Rules
+
+- `accessibility.editions` is required when `accessibility` is specified
+- Each edition must have valid `available` (boolean) and `enabledInBundle` (array) fields
+- `enabledInBundle` must contain only valid bundle names
+- Edition names must be from the valid editions list
+
+#### Example
+
+```yaml
+accessibility:
+  editions:
+    _default:
+      available: true
+      enabledInBundle:
+        - Minimal
+        - Managed
+        - Default
+    ee:
+      available: true
+      enabledInBundle:
+        - Minimal
+        - Managed
+        - Default
+```
 
 ## Settings example
 


### PR DESCRIPTION
We need to add a description check for accessibility section module.yaml file:

```yaml
accessibility:
  editions:
    _default:
      available: true
      enabledInBundle:
        - Minimal
        - Managed
        - Default
    ee:
      available: true
      enabledInBundle:
        - Minimal
        - Managed
        - Default
```

`editions` must be one of: ce, fe, ee, se, se-plus, be, _default

`enabledInBundle` must be on of: Minimal, Managed, Default

Example:

```plain
🐒 [definition-file (#module)]
     Message:      Invalid edition name "ee1". Must be one of: ce, fe, ee, se, se-plus, be, _default
     Module:       kube-dns
     FilePath:     module.yaml

🐒 [definition-file (#module)]
     Message:      Invalid bundle "Default1" for edition "_default". Must be one of: Minimal, Managed, Default
     Module:       kube-dns
     FilePath:     module.yaml
```