### PR TITLE
feat: update WERF_ENV retrieval in GetWerfConfig function

### DIFF
--- a/internal/werf/werf.go
+++ b/internal/werf/werf.go
@@ -18,6 +18,7 @@ package werf
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -68,7 +69,7 @@ func GetWerfConfig(dir string) (string, error) {
 
 	templateData := make(map[string]any)
 	templateData["Files"] = NewFiles(werfFile, dir)
-	templateData["Env"] = "EE"
+	templateData["Env"] = cmp.Or(os.Getenv("WERF_ENV"), "EE")
 
 	templateData["Commit"] = map[string]any{
 		"Hash": "hash",


### PR DESCRIPTION
Previously, we used the EE edition by default to generate werf.

In order to properly test the CSE edition, we need to have the ability to change the edition when running the check.

In this change, we check the value of the environment variable WERF_ENV, and if it is not empty, we use its value. Otherwise, we set the EE edition by default.