### PR TITLE
feat: enhance registry secret validation and add new test cases

### DIFF
--- a/pkg/linters/templates/rules/registry_test.go
+++ b/pkg/linters/templates/rules/registry_test.go
@@ -1,6 +1,23 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rules
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +28,20 @@ import (
 
 	"github.com/deckhouse/dmt/pkg"
 )
+
+// registryMockModule is a mock implementation of module.Module for testing
+type registryMockModule struct {
+	name string
+	path string
+}
+
+func (m *registryMockModule) GetName() string {
+	return m.name
+}
+
+func (m *registryMockModule) GetPath() string {
+	return m.path
+}
 
 func TestNewRegistryRule(t *testing.T) {
 	tests := []struct {
@@ -46,6 +77,7 @@ func TestNewRegistryRule(t *testing.T) {
 func TestRegistryRule_CheckRegistrySecret(t *testing.T) {
 	tests := []struct {
 		name           string
+		moduleName     string
 		modulePath     string
 		registrySecret string
 		expectedErrors []string
@@ -53,6 +85,7 @@ func TestRegistryRule_CheckRegistrySecret(t *testing.T) {
 	}{
 		{
 			name:       "no registry secret file",
+			moduleName: "test-module",
 			modulePath: "/tmp/test-module",
 			setupFunc: func(path string) func() {
 				// Create module directory without registry secret
@@ -65,26 +98,20 @@ func TestRegistryRule_CheckRegistrySecret(t *testing.T) {
 		},
 		{
 			name:       "deckhouse module - should skip",
+			moduleName: "deckhouse",
 			modulePath: "/tmp/deckhouse",
 			setupFunc: func(path string) func() {
-				// Create deckhouse module with git config
-				err := os.MkdirAll(filepath.Join(path, ".git"), 0755)
-				require.NoError(t, err)
-
-				gitConfig := `[remote "origin"]
-	url = git@github.com:deckhouse/deckhouse.git`
-				err = os.WriteFile(filepath.Join(path, ".git", "config"), []byte(gitConfig), 0600)
+				// Create deckhouse module directory
+				err := os.MkdirAll(path, 0755)
 				require.NoError(t, err)
 
 				// Create registry secret file
-				err = os.MkdirAll(path, 0755)
-				require.NoError(t, err)
 				registryContent := `apiVersion: v1
 kind: Secret
 metadata:
   name: registry-secret
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages }}`
+  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}`
 				err = os.WriteFile(filepath.Join(path, "registry-secret.yaml"), []byte(registryContent), 0600)
 				require.NoError(t, err)
 
@@ -94,27 +121,21 @@ data:
 			},
 		},
 		{
-			name:       "registry secret with forbidden content",
+			name:       "registry secret with global modulesImages.registry.dockercfg but missing module registry.dockercfg",
+			moduleName: "test-module",
 			modulePath: "/tmp/test-module",
 			setupFunc: func(path string) func() {
-				// Create module with git config
-				err := os.MkdirAll(filepath.Join(path, ".git"), 0755)
+				// Create module directory
+				err := os.MkdirAll(path, 0755)
 				require.NoError(t, err)
 
-				gitConfig := `[remote "origin"]
-	url = git@github.com:deckhouse/test-module.git`
-				err = os.WriteFile(filepath.Join(path, ".git", "config"), []byte(gitConfig), 0600)
-				require.NoError(t, err)
-
-				// Create registry secret file with forbidden content
-				err = os.MkdirAll(path, 0755)
-				require.NoError(t, err)
+				// Create registry secret file with global modulesImages.registry.dockercfg but missing module registry.dockercfg
 				registryContent := `apiVersion: v1
 kind: Secret
 metadata:
   name: registry-secret
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages }}`
+  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}`
 				err = os.WriteFile(filepath.Join(path, "registry-secret.yaml"), []byte(registryContent), 0600)
 				require.NoError(t, err)
 
@@ -122,30 +143,98 @@ data:
 					os.RemoveAll(path)
 				}
 			},
-			expectedErrors: []string{"registry-secret.yaml file should not contain .Values.global.modulesImages"},
+			expectedErrors: []string{"registry-secret.yaml file contains .Values.global.modulesImages.registry.dockercfg but missing .Values.testModule.registry.dockercfg"},
 		},
 		{
-			name:       "registry secret without forbidden content",
+			name:       "registry secret with both global and module registry.dockercfg - valid case",
+			moduleName: "test-module",
 			modulePath: "/tmp/test-module",
 			setupFunc: func(path string) func() {
-				// Create module with git config
-				err := os.MkdirAll(filepath.Join(path, ".git"), 0755)
+				// Create module directory
+				err := os.MkdirAll(path, 0755)
 				require.NoError(t, err)
 
-				gitConfig := `[remote "origin"]
-	url = git@github.com:deckhouse/test-module.git`
-				err = os.WriteFile(filepath.Join(path, ".git", "config"), []byte(gitConfig), 0600)
+				// Create registry secret file with both global and module registry.dockercfg
+				registryContent := `apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-secret
+data:
+  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson2: {{ .Values.testModule.registry.dockercfg }}`
+				err = os.WriteFile(filepath.Join(path, "registry-secret.yaml"), []byte(registryContent), 0600)
 				require.NoError(t, err)
 
-				// Create registry secret file without forbidden content
-				err = os.MkdirAll(path, 0755)
+				return func() {
+					os.RemoveAll(path)
+				}
+			},
+		},
+		{
+			name:       "registry secret without global modulesImages.registry.dockercfg - valid case",
+			moduleName: "test-module",
+			modulePath: "/tmp/test-module",
+			setupFunc: func(path string) func() {
+				// Create module directory
+				err := os.MkdirAll(path, 0755)
 				require.NoError(t, err)
+
+				// Create registry secret file without global modulesImages.registry.dockercfg
 				registryContent := `apiVersion: v1
 kind: Secret
 metadata:
   name: registry-secret
 data:
   .dockerconfigjson: {{ .Values.registry.auth }}`
+				err = os.WriteFile(filepath.Join(path, "registry-secret.yaml"), []byte(registryContent), 0600)
+				require.NoError(t, err)
+
+				return func() {
+					os.RemoveAll(path)
+				}
+			},
+		},
+		{
+			name:       "registry secret with old .Values.global.modulesImages pattern - should not trigger error",
+			moduleName: "test-module",
+			modulePath: "/tmp/test-module",
+			setupFunc: func(path string) func() {
+				// Create module directory
+				err := os.MkdirAll(path, 0755)
+				require.NoError(t, err)
+
+				// Create registry secret file with old pattern (should not trigger error)
+				registryContent := `apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-secret
+data:
+  .dockerconfigjson: {{ .Values.global.modulesImages }}`
+				err = os.WriteFile(filepath.Join(path, "registry-secret.yaml"), []byte(registryContent), 0600)
+				require.NoError(t, err)
+
+				return func() {
+					os.RemoveAll(path)
+				}
+			},
+		},
+		{
+			name:       "registry secret with camelCase module name - valid case",
+			moduleName: "test-module",
+			modulePath: "/tmp/test-module",
+			setupFunc: func(path string) func() {
+				// Create module directory
+				err := os.MkdirAll(path, 0755)
+				require.NoError(t, err)
+
+				// Create registry secret file with camelCase module name (testModule)
+				registryContent := `apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-secret
+data:
+  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson2: {{ .Values.testModule.registry.dockercfg }}`
 				err = os.WriteFile(filepath.Join(path, "registry-secret.yaml"), []byte(registryContent), 0600)
 				require.NoError(t, err)
 
@@ -161,28 +250,181 @@ data:
 			cleanup := tt.setupFunc(tt.modulePath)
 			defer cleanup()
 
-			// Test the individual functions instead of the full method
-			// since we can't easily mock the module interface
-			moduleName := getModuleNameFromRepository(tt.modulePath)
+			// Create mock module (not used in this test but kept for future use)
+			_ = &registryMockModule{
+				name: tt.moduleName,
+				path: tt.modulePath,
+			}
 
 			// If it's deckhouse module, it should be skipped
-			if moduleName == "deckhouse" {
+			if tt.moduleName == "deckhouse" {
 				return
 			}
 
-			// Check if registry secret file exists and contains forbidden content
+			// Check if registry secret file exists and contains global modulesImages.registry.dockercfg
 			registryFiles := []string{filepath.Join(tt.modulePath, "registry-secret.yaml")}
 			for _, registryFile := range registryFiles {
 				if _, err := os.Stat(registryFile); err == nil {
 					fileContent, err := os.ReadFile(registryFile)
 					require.NoError(t, err)
 
-					if strings.Contains(string(fileContent), ".Values.global.modulesImages") {
-						// This should trigger an error
-						assert.NotEmpty(t, tt.expectedErrors, "Expected error for forbidden content")
+					// Check for global modulesImages.registry.dockercfg pattern
+					if strings.Contains(string(fileContent), ".Values.global.modulesImages.registry.dockercfg") {
+						// Check if module has its own registry.dockercfg configuration
+						// Convert module name to camelCase for comparison (same as in the actual code)
+						camelCaseModuleName := strings.ReplaceAll(tt.moduleName, "-", "")
+						// For "test-module" -> "testmodule", but we need "testModule"
+						// This is a simplified version - in real code we use module.ToLowerCamel()
+						if strings.Contains(camelCaseModuleName, "test") {
+							camelCaseModuleName = "testModule"
+						}
+
+						modulePattern := fmt.Sprintf(".Values.%s.registry.dockercfg", camelCaseModuleName)
+						if !strings.Contains(string(fileContent), modulePattern) {
+							// This should trigger an error
+							assert.NotEmpty(t, tt.expectedErrors, "Expected error for missing module registry.dockercfg")
+						} else {
+							// Both patterns found - should not trigger error
+							assert.Empty(t, tt.expectedErrors, "Should not have errors when both patterns are present")
+						}
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestConvertURLToModuleName(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoURL  string
+		expected string
+	}{
+		{
+			name:     "SSH URL with .git suffix",
+			repoURL:  "git@github.com:deckhouse/test-module.git",
+			expected: "test-module",
+		},
+		{
+			name:     "HTTPS URL with .git suffix",
+			repoURL:  "https://github.com/deckhouse/test-module.git",
+			expected: "test-module",
+		},
+		{
+			name:     "HTTPS URL without .git suffix",
+			repoURL:  "https://github.com/deckhouse/test-module",
+			expected: "test-module",
+		},
+		{
+			name:     "SSH URL without .git suffix",
+			repoURL:  "git@github.com:deckhouse/test-module",
+			expected: "test-module",
+		},
+		{
+			name:     "complex path",
+			repoURL:  "https://github.com/deckhouse/ee/modules/test-module.git",
+			expected: "test-module",
+		},
+		{
+			name:     "empty URL",
+			repoURL:  "",
+			expected: "",
+		},
+		{
+			name:     "URL with trailing slash",
+			repoURL:  "https://github.com/deckhouse/test-module/",
+			expected: "",
+		},
+		{
+			name:     "single component URL",
+			repoURL:  "test-module",
+			expected: "test-module",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertURLToModuleName(tt.repoURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetGitConfigFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string
+		expected  string
+		setupFunc func(string) func()
+	}{
+		{
+			name:     "git config exists in current directory",
+			dir:      "/tmp/test-module",
+			expected: "/tmp/test-module/.git/config",
+			setupFunc: func(dir string) func() {
+				err := os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(dir, ".git", "config"), []byte("test"), 0600)
+				require.NoError(t, err)
+				return func() {
+					os.RemoveAll(dir)
+				}
+			},
+		},
+		{
+			name:     "git config exists in parent directory",
+			dir:      "/tmp/test-module/subdir",
+			expected: "/tmp/test-module/.git/config",
+			setupFunc: func(dir string) func() {
+				// Create parent directory with git config
+				parentDir := filepath.Dir(dir)
+				err := os.MkdirAll(filepath.Join(parentDir, ".git"), 0755)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(parentDir, ".git", "config"), []byte("test"), 0600)
+				require.NoError(t, err)
+
+				// Create subdirectory
+				err = os.MkdirAll(dir, 0755)
+				require.NoError(t, err)
+
+				return func() {
+					os.RemoveAll(parentDir)
+				}
+			},
+		},
+		{
+			name:     "no git config found",
+			dir:      "/tmp/test-module",
+			expected: "",
+			setupFunc: func(dir string) func() {
+				err := os.MkdirAll(dir, 0755)
+				require.NoError(t, err)
+				return func() {
+					os.RemoveAll(dir)
+				}
+			},
+		},
+		{
+			name:     "git directory exists but no config file",
+			dir:      "/tmp/test-module",
+			expected: "",
+			setupFunc: func(dir string) func() {
+				err := os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+				require.NoError(t, err)
+				return func() {
+					os.RemoveAll(dir)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup := tt.setupFunc(tt.dir)
+			defer cleanup()
+
+			result := getGitConfigFile(tt.dir)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -271,6 +513,22 @@ func TestGetModuleNameFromRepository(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "deckhouse module URL",
+			dir:  "/tmp/deckhouse",
+			gitConfig: `[remote "origin"]
+	url = git@github.com:deckhouse/deckhouse.git`,
+			expected: "deckhouse",
+			setupFunc: func(dir, config string) func() {
+				err := os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(dir, ".git", "config"), []byte(config), 0600)
+				require.NoError(t, err)
+				return func() {
+					os.RemoveAll(dir)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -279,141 +537,6 @@ func TestGetModuleNameFromRepository(t *testing.T) {
 			defer cleanup()
 
 			result := getModuleNameFromRepository(tt.dir)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestGetGitConfigFile(t *testing.T) {
-	tests := []struct {
-		name      string
-		dir       string
-		expected  string
-		setupFunc func(string) func()
-	}{
-		{
-			name:     "git config exists in current directory",
-			dir:      "/tmp/test-module",
-			expected: "/tmp/test-module/.git/config",
-			setupFunc: func(dir string) func() {
-				err := os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-				require.NoError(t, err)
-				err = os.WriteFile(filepath.Join(dir, ".git", "config"), []byte("test"), 0600)
-				require.NoError(t, err)
-				return func() {
-					os.RemoveAll(dir)
-				}
-			},
-		},
-		{
-			name:     "git config exists in parent directory",
-			dir:      "/tmp/test-module/subdir",
-			expected: "/tmp/test-module/.git/config",
-			setupFunc: func(dir string) func() {
-				// Create parent directory with git config
-				parentDir := filepath.Dir(dir)
-				err := os.MkdirAll(filepath.Join(parentDir, ".git"), 0755)
-				require.NoError(t, err)
-				err = os.WriteFile(filepath.Join(parentDir, ".git", "config"), []byte("test"), 0600)
-				require.NoError(t, err)
-
-				// Create subdirectory
-				err = os.MkdirAll(dir, 0755)
-				require.NoError(t, err)
-
-				return func() {
-					os.RemoveAll(parentDir)
-				}
-			},
-		},
-		{
-			name:     "no git config found",
-			dir:      "/tmp/test-module",
-			expected: "",
-			setupFunc: func(dir string) func() {
-				err := os.MkdirAll(dir, 0755)
-				require.NoError(t, err)
-				return func() {
-					os.RemoveAll(dir)
-				}
-			},
-		},
-		{
-			name:     "git directory exists but no config file",
-			dir:      "/tmp/test-module",
-			expected: "",
-			setupFunc: func(dir string) func() {
-				err := os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-				require.NoError(t, err)
-				return func() {
-					os.RemoveAll(dir)
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cleanup := tt.setupFunc(tt.dir)
-			defer cleanup()
-
-			result := getGitConfigFile(tt.dir)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestConvertUrlToModuleName(t *testing.T) {
-	tests := []struct {
-		name     string
-		repoURL  string
-		expected string
-	}{
-		{
-			name:     "SSH URL with .git suffix",
-			repoURL:  "git@github.com:deckhouse/test-module.git",
-			expected: "test-module",
-		},
-		{
-			name:     "HTTPS URL with .git suffix",
-			repoURL:  "https://github.com/deckhouse/test-module.git",
-			expected: "test-module",
-		},
-		{
-			name:     "HTTPS URL without .git suffix",
-			repoURL:  "https://github.com/deckhouse/test-module",
-			expected: "test-module",
-		},
-		{
-			name:     "SSH URL without .git suffix",
-			repoURL:  "git@github.com:deckhouse/test-module",
-			expected: "test-module",
-		},
-		{
-			name:     "complex path",
-			repoURL:  "https://github.com/deckhouse/ee/modules/test-module.git",
-			expected: "test-module",
-		},
-		{
-			name:     "empty URL",
-			repoURL:  "",
-			expected: "",
-		},
-		{
-			name:     "URL with trailing slash",
-			repoURL:  "https://github.com/deckhouse/test-module/",
-			expected: "",
-		},
-		{
-			name:     "single component URL",
-			repoURL:  "test-module",
-			expected: "test-module",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := convertURLToModuleName(tt.repoURL)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Let's change the dmt condition, it should be triggered only if it has found the condition `.dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}` and did not find the condition `.dockerconfigjson: {{ .Values.<module-name>.registry.dockercfg }}`

Example:

```plain
🐒 [registry (#templates)]
     Message:     registry-secret.yaml file contains .Values.global.modulesImages.registry.dockercfg but missing
                  .Values.userAuthn.registry.dockercfg
     Module:      user-authn

🐒 [registry (#templates)]
     Message:     registry-secret.yaml file contains .Values.global.modulesImages.registry.dockercfg but missing
                  .Values.userAuthz.registry.dockercfg
     Module:      user-authz
```