### PR TITLE
[dmt] Add update field validations

### DIFF
--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -5,6 +5,7 @@
 - Check oss info in the `oss.yaml` file.
 - Check license header in files.
 - Validates `accessibility` section in `module.yaml` files.
+- Validates `update` section in `module.yaml` files.
 
 ### Accessibility Validation
 
@@ -50,6 +51,31 @@ accessibility:
         - Minimal
         - Managed
         - Default
+```
+
+### Update Validation
+
+The linter validates the optional `update` section in `module.yaml` files:
+
+#### Validation Rules
+
+- Each version entry must have both `from` and `to` fields populated
+- The `to` version must be greater than the `from` version 
+- Versions must be in `major.minor` format (patch versions are not allowed)
+- Version entries must be sorted by `from` version ascending, then by `to` version ascending
+- For the same `to` version, there must not be duplicate `from` versions
+
+#### Example
+
+```yaml
+update:
+  versions:
+    - from: "1.16"
+      to: "1.20"
+    - from: "1.16"
+      to: "1.25"
+    - from: "1.17"
+      to: "1.20"
 ```
 
 ## Settings example

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -255,7 +255,7 @@ func (u *ModuleUpdate) validateUpdate(errorList *errors.LintRuleErrorsList) {
 		return
 	}
 
-	versionPattern := regexp.MustCompile(`^[0-9]+\.[0-9]+$`)
+	versionPattern := regexp.MustCompile(`^\d+\.\d+$`)
 
 	for i, version := range u.Versions {
 		if version.From == "" {

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -20,7 +20,9 @@ import (
 	errs "errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	"k8s.io/utils/ptr"
@@ -86,6 +88,7 @@ type DeckhouseModule struct {
 	Descriptions  ModuleDescriptions   `json:"descriptions,omitempty"`
 	Requirements  *ModuleRequirements  `json:"requirements,omitempty"`
 	Accessibility *ModuleAccessibility `json:"accessibility,omitempty"`
+	Update        *ModuleUpdate        `json:"update,omitempty"`
 }
 
 type ModuleDescriptions struct {
@@ -111,6 +114,15 @@ type ModuleAccessibility struct {
 type ModuleEdition struct {
 	Available        bool     `json:"available"`
 	EnabledInBundles []string `json:"enabledInBundles"`
+}
+
+type ModuleUpdate struct {
+	Versions []ModuleUpdateVersion `json:"versions,omitempty"`
+}
+
+type ModuleUpdateVersion struct {
+	From string `json:"from"`
+	To   string `json:"to"`
 }
 
 func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *errors.LintRuleErrorsList) {
@@ -179,6 +191,10 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 		yml.Accessibility.validateAccessibility(errorList)
 	}
 
+	if yml.Update != nil {
+		yml.Update.validateUpdate(errorList)
+	}
+
 	// ru description is not required
 	if yml.Descriptions.English == "" {
 		errorList.Warn("Module `descriptions.en` field is required")
@@ -230,6 +246,111 @@ func (a *ModuleAccessibility) validateAccessibility(errorList *errors.LintRuleEr
 					errorList.Errorf("Invalid bundle %q for edition %q. Must be one of: %s", bundle, editionName, strings.Join(ValidBundles, ", "))
 				}
 			}
+		}
+	}
+}
+
+func (u *ModuleUpdate) validateUpdate(errorList *errors.LintRuleErrorsList) {
+	if len(u.Versions) == 0 {
+		return
+	}
+
+	versionPattern := regexp.MustCompile(`^[0-9]+\.[0-9]+$`)
+
+	for i, version := range u.Versions {
+		if version.From == "" {
+			errorList.Errorf("Version entry at index %d: field 'from' is required", i)
+			continue
+		}
+
+		if version.To == "" {
+			errorList.Errorf("Version entry at index %d: field 'to' is required", i)
+			continue
+		}
+
+		if !versionPattern.MatchString(version.From) {
+			errorList.Errorf("Version entry at index %d: 'from' version '%s' must be in major.minor format (patch versions not allowed)", i, version.From)
+			continue
+		}
+
+		if !versionPattern.MatchString(version.To) {
+			errorList.Errorf("Version entry at index %d: 'to' version '%s' must be in major.minor format (patch versions not allowed)", i, version.To)
+			continue
+		}
+
+		fromVer, err := semver.NewVersion(version.From)
+		if err != nil {
+			errorList.Errorf("Version entry at index %d: invalid 'from' version '%s': %s", i, version.From, err)
+			continue
+		}
+
+		toVer, err := semver.NewVersion(version.To)
+		if err != nil {
+			errorList.Errorf("Version entry at index %d: invalid 'to' version '%s': %s", i, version.To, err)
+			continue
+		}
+
+		if !toVer.GreaterThan(fromVer) {
+			errorList.Errorf("Version entry at index %d: 'to' version '%s' must be greater than 'from' version '%s'", i, version.To, version.From)
+		}
+	}
+
+	u.validateUpdateSorting(errorList)
+	u.validateUpdateDuplicates(errorList)
+}
+
+func (u *ModuleUpdate) validateUpdateSorting(errorList *errors.LintRuleErrorsList) {
+	if len(u.Versions) <= 1 {
+		return
+	}
+
+	sortedVersions := make([]ModuleUpdateVersion, len(u.Versions))
+	copy(sortedVersions, u.Versions)
+
+	sort.Slice(sortedVersions, func(i, j int) bool {
+		fromI, errI := semver.NewVersion(sortedVersions[i].From)
+		fromJ, errJ := semver.NewVersion(sortedVersions[j].From)
+
+		if errI != nil || errJ != nil {
+			return sortedVersions[i].From < sortedVersions[j].From
+		}
+
+		if fromI.Equal(fromJ) {
+			toI, errI := semver.NewVersion(sortedVersions[i].To)
+			toJ, errJ := semver.NewVersion(sortedVersions[j].To)
+
+			if errI != nil || errJ != nil {
+				return sortedVersions[i].To < sortedVersions[j].To
+			}
+
+			return toI.LessThan(toJ)
+		}
+
+		return fromI.LessThan(fromJ)
+	})
+
+	for i, original := range u.Versions {
+		if original.From != sortedVersions[i].From || original.To != sortedVersions[i].To {
+			errorList.Error("Update versions must be sorted by 'from' version ascending, then by 'to' version ascending")
+			break
+		}
+	}
+}
+
+func (u *ModuleUpdate) validateUpdateDuplicates(errorList *errors.LintRuleErrorsList) {
+	toMap := make(map[string][]string)
+
+	for _, version := range u.Versions {
+		if version.From == "" || version.To == "" {
+			continue
+		}
+		toMap[version.To] = append(toMap[version.To], version.From)
+	}
+
+	for to, froms := range toMap {
+		if len(froms) > 1 {
+			sort.Strings(froms)
+			errorList.Errorf("Duplicate 'to' version '%s' with different 'from' versions: %s. Use the earliest 'from' version instead", to, strings.Join(froms, ", "))
 		}
 	}
 }


### PR DESCRIPTION
### Description

With the introduction of [Deckhouse PR #14978](https://github.com/deckhouse/deckhouse/pull/14978), modules can now define version jump paths to enable controlled upgrades between releases.

This PR implements comprehensive validation for the new `update` section in Deckhouse module definitions (`module.yaml`). The `update` section allows modules to define version jump paths for controlled upgrades between releases.

### Changes Made

1. **Added data structures** for `update` section:
   - `ModuleUpdate` struct with `Versions` array
   - `ModuleUpdateVersion` struct with `From` and `To` fields

2. **Implemented validation logic** (`validateUpdate` function):
   - Required fields validation (`from` and `to` must be present)
   - Version format validation (only `major.minor`, patch versions forbidden)
   - Version comparison (`to` must be greater than `from`)
   - Sorting validation (ascending by `from`, then by `to`)
   - Duplicate prevention (no multiple `from` versions for same `to`)

3. **Added comprehensive test coverage**

4. **Updated documentation**:
   - Added `update` validation description to module linter README
   - Included usage examples and validation rules

### Example Usage

```yaml
# ✅ Valid configuration
update:
  versions:
    - from: "1.16"
      to: "1.20"
    - from: "1.16" 
      to: "1.25"
    - from: "1.18"
      to: "2.0"

# ❌ Invalid - would be caught by validation
update:
  versions:
    - from: "1.20"      # Error: from > to
      to: "1.16"
    - from: "1.16.5"    # Error: patch version not allowed
      to: "2.0.1"       # Error: patch version not allowed
```

This feature ensures that Deckhouse modules can safely leverage the new upgrade path functionality while maintaining high standards of configuration validity and reliability.