### PR TITLE
[dmt] remove volume mounts check

### DIFF
--- a/pkg/linters/container/rules/container_check_read_only_root_filesystem.go
+++ b/pkg/linters/container/rules/container_check_read_only_root_filesystem.go
@@ -61,10 +61,6 @@ func (r *CheckReadOnlyRootFilesystemRule) ObjectReadOnlyRootFilesystem(object st
 			continue
 		}
 
-		if c.VolumeMounts == nil {
-			continue
-		}
-
 		if c.SecurityContext == nil {
 			errorList.WithObjectID(object.Identity()).
 				Error("Container's SecurityContext is missing")


### PR DESCRIPTION
We need to remove volume mounts check before readonlyfs

## Purpose of ReadOnlyRootFilesystem Check

### **Without VolumeMounts:**

When a container has `ReadOnlyRootFilesystem: true` but **no volume mounts**, it provides:

1. **Maximum Security Hardening**
   - Prevents any runtime modifications to the container's filesystem
   - Blocks malicious code from writing persistent files
   - Eliminates container escape vectors through filesystem manipulation

2. **Immutable Infrastructure**
   - Ensures the container runs exactly as built in the image
   - Prevents configuration drift during runtime
   - Supports the principle of immutable deployments

3. **Attack Surface Reduction**
   - Prevents malware from persisting files to disk
   - Blocks privilege escalation attempts via filesystem modifications
   - Reduces impact of compromised containers

### **With VolumeMounts:**

When a container has `ReadOnlyRootFilesystem: true` **with volume mounts**, it enables:

1. **Selective Write Access**
   - Root filesystem remains read-only for security
   - Only specific mounted volumes allow writes (e.g., tmp, log)
   - Controlled data persistence where needed

2. **Best Practice Security Model**
   ```yaml
   securityContext:
     readOnlyRootFilesystem: true
   volumeMounts:
   - name: tmp-volume
     mountPath: /tmp
   - name: cache-volume  
     mountPath: /app/cache
   ```

3. **Compliance Requirements**
   - Meets security standards (CIS Kubernetes Benchmark)
   - Satisfies enterprise security policies
   - Required for many regulated environments