### PR TITLE
[dmt] Add feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 # Ignore Go coverage output
 coverage.out
 coverage.svg
+# Ignore manual test modules
+/test-modules/**

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -67,18 +67,23 @@ func runLint(dir string) error {
 	color.NoColor = false
 	logger.InfoF("DMT version: %s", version)
 
-	cfg, err := config.NewDefaultRootConfig(dir)
+	dtoLoader := config.NewDTOLoader(dir)
+	userDTO, err := dtoLoader.LoadUserConfig()
 	logger.CheckErr(err)
+
+	globalDTO, err := dtoLoader.LoadGlobalConfig()
+	logger.CheckErr(err)
+
+	cfg := config.NewRootConfig(userDTO, globalDTO)
 
 	// init metrics storage, should be done before running manager
 	metrics.GetClient(dir)
 
-	mng := manager.NewManager(dir, cfg)
+	mng := manager.NewManager(dir, cfg.ToLintersSettings())
 	mng.Run()
 	mng.PrintResult()
 
 	metrics.SetDmtInfo()
-	metrics.SetLinterWarningsMetrics(cfg.GlobalSettings)
 	metrics.SetDmtRuntimeDuration()
 	metrics.SetDmtRuntimeDurationSeconds()
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -241,7 +241,7 @@ func (m *Manager) PrintResult() {
 		default:
 			emojiStr = ":monkey:"
 		}
-		fmt.Fprint(w, emoji.Sprintf(emojiStr))
+		fmt.Fprint(w, emoji.Sprint(emojiStr))
 		fmt.Fprint(w, color.New(color.FgHiBlue).SprintFunc()("["))
 
 		if err.RuleID != "" {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -163,13 +163,6 @@ func (m *Manager) Run() {
 				return
 			}
 
-			// Create rule impact function
-			ruleImpactFunc := func(linterID, ruleID string) *pkg.Level {
-				return moduleConfig.LintersSettings.GetRuleImpact(linterID, ruleID)
-			}
-
-			errorListWithRuleImpact := m.errors.WithRuleImpactFunc(ruleImpactFunc)
-
 			for _, linter := range getLintersForModule(m.cfg, errorListWithRuleImpact) {
 				if flags.LinterName != "" && linter.Name() != flags.LinterName {
 					continue

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -72,10 +72,11 @@ type Manager struct {
 }
 
 func NewManager(dir string, rootConfig *config.RootConfig) *Manager {
+	managerLevel := pkg.Error
 	m := &Manager{
 		cfg: rootConfig,
 
-		errors: errors.NewLintRuleErrorsList(),
+		errors: errors.NewLintRuleErrorsList().WithMaxLevel(&managerLevel),
 	}
 
 	return m.initManager(dir)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -155,9 +155,19 @@ func (m *Manager) Run() {
 
 			logger.InfoF("Run linters for `%s` module", module.GetName())
 
+			moduleConfig := module.GetModuleConfig()
+			if moduleConfig == nil {
+				logger.ErrorF("Module config is nil for module `%s`", module.GetName())
+				return
+			}
+			if moduleConfig.LintersSettings == nil {
+				logger.ErrorF("LintersSettings is nil for module `%s`", module.GetName())
+				return
+			}
+
 			// Create rule impact function
 			ruleImpactFunc := func(linterID, ruleID string) *pkg.Level {
-				return module.GetModuleConfig().LintersSettings.GetRuleImpact(linterID, ruleID)
+				return moduleConfig.LintersSettings.GetRuleImpact(linterID, ruleID)
 			}
 
 			errorListWithRuleImpact := m.errors.WithRuleImpactFunc(ruleImpactFunc)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -107,7 +107,7 @@ func (m *Manager) initManager(dir string) *Manager {
 			// linting errors are already logged
 			continue
 		}
-		mdl, err := modulePkg.NewModule(paths[i], &vals, globalValues, errorList)
+		mdl, err := modulePkg.NewModule(paths[i], &vals, globalValues, errorList, &m.cfg.GlobalSettings.Linters)
 		if err != nil {
 			errorList.
 				WithFilePath(paths[i]).WithModule(moduleName).
@@ -115,8 +115,6 @@ func (m *Manager) initManager(dir string) *Manager {
 				Errorf("cannot create module `%s`", moduleName)
 			continue
 		}
-
-		mdl.MergeRootConfig(m.cfg)
 
 		m.Modules = append(m.Modules, mdl)
 	}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -134,7 +134,7 @@ func (m *Module) GetModuleConfig() *config.ModuleConfig {
 	return m.linterConfig
 }
 
-func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, errorList *dmtErrors.LintRuleErrorsList, globalConfig *global.Linters) (*Module, error) {
+func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, errorList *dmtErrors.LintRuleErrorsList, _ *global.Linters) (*Module, error) {
 	module, err := newModuleFromPath(path)
 	if err != nil {
 		return nil, err
@@ -169,10 +169,19 @@ func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, e
 		return nil, fmt.Errorf("can not parse module config: %w", err)
 	}
 
-	if globalConfig == nil {
-		globalConfig = &global.Linters{}
+	globalDTO := &config.GlobalRootConfigDTO{
+		Global: config.GlobalLintersDTO{
+			Container:  config.GlobalLinterSettingsDTO{},
+			Hooks:      config.GlobalLinterSettingsDTO{},
+			Images:     config.GlobalLinterSettingsDTO{},
+			Module:     config.GlobalLinterSettingsDTO{},
+			NoCyrillic: config.GlobalLinterSettingsDTO{},
+			OpenAPI:    config.GlobalLinterSettingsDTO{},
+			Rbac:       config.GlobalLinterSettingsDTO{},
+			Templates:  config.GlobalLinterSettingsDTO{},
+		},
 	}
-	domainConfig := dtoConfig.ToDomain(globalConfig)
+	domainConfig := config.NewRootConfig(dtoConfig, globalDTO)
 
 	module.linterConfig = &config.ModuleConfig{
 		DomainConfig:    domainConfig,

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -135,7 +135,7 @@ func (m *Module) GetModuleConfig() *config.ModuleConfig {
 }
 
 func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, errorList *dmtErrors.LintRuleErrorsList, globalConfig *global.Linters) (*Module, error) {
-	module, err := newModuleFromPath(path, globalConfig)
+	module, err := newModuleFromPath(path)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func remapTemplates(ch *chart.Chart) {
 	}
 }
 
-func newModuleFromPath(path string, globalConfig *global.Linters) (*Module, error) {
+func newModuleFromPath(path string) (*Module, error) {
 	moduleYamlConfig, err := ParseModuleConfigFile(path)
 	if err != nil {
 		return nil, err

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,0 +1,46 @@
+package pkg
+
+type LinterConfig struct {
+	Impact *Level
+}
+
+type RuleConfig struct {
+	Impact *Level
+}
+
+func (rc *RuleConfig) GetLevel() *Level {
+	return rc.Impact
+}
+
+type LintersSettings struct {
+	Container ContainerLinterConfig
+}
+
+type ContainerLinterConfig struct {
+	LinterConfig
+	Rules        ContainerLinterRules
+	ExcludeRules ContainerExcludeRules
+}
+
+type ContainerLinterRules struct {
+	RecommendedLabelsRule RuleConfig
+}
+
+type ContainerExcludeRules struct {
+	ControllerSecurityContext KindRuleExcludeList
+	DNSPolicy                 KindRuleExcludeList
+
+	HostNetworkPorts       ContainerRuleExcludeList
+	Ports                  ContainerRuleExcludeList
+	ReadOnlyRootFilesystem ContainerRuleExcludeList
+	ImageDigest            ContainerRuleExcludeList
+	Resources              ContainerRuleExcludeList
+	SecurityContext        ContainerRuleExcludeList
+	Liveness               ContainerRuleExcludeList
+	Readiness              ContainerRuleExcludeList
+
+	Description StringRuleExcludeList
+}
+
+// ContainerRuleExcludeList represents a list of container exclusions
+type ContainerRuleExcludeList []ContainerRuleExclude

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -5,25 +5,37 @@ type LinterConfig struct {
 }
 
 type RuleConfig struct {
-	Impact *Level
+	impact *Level
 }
 
 func (rc *RuleConfig) GetLevel() *Level {
-	return rc.Impact
+	return rc.impact
 }
 
 type LintersSettings struct {
 	Container ContainerLinterConfig
+	Image     ImageLinterConfig
+}
+
+type ImageLinterConfig struct {
+	LinterConfig
+	Rules        ImageLinterRules
+	ExcludeRules ImageExcludeRules
+}
+
+type ImageLinterRules struct {
+	DistrolessRule RuleConfig
+	ImageRule      RuleConfig
+	PatchesRule    RuleConfig
+	WerfRule       RuleConfig
+}
+
+type ImageExcludeRules struct {
 }
 
 type ContainerLinterConfig struct {
 	LinterConfig
-	Rules        ContainerLinterRules
 	ExcludeRules ContainerExcludeRules
-}
-
-type ContainerLinterRules struct {
-	RecommendedLabelsRule RuleConfig
 }
 
 type ContainerExcludeRules struct {

--- a/pkg/config/adapter.go
+++ b/pkg/config/adapter.go
@@ -16,103 +16,90 @@ limitations under the License.
 
 package config
 
-func (r *RuntimeLintersSettings) ToLintersSettings() *LintersSettings {
+func (domain *DomainRootConfig) ToLintersSettings() *LintersSettings {
 	return &LintersSettings{
-		Container:  *r.Container.toContainerSettings(),
-		Hooks:      *r.Hooks.toHooksSettings(),
-		Images:     *r.Images.toImageSettings(),
-		Module:     *r.Module.toModuleSettings(),
-		NoCyrillic: *r.NoCyrillic.toNoCyrillicSettings(),
-		OpenAPI:    *r.OpenAPI.toOpenAPISettings(),
-		Rbac:       *r.Rbac.toRbacSettings(),
-		Templates:  *r.Templates.toTemplatesSettings(),
+		Container:  *domain.LintersConfig.Container.ToContainerSettings(),
+		Hooks:      *domain.LintersConfig.Hooks.ToHooksSettings(),
+		Images:     *domain.LintersConfig.Images.ToImageSettings(),
+		Module:     *domain.LintersConfig.Module.ToModuleSettings(),
+		NoCyrillic: *domain.LintersConfig.NoCyrillic.ToNoCyrillicSettings(),
+		OpenAPI:    *domain.LintersConfig.OpenAPI.ToOpenAPISettings(),
+		Rbac:       *domain.LintersConfig.Rbac.ToRbacSettings(),
+		Templates:  *domain.LintersConfig.Templates.ToTemplatesSettings(),
 	}
 }
 
-func (r *RuntimeLinterSettings) toContainerSettings() *ContainerSettings {
+func (c *ContainerConfig) ToContainerSettings() *ContainerSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range c.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &ContainerSettings{
-		Impact:        r.Impact,
+		Impact:        c.Impact,
 		RulesSettings: rulesSettings,
+		ExcludeRules:  ContainerExcludeRules{},
 	}
 }
 
-func (r *RuntimeLinterSettings) toHooksSettings() *HooksSettings {
+func (h *HooksConfig) ToHooksSettings() *HooksSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range h.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &HooksSettings{
-		Impact:        r.Impact,
+		Impact:        h.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (r *RuntimeLinterSettings) toImageSettings() *ImageSettings {
+func (i *ImagesConfig) ToImageSettings() *ImageSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range i.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &ImageSettings{
-		Impact:        r.Impact,
+		Impact:        i.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (r *RuntimeLinterSettings) toModuleSettings() *ModuleSettings {
+func (m *ModuleLinterConfig) ToModuleSettings() *ModuleSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range m.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &ModuleSettings{
-		Impact:        r.Impact,
+		Impact:        m.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (r *RuntimeLinterSettings) toNoCyrillicSettings() *NoCyrillicSettings {
+func (n *NoCyrillicConfig) ToNoCyrillicSettings() *NoCyrillicSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range n.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &NoCyrillicSettings{
-		Impact:        r.Impact,
+		Impact:        n.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (r *RuntimeLinterSettings) toOpenAPISettings() *OpenAPISettings {
+func (o *OpenAPIConfig) ToOpenAPISettings() *OpenAPISettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range o.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &OpenAPISettings{
-		Impact:        r.Impact,
+		Impact:        o.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (r *RuntimeLinterSettings) toRbacSettings() *RbacSettings {
+func (r *RbacConfig) ToRbacSettings() *RbacSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &RbacSettings{
 		Impact:        r.Impact,
@@ -120,43 +107,13 @@ func (r *RuntimeLinterSettings) toRbacSettings() *RbacSettings {
 	}
 }
 
-func (r *RuntimeLinterSettings) toTemplatesSettings() *TemplatesSettings {
+func (t *TemplatesConfig) ToTemplatesSettings() *TemplatesSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+	for ruleName, ruleConfig := range t.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings(ruleConfig)
 	}
 	return &TemplatesSettings{
-		Impact:        r.Impact,
-		RulesSettings: rulesSettings,
-	}
-}
-
-func (r *RuntimeLinterSettings) ToLegacyModuleSettings() *ModuleSettings {
-	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
-	}
-
-	return &ModuleSettings{
-		Impact:        r.Impact,
-		RulesSettings: rulesSettings,
-	}
-}
-
-func (r *RuntimeLinterSettings) ToLegacyContainerSettings() *ContainerSettings {
-	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleSettings := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
-	}
-
-	return &ContainerSettings{
-		Impact:        r.Impact,
+		Impact:        t.Impact,
 		RulesSettings: rulesSettings,
 	}
 }

--- a/pkg/config/adapter.go
+++ b/pkg/config/adapter.go
@@ -16,103 +16,119 @@ limitations under the License.
 
 package config
 
-func (domain *DomainRootConfig) ToLintersSettings() *LintersSettings {
+func (r *DomainRootConfig) ToLintersSettings() *LintersSettings {
 	return &LintersSettings{
-		Container:  *domain.LintersConfig.Container.ToContainerSettings(),
-		Hooks:      *domain.LintersConfig.Hooks.ToHooksSettings(),
-		Images:     *domain.LintersConfig.Images.ToImageSettings(),
-		Module:     *domain.LintersConfig.Module.ToModuleSettings(),
-		NoCyrillic: *domain.LintersConfig.NoCyrillic.ToNoCyrillicSettings(),
-		OpenAPI:    *domain.LintersConfig.OpenAPI.ToOpenAPISettings(),
-		Rbac:       *domain.LintersConfig.Rbac.ToRbacSettings(),
-		Templates:  *domain.LintersConfig.Templates.ToTemplatesSettings(),
+		Container:  r.LintersConfig.Container.ToContainerSettings(),
+		Hooks:      r.LintersConfig.Hooks.ToHooksSettings(),
+		Images:     r.LintersConfig.Images.ToImagesSettings(),
+		Module:     r.LintersConfig.Module.ToModuleSettings(),
+		NoCyrillic: r.LintersConfig.NoCyrillic.ToNoCyrillicSettings(),
+		OpenAPI:    r.LintersConfig.OpenAPI.ToOpenAPISettings(),
+		Rbac:       r.LintersConfig.Rbac.ToRbacSettings(),
+		Templates:  r.LintersConfig.Templates.ToTemplatesSettings(),
 	}
 }
 
-func (c *ContainerConfig) ToContainerSettings() *ContainerSettings {
+func (c *ContainerLinterConfig) ToContainerSettings() ContainerSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range c.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range c.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &ContainerSettings{
+
+	excludeRules := ContainerExcludeRules{}
+
+	return ContainerSettings{
 		Impact:        c.Impact,
 		RulesSettings: rulesSettings,
-		ExcludeRules:  ContainerExcludeRules{},
+		ExcludeRules:  excludeRules,
 	}
 }
 
-func (h *HooksConfig) ToHooksSettings() *HooksSettings {
+func (h *HooksLinterConfig) ToHooksSettings() HooksSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range h.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range h.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &HooksSettings{
+
+	return HooksSettings{
 		Impact:        h.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (i *ImagesConfig) ToImageSettings() *ImageSettings {
+func (i *ImagesLinterConfig) ToImagesSettings() ImageSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range i.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range i.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &ImageSettings{
+
+	excludeRules := ImageExcludeRules{}
+
+	return ImageSettings{
 		Impact:        i.Impact,
 		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
 	}
 }
 
-func (m *ModuleLinterConfig) ToModuleSettings() *ModuleSettings {
+func (m *ModuleLinterConfig) ToModuleSettings() ModuleSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range m.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range m.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &ModuleSettings{
+
+	excludeRules := ModuleExcludeRules{}
+
+	return ModuleSettings{
 		Impact:        m.Impact,
 		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
 	}
 }
 
-func (n *NoCyrillicConfig) ToNoCyrillicSettings() *NoCyrillicSettings {
+func (n *NoCyrillicLinterConfig) ToNoCyrillicSettings() NoCyrillicSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range n.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range n.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &NoCyrillicSettings{
+
+	return NoCyrillicSettings{
 		Impact:        n.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (o *OpenAPIConfig) ToOpenAPISettings() *OpenAPISettings {
+func (o *OpenAPILinterConfig) ToOpenAPISettings() OpenAPISettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range o.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range o.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &OpenAPISettings{
+
+	return OpenAPISettings{
 		Impact:        o.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (r *RbacConfig) ToRbacSettings() *RbacSettings {
+func (r *RbacLinterConfig) ToRbacSettings() RbacSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range r.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range r.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &RbacSettings{
+
+	return RbacSettings{
 		Impact:        r.Impact,
 		RulesSettings: rulesSettings,
 	}
 }
 
-func (t *TemplatesConfig) ToTemplatesSettings() *TemplatesSettings {
+func (t *TemplatesLinterConfig) ToTemplatesSettings() TemplatesSettings {
 	rulesSettings := make(map[string]RuleSettings)
-	for ruleName, ruleConfig := range t.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings(ruleConfig)
+	for ruleID, ruleConfig := range t.RulesSettings {
+		rulesSettings[ruleID] = RuleSettings(ruleConfig)
 	}
-	return &TemplatesSettings{
+
+	return TemplatesSettings{
 		Impact:        t.Impact,
 		RulesSettings: rulesSettings,
 	}

--- a/pkg/config/adapter.go
+++ b/pkg/config/adapter.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+func (r *RuntimeLintersSettings) ToLintersSettings() *LintersSettings {
+	return &LintersSettings{
+		Container:  *r.Container.toContainerSettings(),
+		Hooks:      *r.Hooks.toHooksSettings(),
+		Images:     *r.Images.toImageSettings(),
+		Module:     *r.Module.toModuleSettings(),
+		NoCyrillic: *r.NoCyrillic.toNoCyrillicSettings(),
+		OpenAPI:    *r.OpenAPI.toOpenAPISettings(),
+		Rbac:       *r.Rbac.toRbacSettings(),
+		Templates:  *r.Templates.toTemplatesSettings(),
+	}
+}
+
+func (r *RuntimeLinterSettings) toContainerSettings() *ContainerSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &ContainerSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toHooksSettings() *HooksSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &HooksSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toImageSettings() *ImageSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &ImageSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toModuleSettings() *ModuleSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &ModuleSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toNoCyrillicSettings() *NoCyrillicSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &NoCyrillicSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toOpenAPISettings() *OpenAPISettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &OpenAPISettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toRbacSettings() *RbacSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &RbacSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) toTemplatesSettings() *TemplatesSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+	return &TemplatesSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) ToLegacyModuleSettings() *ModuleSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+
+	return &ModuleSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}
+
+func (r *RuntimeLinterSettings) ToLegacyContainerSettings() *ContainerSettings {
+	rulesSettings := make(map[string]RuleSettings)
+	for ruleName, ruleSettings := range r.RulesSettings {
+		rulesSettings[ruleName] = RuleSettings{
+			Impact: ruleSettings.Impact,
+		}
+	}
+
+	return &ContainerSettings{
+		Impact:        r.Impact,
+		RulesSettings: rulesSettings,
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type RootConfig struct {
 }
 
 type ModuleConfig struct {
-	LintersSettings LintersSettings `mapstructure:"linters-settings"`
+	LintersSettings *LintersSettings
 }
 
 func calculateImpact(v, input *pkg.Level) *pkg.Level {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config/global"
 )
 
@@ -27,21 +26,8 @@ type RootConfig struct {
 }
 
 type ModuleConfig struct {
+	DomainConfig    *DomainRootConfig
 	LintersSettings *LintersSettings
-}
-
-func calculateImpact(v, input *pkg.Level) *pkg.Level {
-	if input != nil {
-		return input
-	}
-
-	if v != nil {
-		return v
-	}
-
-	lvl := pkg.Error
-
-	return &lvl
 }
 
 func NewDefaultRootConfig(dir string) (*RootConfig, error) {

--- a/pkg/config/container_remapper.go
+++ b/pkg/config/container_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewContainerLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) ContainerLinterConfig {
+	config := ContainerLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/container_remapper.go
+++ b/pkg/config/container_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewContainerLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) ContainerLinterConfig {
-	config := ContainerLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return ContainerLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/container_settings.go
+++ b/pkg/config/container_settings.go
@@ -25,7 +25,7 @@ type ContainerSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (c ContainerSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (c *ContainerSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if c.RulesSettings != nil {
 		if ruleSettings, exists := c.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/container_settings.go
+++ b/pkg/config/container_settings.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// ContainerSettings represents container linter settings
+type ContainerSettings struct {
+	ExcludeRules  ContainerExcludeRules   `mapstructure:"exclude-rules"`
+	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific container rule
+func (c ContainerSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if c.RulesSettings != nil {
+		if ruleSettings, exists := c.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return c.Impact
+}
+
+// ContainerExcludeRules represents container-specific exclude rules
+type ContainerExcludeRules struct {
+	ControllerSecurityContext KindRuleExcludeList `mapstructure:"controller-security-context"`
+	DNSPolicy                 KindRuleExcludeList `mapstructure:"dns-policy"`
+
+	HostNetworkPorts       ContainerRuleExcludeList `mapstructure:"host-network-ports"`
+	Ports                  ContainerRuleExcludeList `mapstructure:"ports"`
+	ReadOnlyRootFilesystem ContainerRuleExcludeList `mapstructure:"read-only-root-filesystem"`
+	ImageDigest            ContainerRuleExcludeList `mapstructure:"image-digest"`
+	Resources              ContainerRuleExcludeList `mapstructure:"resources"`
+	SecurityContext        ContainerRuleExcludeList `mapstructure:"security-context"`
+	Liveness               ContainerRuleExcludeList `mapstructure:"liveness-probe"`
+	Readiness              ContainerRuleExcludeList `mapstructure:"readiness-probe"`
+
+	Description StringRuleExcludeList `mapstructure:"description"`
+}

--- a/pkg/config/container_settings.go
+++ b/pkg/config/container_settings.go
@@ -19,26 +19,9 @@ package config
 import "github.com/deckhouse/dmt/pkg"
 
 type ContainerSettings struct {
-	ExcludeRules  ContainerExcludeRules   `mapstructure:"exclude-rules"`
-	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
+	ExcludeRules ContainerExcludeRules `mapstructure:"exclude-rules"`
 
 	Impact *pkg.Level `mapstructure:"impact"`
-}
-
-func (c *ContainerSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	if c.RulesSettings != nil {
-		if ruleSettings, exists := c.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
-			return ruleSettings.Impact
-		}
-	}
-	return c.Impact
-}
-
-func (c *ContainerSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
-	if c.RulesSettings == nil {
-		c.RulesSettings = make(map[string]RuleSettings)
-	}
-	c.RulesSettings[ruleName] = RuleSettings{Impact: impact}
 }
 
 type ContainerExcludeRules struct {

--- a/pkg/config/container_settings.go
+++ b/pkg/config/container_settings.go
@@ -34,6 +34,13 @@ func (c *ContainerSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return c.Impact
 }
 
+func (c *ContainerSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if c.RulesSettings == nil {
+		c.RulesSettings = make(map[string]RuleSettings)
+	}
+	c.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type ContainerExcludeRules struct {
 	ControllerSecurityContext KindRuleExcludeList `mapstructure:"controller-security-context"`
 	DNSPolicy                 KindRuleExcludeList `mapstructure:"dns-policy"`

--- a/pkg/config/container_settings.go
+++ b/pkg/config/container_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// ContainerSettings represents container linter settings
 type ContainerSettings struct {
 	ExcludeRules  ContainerExcludeRules   `mapstructure:"exclude-rules"`
 	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -26,19 +25,15 @@ type ContainerSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific container rule
 func (c ContainerSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if c.RulesSettings != nil {
 		if ruleSettings, exists := c.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return c.Impact
 }
 
-// ContainerExcludeRules represents container-specific exclude rules
 type ContainerExcludeRules struct {
 	ControllerSecurityContext KindRuleExcludeList `mapstructure:"controller-security-context"`
 	DNSPolicy                 KindRuleExcludeList `mapstructure:"dns-policy"`

--- a/pkg/config/domain.go
+++ b/pkg/config/domain.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2025 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package config
 
 import "github.com/deckhouse/dmt/pkg"
@@ -22,66 +6,73 @@ type RuleConfig struct {
 	Impact *pkg.Level
 }
 
-type ContainerConfig struct {
+type ContainerLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
-	ExcludeRules  ContainerExcludeRules
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type HooksConfig struct {
+type HooksLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type ImagesConfig struct {
+type ImagesLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
 type ModuleLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type NoCyrillicConfig struct {
+type NoCyrillicLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type OpenAPIConfig struct {
+type OpenAPILinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type RbacConfig struct {
+type RbacLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type TemplatesConfig struct {
+type TemplatesLinterConfig struct {
 	Impact        *pkg.Level
 	RulesSettings map[string]RuleConfig
+	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
 }
 
-type DomainLintersConfig struct {
-	Container  ContainerConfig
-	Hooks      HooksConfig
-	Images     ImagesConfig
+type LintersConfig struct {
+	Container  ContainerLinterConfig
+	Hooks      HooksLinterConfig
+	Images     ImagesLinterConfig
 	Module     ModuleLinterConfig
-	NoCyrillic NoCyrillicConfig
-	OpenAPI    OpenAPIConfig
-	Rbac       RbacConfig
-	Templates  TemplatesConfig
+	NoCyrillic NoCyrillicLinterConfig
+	OpenAPI    OpenAPILinterConfig
+	Rbac       RbacLinterConfig
+	Templates  TemplatesLinterConfig
 }
 
 type DomainRootConfig struct {
-	LintersConfig DomainLintersConfig
+	LintersConfig LintersConfig
 }

--- a/pkg/config/domain.go
+++ b/pkg/config/domain.go
@@ -11,6 +11,11 @@ type ContainerLinterConfig struct {
 	RulesSettings map[string]RuleConfig
 	ExcludeRules  []string
 	GetRuleImpact func(ruleID string) *pkg.Level
+	Rules         ContainerLinterRules
+}
+
+type ContainerLinterRules struct {
+	RecommendedLabelsRule RuleConfig
 }
 
 type HooksLinterConfig struct {

--- a/pkg/config/domain.go
+++ b/pkg/config/domain.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+type RuleConfig struct {
+	Impact *pkg.Level
+}
+
+type ContainerConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	ExcludeRules  ContainerExcludeRules
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type HooksConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type ImagesConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type ModuleLinterConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type NoCyrillicConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type OpenAPIConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type RbacConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type TemplatesConfig struct {
+	Impact        *pkg.Level
+	RulesSettings map[string]RuleConfig
+	GetRuleImpact func(ruleID string) *pkg.Level
+}
+
+type DomainLintersConfig struct {
+	Container  ContainerConfig
+	Hooks      HooksConfig
+	Images     ImagesConfig
+	Module     ModuleLinterConfig
+	NoCyrillic NoCyrillicConfig
+	OpenAPI    OpenAPIConfig
+	Rbac       RbacConfig
+	Templates  TemplatesConfig
+}
+
+type DomainRootConfig struct {
+	LintersConfig DomainLintersConfig
+}

--- a/pkg/config/dto.go
+++ b/pkg/config/dto.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+type UserRuleSettings struct {
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+type UserLinterSettings struct {
+	Impact        *pkg.Level                  `mapstructure:"impact"`
+	RulesSettings map[string]UserRuleSettings `mapstructure:"rules-settings"`
+}
+
+type UserLintersSettings struct {
+	Container  UserLinterSettings `mapstructure:"container"`
+	Hooks      UserLinterSettings `mapstructure:"hooks"`
+	Images     UserLinterSettings `mapstructure:"images"`
+	License    UserLinterSettings `mapstructure:"license"`
+	Module     UserLinterSettings `mapstructure:"module"`
+	NoCyrillic UserLinterSettings `mapstructure:"no-cyrillic"`
+	OpenAPI    UserLinterSettings `mapstructure:"openapi"`
+	Rbac       UserLinterSettings `mapstructure:"rbac"`
+	Templates  UserLinterSettings `mapstructure:"templates"`
+}
+
+type UserRootConfig struct {
+	LintersSettings UserLintersSettings `mapstructure:"linters-settings"`
+}

--- a/pkg/config/dto.go
+++ b/pkg/config/dto.go
@@ -1,47 +1,50 @@
-/*
-Copyright 2025 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package config
 
-import (
-	"github.com/deckhouse/dmt/pkg"
-)
+import "github.com/deckhouse/dmt/pkg"
 
-type UserRuleSettings struct {
+type UserRuleSettingsDTO struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-type UserLinterSettings struct {
-	Impact        *pkg.Level                  `mapstructure:"impact"`
-	RulesSettings map[string]UserRuleSettings `mapstructure:"rules-settings"`
-	ExcludeRules  []string                    `mapstructure:"exclude-rules"`
+type UserLinterSettingsDTO struct {
+	Impact        *pkg.Level                     `mapstructure:"impact"`
+	RulesSettings map[string]UserRuleSettingsDTO `mapstructure:"rules-settings"`
+	ExcludeRules  []string                       `mapstructure:"exclude-rules"`
 }
 
-type UserLintersSettings struct {
-	Container  UserLinterSettings `mapstructure:"container"`
-	Hooks      UserLinterSettings `mapstructure:"hooks"`
-	Images     UserLinterSettings `mapstructure:"images"`
-	License    UserLinterSettings `mapstructure:"license"`
-	Module     UserLinterSettings `mapstructure:"module"`
-	NoCyrillic UserLinterSettings `mapstructure:"no-cyrillic"`
-	OpenAPI    UserLinterSettings `mapstructure:"openapi"`
-	Rbac       UserLinterSettings `mapstructure:"rbac"`
-	Templates  UserLinterSettings `mapstructure:"templates"`
+type UserLintersSettingsDTO struct {
+	Container  UserLinterSettingsDTO `mapstructure:"container"`
+	Hooks      UserLinterSettingsDTO `mapstructure:"hooks"`
+	Images     UserLinterSettingsDTO `mapstructure:"images"`
+	Module     UserLinterSettingsDTO `mapstructure:"module"`
+	NoCyrillic UserLinterSettingsDTO `mapstructure:"no-cyrillic"`
+	OpenAPI    UserLinterSettingsDTO `mapstructure:"openapi"`
+	Rbac       UserLinterSettingsDTO `mapstructure:"rbac"`
+	Templates  UserLinterSettingsDTO `mapstructure:"templates"`
 }
 
-type UserRootConfig struct {
-	LintersSettings UserLintersSettings `mapstructure:"linters-settings"`
+type UserRootConfigDTO struct {
+	LintersSettings UserLintersSettingsDTO `mapstructure:"linters-settings"`
+}
+
+// Global DTO structures
+type GlobalLinterSettingsDTO struct {
+	Impact        *pkg.Level                     `mapstructure:"impact"`
+	RulesSettings map[string]UserRuleSettingsDTO `mapstructure:"rules-settings"`
+	ExcludeRules  []string                       `mapstructure:"exclude-rules"`
+}
+
+type GlobalLintersDTO struct {
+	Container  GlobalLinterSettingsDTO `mapstructure:"container"`
+	Hooks      GlobalLinterSettingsDTO `mapstructure:"hooks"`
+	Images     GlobalLinterSettingsDTO `mapstructure:"images"`
+	Module     GlobalLinterSettingsDTO `mapstructure:"module"`
+	NoCyrillic GlobalLinterSettingsDTO `mapstructure:"no-cyrillic"`
+	OpenAPI    GlobalLinterSettingsDTO `mapstructure:"openapi"`
+	Rbac       GlobalLinterSettingsDTO `mapstructure:"rbac"`
+	Templates  GlobalLinterSettingsDTO `mapstructure:"templates"`
+}
+
+type GlobalRootConfigDTO struct {
+	Global GlobalLintersDTO `mapstructure:"global"`
 }

--- a/pkg/config/dto.go
+++ b/pkg/config/dto.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package config
 
-import "github.com/deckhouse/dmt/pkg"
+import (
+	"github.com/deckhouse/dmt/pkg"
+)
 
 type UserRuleSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
@@ -25,6 +27,7 @@ type UserRuleSettings struct {
 type UserLinterSettings struct {
 	Impact        *pkg.Level                  `mapstructure:"impact"`
 	RulesSettings map[string]UserRuleSettings `mapstructure:"rules-settings"`
+	ExcludeRules  []string                    `mapstructure:"exclude-rules"`
 }
 
 type UserLintersSettings struct {

--- a/pkg/config/dto_loader.go
+++ b/pkg/config/dto_loader.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+type DTOLoader struct {
+	viper *viper.Viper
+	dir   string
+}
+
+func NewDTOLoader(dir string) *DTOLoader {
+	return &DTOLoader{
+		viper: viper.NewWithOptions(),
+		dir:   dir,
+	}
+}
+
+func (l *DTOLoader) LoadUserConfig() (*UserRootConfigDTO, error) {
+	l.viper.SetConfigName(".dmtlint")
+	l.viper.SetConfigType("yaml")
+	l.viper.AddConfigPath(l.dir)
+
+	if err := l.viper.ReadInConfig(); err != nil {
+		return &UserRootConfigDTO{}, nil
+	}
+
+	var userDTO UserRootConfigDTO
+	if err := l.viper.Unmarshal(&userDTO, customDecoderHook()); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal user config: %w", err)
+	}
+
+	return &userDTO, nil
+}
+
+func (l *DTOLoader) LoadGlobalConfig() (*GlobalRootConfigDTO, error) {
+	l.viper.SetConfigName(".dmtlint")
+	l.viper.SetConfigType("yaml")
+	l.viper.AddConfigPath(".")
+
+	if err := l.viper.ReadInConfig(); err != nil {
+		return &GlobalRootConfigDTO{}, nil
+	}
+
+	var globalDTO GlobalRootConfigDTO
+	if err := l.viper.Unmarshal(&globalDTO, customDecoderHook()); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal global config: %w", err)
+	}
+
+	return &globalDTO, nil
+}

--- a/pkg/config/exclude_rules.go
+++ b/pkg/config/exclude_rules.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// ServicePortExcludeList represents a list of service port exclusions
+type ServicePortExcludeList []ServicePortExclude
+
+// Get converts ServicePortExcludeList to []pkg.ServicePortExclude
+func (l ServicePortExcludeList) Get() []pkg.ServicePortExclude {
+	result := make([]pkg.ServicePortExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, *remapServicePortRuleExclude(&l[idx]))
+	}
+
+	return result
+}
+
+// StringRuleExcludeList represents a list of string exclusions
+type StringRuleExcludeList []string
+
+// Get converts StringRuleExcludeList to []pkg.StringRuleExclude
+func (l StringRuleExcludeList) Get() []pkg.StringRuleExclude {
+	result := make([]pkg.StringRuleExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, pkg.StringRuleExclude(l[idx]))
+	}
+
+	return result
+}
+
+// PrefixRuleExcludeList represents a list of prefix exclusions
+type PrefixRuleExcludeList []string
+
+// Get converts PrefixRuleExcludeList to []pkg.PrefixRuleExclude
+func (l PrefixRuleExcludeList) Get() []pkg.PrefixRuleExclude {
+	result := make([]pkg.PrefixRuleExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, pkg.PrefixRuleExclude(l[idx]))
+	}
+
+	return result
+}
+
+// KindRuleExcludeList represents a list of kind exclusions
+type KindRuleExcludeList []KindRuleExclude
+
+// Get converts KindRuleExcludeList to []pkg.KindRuleExclude
+func (l KindRuleExcludeList) Get() []pkg.KindRuleExclude {
+	result := make([]pkg.KindRuleExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, *remapKindRuleExclude(&l[idx]))
+	}
+
+	return result
+}
+
+// ContainerRuleExcludeList represents a list of container exclusions
+type ContainerRuleExcludeList []ContainerRuleExclude
+
+// Get converts ContainerRuleExcludeList to []pkg.ContainerRuleExclude
+func (l ContainerRuleExcludeList) Get() []pkg.ContainerRuleExclude {
+	result := make([]pkg.ContainerRuleExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, *remapContainerRuleExclude(&l[idx]))
+	}
+
+	return result
+}
+
+// KindRuleExclude represents a kind-based rule exclusion
+type KindRuleExclude struct {
+	Kind string `mapstructure:"kind"`
+	Name string `mapstructure:"name"`
+}
+
+// ContainerRuleExclude represents a container-based rule exclusion
+type ContainerRuleExclude struct {
+	Kind      string `mapstructure:"kind"`
+	Name      string `mapstructure:"name"`
+	Container string `mapstructure:"container"`
+}
+
+// ServicePortExclude represents a service port exclusion
+type ServicePortExclude struct {
+	Name string `mapstructure:"name"`
+	Port string `mapstructure:"port"`
+}
+
+// Helper functions for remapping exclude rules
+func remapKindRuleExclude(input *KindRuleExclude) *pkg.KindRuleExclude {
+	return &pkg.KindRuleExclude{
+		Name: input.Name,
+		Kind: input.Kind,
+	}
+}
+
+func remapServicePortRuleExclude(input *ServicePortExclude) *pkg.ServicePortExclude {
+	return &pkg.ServicePortExclude{
+		Name: input.Name,
+		Port: input.Port,
+	}
+}
+
+func remapContainerRuleExclude(input *ContainerRuleExclude) *pkg.ContainerRuleExclude {
+	return &pkg.ContainerRuleExclude{
+		Kind:      input.Kind,
+		Name:      input.Name,
+		Container: input.Container,
+	}
+}

--- a/pkg/config/exclude_rules.go
+++ b/pkg/config/exclude_rules.go
@@ -107,7 +107,6 @@ type ServicePortExclude struct {
 	Port string `mapstructure:"port"`
 }
 
-// Helper functions for remapping exclude rules
 func remapKindRuleExclude(input *KindRuleExclude) *pkg.KindRuleExclude {
 	return &pkg.KindRuleExclude{
 		Name: input.Name,

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -19,22 +19,35 @@ package global
 import "github.com/deckhouse/dmt/pkg"
 
 type Global struct {
-	Linters Linters `mapstructure:"linters"`
+	Linters Linters `mapstructure:"linters-settings"`
 }
 
 type Linters struct {
-	Container  LinterConfig `mapstructure:"container"`
-	Hooks      LinterConfig `mapstructure:"hooks"`
-	Images     LinterConfig `mapstructure:"images"`
-	License    LinterConfig `mapstructure:"license"`
-	Module     LinterConfig `mapstructure:"module"`
-	NoCyrillic LinterConfig `mapstructure:"no-cyrillic"`
-	OpenAPI    LinterConfig `mapstructure:"openapi"`
-	Rbac       LinterConfig `mapstructure:"rbac"`
-	Templates  LinterConfig `mapstructure:"templates"`
+	Container  ContainerLinterConfig `mapstructure:"container"`
+	Hooks      LinterConfig          `mapstructure:"hooks"`
+	Images     LinterConfig          `mapstructure:"images"`
+	License    LinterConfig          `mapstructure:"license"`
+	Module     LinterConfig          `mapstructure:"module"`
+	NoCyrillic LinterConfig          `mapstructure:"no-cyrillic"`
+	OpenAPI    LinterConfig          `mapstructure:"openapi"`
+	Rbac       LinterConfig          `mapstructure:"rbac"`
+	Templates  LinterConfig          `mapstructure:"templates"`
+}
+
+type ContainerLinterConfig struct {
+	LinterConfig
+	Rules ContainerLinterRules `mapstructure:"rules"`
+}
+
+type ContainerLinterRules struct {
+	RecommendedLabelsRule RuleConfig `mapstructure:"recommended-labels"`
 }
 
 type LinterConfig struct {
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+type RuleConfig struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -19,7 +19,7 @@ package global
 import "github.com/deckhouse/dmt/pkg"
 
 type Global struct {
-	Linters Linters `mapstructure:"linters-settings"`
+	Linters Linters `mapstructure:"linters"`
 }
 
 type Linters struct {

--- a/pkg/config/hooks_remapper.go
+++ b/pkg/config/hooks_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewHooksLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) HooksLinterConfig {
+	config := HooksLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/hooks_remapper.go
+++ b/pkg/config/hooks_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewHooksLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) HooksLinterConfig {
-	config := HooksLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return HooksLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/hooks_settings.go
+++ b/pkg/config/hooks_settings.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// HooksSettings represents hooks linter settings
+type HooksSettings struct {
+	Ingress       HooksIngressRuleSetting `mapstructure:"ingress"`
+	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific hooks rule
+func (h HooksSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if h.RulesSettings != nil {
+		if ruleSettings, exists := h.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return h.Impact
+}
+
+// HooksIngressRuleSetting represents hooks ingress rule settings
+type HooksIngressRuleSetting struct {
+	// disable ingress rule completely
+	Disable bool `mapstructure:"disable"`
+}

--- a/pkg/config/hooks_settings.go
+++ b/pkg/config/hooks_settings.go
@@ -25,7 +25,7 @@ type HooksSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (h HooksSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (h *HooksSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if h.RulesSettings != nil {
 		if ruleSettings, exists := h.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/hooks_settings.go
+++ b/pkg/config/hooks_settings.go
@@ -34,6 +34,13 @@ func (h *HooksSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return h.Impact
 }
 
+func (h *HooksSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if h.RulesSettings == nil {
+		h.RulesSettings = make(map[string]RuleSettings)
+	}
+	h.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type HooksIngressRuleSetting struct {
 	// disable ingress rule completely
 	Disable bool `mapstructure:"disable"`

--- a/pkg/config/hooks_settings.go
+++ b/pkg/config/hooks_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// HooksSettings represents hooks linter settings
 type HooksSettings struct {
 	Ingress       HooksIngressRuleSetting `mapstructure:"ingress"`
 	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -26,19 +25,15 @@ type HooksSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific hooks rule
 func (h HooksSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if h.RulesSettings != nil {
 		if ruleSettings, exists := h.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return h.Impact
 }
 
-// HooksIngressRuleSetting represents hooks ingress rule settings
 type HooksIngressRuleSetting struct {
 	// disable ingress rule completely
 	Disable bool `mapstructure:"disable"`

--- a/pkg/config/images_remapper.go
+++ b/pkg/config/images_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewImagesLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) ImagesLinterConfig {
+	config := ImagesLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/images_remapper.go
+++ b/pkg/config/images_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewImagesLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) ImagesLinterConfig {
-	config := ImagesLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return ImagesLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/images_settings.go
+++ b/pkg/config/images_settings.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// ImageSettings represents image linter settings
+type ImageSettings struct {
+	ExcludeRules  ImageExcludeRules       `mapstructure:"exclude-rules"`
+	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	Patches PatchesRuleSettings `mapstructure:"patches"`
+	Werf    WerfRuleSettings    `mapstructure:"werf"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific image rule
+func (i ImageSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if i.RulesSettings != nil {
+		if ruleSettings, exists := i.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return i.Impact
+}
+
+// ImageExcludeRules represents image-specific exclude rules
+type ImageExcludeRules struct {
+	SkipImageFilePathPrefix      PrefixRuleExcludeList `mapstructure:"skip-image-file-path-prefix"`
+	SkipDistrolessFilePathPrefix PrefixRuleExcludeList `mapstructure:"skip-distroless-file-path-prefix"`
+}
+
+// PatchesRuleSettings represents patches rule settings
+type PatchesRuleSettings struct {
+	// disable conversions rule completely
+	Disable bool `mapstructure:"disable"`
+}
+
+// WerfRuleSettings represents werf rule settings
+type WerfRuleSettings struct {
+	// disable werf rule completely
+	Disable bool `mapstructure:"disable"`
+}

--- a/pkg/config/images_settings.go
+++ b/pkg/config/images_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// ImageSettings represents image linter settings
 type ImageSettings struct {
 	ExcludeRules  ImageExcludeRules       `mapstructure:"exclude-rules"`
 	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -29,31 +28,25 @@ type ImageSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific image rule
 func (i ImageSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if i.RulesSettings != nil {
 		if ruleSettings, exists := i.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return i.Impact
 }
 
-// ImageExcludeRules represents image-specific exclude rules
 type ImageExcludeRules struct {
 	SkipImageFilePathPrefix      PrefixRuleExcludeList `mapstructure:"skip-image-file-path-prefix"`
 	SkipDistrolessFilePathPrefix PrefixRuleExcludeList `mapstructure:"skip-distroless-file-path-prefix"`
 }
 
-// PatchesRuleSettings represents patches rule settings
 type PatchesRuleSettings struct {
 	// disable conversions rule completely
 	Disable bool `mapstructure:"disable"`
 }
 
-// WerfRuleSettings represents werf rule settings
 type WerfRuleSettings struct {
 	// disable werf rule completely
 	Disable bool `mapstructure:"disable"`

--- a/pkg/config/images_settings.go
+++ b/pkg/config/images_settings.go
@@ -37,6 +37,13 @@ func (i *ImageSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return i.Impact
 }
 
+func (i *ImageSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if i.RulesSettings == nil {
+		i.RulesSettings = make(map[string]RuleSettings)
+	}
+	i.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type ImageExcludeRules struct {
 	SkipImageFilePathPrefix      PrefixRuleExcludeList `mapstructure:"skip-image-file-path-prefix"`
 	SkipDistrolessFilePathPrefix PrefixRuleExcludeList `mapstructure:"skip-distroless-file-path-prefix"`

--- a/pkg/config/images_settings.go
+++ b/pkg/config/images_settings.go
@@ -28,7 +28,7 @@ type ImageSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (i ImageSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (i *ImageSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if i.RulesSettings != nil {
 		if ruleSettings, exists := i.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -21,12 +21,10 @@ import (
 	"github.com/deckhouse/dmt/pkg/config/global"
 )
 
-// RuleSettings represents settings for a specific rule
 type RuleSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// LintersSettings represents the main configuration structure for all linters
 type LintersSettings struct {
 	Container  ContainerSettings  `mapstructure:"container"`
 	Hooks      HooksSettings      `mapstructure:"hooks"`

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -16,14 +16,6 @@ limitations under the License.
 
 package config
 
-import (
-	"github.com/deckhouse/dmt/pkg"
-)
-
-type RuleSettings struct {
-	Impact *pkg.Level `mapstructure:"impact"`
-}
-
 type LintersSettings struct {
 	Container  ContainerSettings  `mapstructure:"container"`
 	Hooks      HooksSettings      `mapstructure:"hooks"`
@@ -33,28 +25,4 @@ type LintersSettings struct {
 	OpenAPI    OpenAPISettings    `mapstructure:"openapi"`
 	Rbac       RbacSettings       `mapstructure:"rbac"`
 	Templates  TemplatesSettings  `mapstructure:"templates"`
-}
-
-// GetRuleImpact returns the impact level for a specific rule in a specific linter
-func (cfg *LintersSettings) GetRuleImpact(linterName, ruleName string) *pkg.Level {
-	switch linterName {
-	case "container":
-		return cfg.Container.GetRuleImpact(ruleName)
-	case "hooks":
-		return cfg.Hooks.GetRuleImpact(ruleName)
-	case "images":
-		return cfg.Images.GetRuleImpact(ruleName)
-	case "module":
-		return cfg.Module.GetRuleImpact(ruleName)
-	case "no-cyrillic":
-		return cfg.NoCyrillic.GetRuleImpact(ruleName)
-	case "openapi":
-		return cfg.OpenAPI.GetRuleImpact(ruleName)
-	case "rbac":
-		return cfg.Rbac.GetRuleImpact(ruleName)
-	case "templates":
-		return cfg.Templates.GetRuleImpact(ruleName)
-	default:
-		return nil
-	}
 }

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config/global"
 )
 
 type RuleSettings struct {
@@ -34,22 +33,6 @@ type LintersSettings struct {
 	OpenAPI    OpenAPISettings    `mapstructure:"openapi"`
 	Rbac       RbacSettings       `mapstructure:"rbac"`
 	Templates  TemplatesSettings  `mapstructure:"templates"`
-}
-
-// MergeGlobal merges global configuration with linter settings
-func (cfg *LintersSettings) MergeGlobal(lcfg *global.Linters) {
-	if lcfg == nil {
-		return
-	}
-
-	cfg.OpenAPI.Impact = calculateImpact(cfg.OpenAPI.Impact, lcfg.OpenAPI.Impact)
-	cfg.NoCyrillic.Impact = calculateImpact(cfg.NoCyrillic.Impact, lcfg.NoCyrillic.Impact)
-	cfg.Container.Impact = calculateImpact(cfg.Container.Impact, lcfg.Container.Impact)
-	cfg.Templates.Impact = calculateImpact(cfg.Templates.Impact, lcfg.Templates.Impact)
-	cfg.Images.Impact = calculateImpact(cfg.Images.Impact, lcfg.Images.Impact)
-	cfg.Rbac.Impact = calculateImpact(cfg.Rbac.Impact, lcfg.Rbac.Impact)
-	cfg.Hooks.Impact = calculateImpact(cfg.Hooks.Impact, lcfg.Hooks.Impact)
-	cfg.Module.Impact = calculateImpact(cfg.Module.Impact, lcfg.Module.Impact)
 }
 
 // GetRuleImpact returns the impact level for a specific rule in a specific linter

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -68,7 +68,7 @@ func (l *Loader) Load() error {
 }
 
 func (l *Loader) setConfigFile() error {
-	l.viper.SetConfigName("dmt-config")
+	l.viper.SetConfigName(".dmtlint")
 
 	configSearchPaths := l.getConfigSearchPaths()
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -68,7 +68,7 @@ func (l *Loader) Load() error {
 }
 
 func (l *Loader) setConfigFile() error {
-	l.viper.SetConfigName(".dmtlint")
+	l.viper.SetConfigName("dmt-config")
 
 	configSearchPaths := l.getConfigSearchPaths()
 

--- a/pkg/config/loader_dto.go
+++ b/pkg/config/loader_dto.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package config
 
-func LoadUserConfig(path string) (*UserRootConfig, error) {
-	dtoConfig := &UserRootConfig{}
+func LoadUserConfig(path string) (*UserRootConfigDTO, error) {
+	dtoConfig := &UserRootConfigDTO{}
 	loader := NewLoader(dtoConfig, path)
 
 	err := loader.Load()

--- a/pkg/config/loader_dto.go
+++ b/pkg/config/loader_dto.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+func LoadUserConfig(path string) (*UserRootConfig, error) {
+	dtoConfig := &UserRootConfig{}
+	loader := NewLoader(dtoConfig, path)
+
+	err := loader.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	return dtoConfig, nil
+}

--- a/pkg/config/module_remapper.go
+++ b/pkg/config/module_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewModuleLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) ModuleLinterConfig {
+	config := ModuleLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/module_remapper.go
+++ b/pkg/config/module_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewModuleLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) ModuleLinterConfig {
-	config := ModuleLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return ModuleLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/module_settings.go
+++ b/pkg/config/module_settings.go
@@ -39,6 +39,13 @@ func (m *ModuleSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return m.Impact
 }
 
+func (m *ModuleSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if m.RulesSettings == nil {
+		m.RulesSettings = make(map[string]RuleSettings)
+	}
+	m.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type ModuleExcludeRules struct {
 	License LicenseExcludeRule `mapstructure:"license"`
 }

--- a/pkg/config/module_settings.go
+++ b/pkg/config/module_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// ModuleSettings represents module linter settings
 type ModuleSettings struct {
 	ExcludeRules  ModuleExcludeRules      `mapstructure:"exclude-rules"`
 	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -31,48 +30,39 @@ type ModuleSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific module rule
 func (m ModuleSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if m.RulesSettings != nil {
 		if ruleSettings, exists := m.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return m.Impact
 }
 
-// ModuleExcludeRules represents module-specific exclude rules
 type ModuleExcludeRules struct {
 	License LicenseExcludeRule `mapstructure:"license"`
 }
 
-// ModuleOSSRuleSettings represents module OSS rule settings
 type ModuleOSSRuleSettings struct {
 	// disable oss rule completely
 	Disable bool `mapstructure:"disable"`
 }
 
-// ModuleDefinitionFileRuleSettings represents module definition file rule settings
 type ModuleDefinitionFileRuleSettings struct {
 	// disable definition-file rule completely
 	Disable bool `mapstructure:"disable"`
 }
 
-// ConversionsRuleSettings represents conversions rule settings
 type ConversionsRuleSettings struct {
 	// disable conversions rule completely
 	Disable bool `mapstructure:"disable"`
 }
 
-// HelmignoreRuleSettings represents helmignore rule settings
 type HelmignoreRuleSettings struct {
 	// disable helmignore rule completely
 	Disable bool `mapstructure:"disable"`
 }
 
-// LicenseExcludeRule represents license exclude rule
 type LicenseExcludeRule struct {
 	Files       StringRuleExcludeList `mapstructure:"files"`
 	Directories PrefixRuleExcludeList `mapstructure:"directories"`

--- a/pkg/config/module_settings.go
+++ b/pkg/config/module_settings.go
@@ -30,7 +30,7 @@ type ModuleSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (m ModuleSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (m *ModuleSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if m.RulesSettings != nil {
 		if ruleSettings, exists := m.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/module_settings.go
+++ b/pkg/config/module_settings.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// ModuleSettings represents module linter settings
+type ModuleSettings struct {
+	ExcludeRules  ModuleExcludeRules      `mapstructure:"exclude-rules"`
+	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	OSS            ModuleOSSRuleSettings            `mapstructure:"oss"`
+	DefinitionFile ModuleDefinitionFileRuleSettings `mapstructure:"definition-file"`
+	Conversions    ConversionsRuleSettings          `mapstructure:"conversions"`
+	Helmignore     HelmignoreRuleSettings           `mapstructure:"helmignore"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific module rule
+func (m ModuleSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if m.RulesSettings != nil {
+		if ruleSettings, exists := m.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return m.Impact
+}
+
+// ModuleExcludeRules represents module-specific exclude rules
+type ModuleExcludeRules struct {
+	License LicenseExcludeRule `mapstructure:"license"`
+}
+
+// ModuleOSSRuleSettings represents module OSS rule settings
+type ModuleOSSRuleSettings struct {
+	// disable oss rule completely
+	Disable bool `mapstructure:"disable"`
+}
+
+// ModuleDefinitionFileRuleSettings represents module definition file rule settings
+type ModuleDefinitionFileRuleSettings struct {
+	// disable definition-file rule completely
+	Disable bool `mapstructure:"disable"`
+}
+
+// ConversionsRuleSettings represents conversions rule settings
+type ConversionsRuleSettings struct {
+	// disable conversions rule completely
+	Disable bool `mapstructure:"disable"`
+}
+
+// HelmignoreRuleSettings represents helmignore rule settings
+type HelmignoreRuleSettings struct {
+	// disable helmignore rule completely
+	Disable bool `mapstructure:"disable"`
+}
+
+// LicenseExcludeRule represents license exclude rule
+type LicenseExcludeRule struct {
+	Files       StringRuleExcludeList `mapstructure:"files"`
+	Directories PrefixRuleExcludeList `mapstructure:"directories"`
+}

--- a/pkg/config/no_cyrillic_settings.go
+++ b/pkg/config/no_cyrillic_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// NoCyrillicSettings represents no-cyrillic linter settings
 type NoCyrillicSettings struct {
 	NoCyrillicExcludeRules NoCyrillicExcludeRules  `mapstructure:"exclude-rules"`
 	RulesSettings          map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -26,19 +25,15 @@ type NoCyrillicSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific no-cyrillic rule
 func (n NoCyrillicSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if n.RulesSettings != nil {
 		if ruleSettings, exists := n.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return n.Impact
 }
 
-// NoCyrillicExcludeRules represents no-cyrillic-specific exclude rules
 type NoCyrillicExcludeRules struct {
 	Files       StringRuleExcludeList `mapstructure:"files"`
 	Directories PrefixRuleExcludeList `mapstructure:"directories"`

--- a/pkg/config/no_cyrillic_settings.go
+++ b/pkg/config/no_cyrillic_settings.go
@@ -25,7 +25,7 @@ type NoCyrillicSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (n NoCyrillicSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (n *NoCyrillicSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if n.RulesSettings != nil {
 		if ruleSettings, exists := n.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/no_cyrillic_settings.go
+++ b/pkg/config/no_cyrillic_settings.go
@@ -34,6 +34,13 @@ func (n *NoCyrillicSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return n.Impact
 }
 
+func (n *NoCyrillicSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if n.RulesSettings == nil {
+		n.RulesSettings = make(map[string]RuleSettings)
+	}
+	n.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type NoCyrillicExcludeRules struct {
 	Files       StringRuleExcludeList `mapstructure:"files"`
 	Directories PrefixRuleExcludeList `mapstructure:"directories"`

--- a/pkg/config/no_cyrillic_settings.go
+++ b/pkg/config/no_cyrillic_settings.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// NoCyrillicSettings represents no-cyrillic linter settings
+type NoCyrillicSettings struct {
+	NoCyrillicExcludeRules NoCyrillicExcludeRules  `mapstructure:"exclude-rules"`
+	RulesSettings          map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific no-cyrillic rule
+func (n NoCyrillicSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if n.RulesSettings != nil {
+		if ruleSettings, exists := n.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return n.Impact
+}
+
+// NoCyrillicExcludeRules represents no-cyrillic-specific exclude rules
+type NoCyrillicExcludeRules struct {
+	Files       StringRuleExcludeList `mapstructure:"files"`
+	Directories PrefixRuleExcludeList `mapstructure:"directories"`
+}

--- a/pkg/config/nocyrillic_remapper.go
+++ b/pkg/config/nocyrillic_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewNoCyrillicLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) NoCyrillicLinterConfig {
+	config := NoCyrillicLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/nocyrillic_remapper.go
+++ b/pkg/config/nocyrillic_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewNoCyrillicLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) NoCyrillicLinterConfig {
-	config := NoCyrillicLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return NoCyrillicLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/openapi_remapper.go
+++ b/pkg/config/openapi_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewOpenAPILinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) OpenAPILinterConfig {
-	config := OpenAPILinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return OpenAPILinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/openapi_remapper.go
+++ b/pkg/config/openapi_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewOpenAPILinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) OpenAPILinterConfig {
+	config := OpenAPILinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/openapi_settings.go
+++ b/pkg/config/openapi_settings.go
@@ -34,6 +34,13 @@ func (o *OpenAPISettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return o.Impact
 }
 
+func (o *OpenAPISettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if o.RulesSettings == nil {
+		o.RulesSettings = make(map[string]RuleSettings)
+	}
+	o.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type OpenAPIExcludeRules struct {
 	KeyBannedNames         []string              `mapstructure:"key-banned-names"`
 	EnumFileExcludes       []string              `mapstructure:"enum"`

--- a/pkg/config/openapi_settings.go
+++ b/pkg/config/openapi_settings.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// OpenAPISettings represents openapi linter settings
+type OpenAPISettings struct {
+	OpenAPIExcludeRules OpenAPIExcludeRules     `mapstructure:"exclude-rules"`
+	RulesSettings       map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific openapi rule
+func (o OpenAPISettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if o.RulesSettings != nil {
+		if ruleSettings, exists := o.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return o.Impact
+}
+
+// OpenAPIExcludeRules represents openapi-specific exclude rules
+type OpenAPIExcludeRules struct {
+	KeyBannedNames         []string              `mapstructure:"key-banned-names"`
+	EnumFileExcludes       []string              `mapstructure:"enum"`
+	HAAbsoluteKeysExcludes StringRuleExcludeList `mapstructure:"ha-absolute-keys"`
+	CRDNamesExcludes       StringRuleExcludeList `mapstructure:"crd-names"`
+}

--- a/pkg/config/openapi_settings.go
+++ b/pkg/config/openapi_settings.go
@@ -25,7 +25,7 @@ type OpenAPISettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (o OpenAPISettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (o *OpenAPISettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if o.RulesSettings != nil {
 		if ruleSettings, exists := o.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/openapi_settings.go
+++ b/pkg/config/openapi_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// OpenAPISettings represents openapi linter settings
 type OpenAPISettings struct {
 	OpenAPIExcludeRules OpenAPIExcludeRules     `mapstructure:"exclude-rules"`
 	RulesSettings       map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -26,19 +25,15 @@ type OpenAPISettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific openapi rule
 func (o OpenAPISettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if o.RulesSettings != nil {
 		if ruleSettings, exists := o.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return o.Impact
 }
 
-// OpenAPIExcludeRules represents openapi-specific exclude rules
 type OpenAPIExcludeRules struct {
 	KeyBannedNames         []string              `mapstructure:"key-banned-names"`
 	EnumFileExcludes       []string              `mapstructure:"enum"`

--- a/pkg/config/rbac_remapper.go
+++ b/pkg/config/rbac_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewRbacLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) RbacLinterConfig {
-	config := RbacLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return RbacLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/rbac_remapper.go
+++ b/pkg/config/rbac_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewRbacLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) RbacLinterConfig {
+	config := RbacLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/rbac_settings.go
+++ b/pkg/config/rbac_settings.go
@@ -34,6 +34,13 @@ func (r *RbacSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return r.Impact
 }
 
+func (r *RbacSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if r.RulesSettings == nil {
+		r.RulesSettings = make(map[string]RuleSettings)
+	}
+	r.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type RBACExcludeRules struct {
 	BindingSubject StringRuleExcludeList `mapstructure:"binding-subject"`
 	Placement      KindRuleExcludeList   `mapstructure:"placement"`

--- a/pkg/config/rbac_settings.go
+++ b/pkg/config/rbac_settings.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// RbacSettings represents rbac linter settings
+type RbacSettings struct {
+	ExcludeRules  RBACExcludeRules        `mapstructure:"exclude-rules"`
+	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific rbac rule
+func (r RbacSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if r.RulesSettings != nil {
+		if ruleSettings, exists := r.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return r.Impact
+}
+
+// RBACExcludeRules represents rbac-specific exclude rules
+type RBACExcludeRules struct {
+	BindingSubject StringRuleExcludeList `mapstructure:"binding-subject"`
+	Placement      KindRuleExcludeList   `mapstructure:"placement"`
+	Wildcards      KindRuleExcludeList   `mapstructure:"wildcards"`
+}

--- a/pkg/config/rbac_settings.go
+++ b/pkg/config/rbac_settings.go
@@ -25,7 +25,7 @@ type RbacSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (r RbacSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (r *RbacSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if r.RulesSettings != nil {
 		if ruleSettings, exists := r.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/rbac_settings.go
+++ b/pkg/config/rbac_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// RbacSettings represents rbac linter settings
 type RbacSettings struct {
 	ExcludeRules  RBACExcludeRules        `mapstructure:"exclude-rules"`
 	RulesSettings map[string]RuleSettings `mapstructure:"rules-settings"`
@@ -26,19 +25,15 @@ type RbacSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific rbac rule
 func (r RbacSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if r.RulesSettings != nil {
 		if ruleSettings, exists := r.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return r.Impact
 }
 
-// RBACExcludeRules represents rbac-specific exclude rules
 type RBACExcludeRules struct {
 	BindingSubject StringRuleExcludeList `mapstructure:"binding-subject"`
 	Placement      KindRuleExcludeList   `mapstructure:"placement"`

--- a/pkg/config/remapper.go
+++ b/pkg/config/remapper.go
@@ -60,3 +60,27 @@ func mergeExcludeRules(userRules, globalRules []string) []string {
 
 	return result
 }
+
+func newLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) (map[string]RuleConfig, []string, func(string) *pkg.Level) {
+	rulesSettings := make(map[string]RuleConfig)
+	excludeRules := mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules)
+	impact := mergeImpact(userDTO.Impact, globalDTO.Impact)
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		rulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := rulesSettings[ruleID]; !exists {
+			rulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+
+	getRuleImpact := func(ruleID string) *pkg.Level {
+		if rule, exists := rulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return impact
+	}
+
+	return rulesSettings, excludeRules, getRuleImpact
+}

--- a/pkg/config/remapper.go
+++ b/pkg/config/remapper.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/deckhouse/dmt/pkg/config/global"
+)
+
+// RemapGlobalLintersToLintersSettings converts global.Linters to LintersSettings
+func RemapGlobalLintersToLintersSettings(globalLinters *global.Linters) *LintersSettings {
+	if globalLinters == nil {
+		return &LintersSettings{}
+	}
+
+	return &LintersSettings{
+		Container:  ContainerSettings{Impact: globalLinters.Container.Impact},
+		Hooks:      HooksSettings{Impact: globalLinters.Hooks.Impact},
+		Images:     ImageSettings{Impact: globalLinters.Images.Impact},
+		Module:     ModuleSettings{Impact: globalLinters.Module.Impact},
+		NoCyrillic: NoCyrillicSettings{Impact: globalLinters.NoCyrillic.Impact},
+		OpenAPI:    OpenAPISettings{Impact: globalLinters.OpenAPI.Impact},
+		Rbac:       RbacSettings{Impact: globalLinters.Rbac.Impact},
+		Templates:  TemplatesSettings{Impact: globalLinters.Templates.Impact},
+	}
+}

--- a/pkg/config/remapper.go
+++ b/pkg/config/remapper.go
@@ -50,12 +50,10 @@ func (dto *UserLinterSettings) ToRuntime(globalConfig global.LinterConfig) *Runt
 
 	rulesSettings := make(map[string]RuleSettings)
 	for ruleName, ruleSettings := range dto.RulesSettings {
-		rulesSettings[ruleName] = RuleSettings{
-			Impact: ruleSettings.Impact,
-		}
+		rulesSettings[ruleName] = RuleSettings(ruleSettings)
 	}
 
-	ruleImpactFunc := func(linterID, ruleID string) *pkg.Level {
+	ruleImpactFunc := func(_, ruleID string) *pkg.Level {
 		if rulesSettings, exists := rulesSettings[ruleID]; exists && rulesSettings.Impact != nil {
 			return rulesSettings.Impact
 		}
@@ -69,9 +67,9 @@ func (dto *UserLinterSettings) ToRuntime(globalConfig global.LinterConfig) *Runt
 	}
 }
 
-func calculateRuntimeImpact(local, global *pkg.Level) *pkg.Level {
+func calculateRuntimeImpact(local, globalLevel *pkg.Level) *pkg.Level {
 	if local != nil {
 		return local
 	}
-	return global
+	return globalLevel
 }

--- a/pkg/config/rule_impact_test.go
+++ b/pkg/config/rule_impact_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/deckhouse/dmt/pkg"
+)
+
+func TestRuleImpactConfiguration(t *testing.T) {
+	// Test LintersSettings with rule-specific settings
+	linterSettings := &LintersSettings{
+		Container: ContainerSettings{
+			Impact: &[]pkg.Level{pkg.Error}[0],
+			RulesSettings: map[string]RuleSettings{
+				"some-rule": {
+					Impact: &[]pkg.Level{pkg.Warn}[0],
+				},
+				"another-rule": {
+					Impact: &[]pkg.Level{pkg.Critical}[0],
+				},
+			},
+		},
+		Hooks: HooksSettings{
+			Impact: &[]pkg.Level{pkg.Error}[0],
+			RulesSettings: map[string]RuleSettings{
+				"ingress-rule": {
+					Impact: &[]pkg.Level{pkg.Warn}[0],
+				},
+			},
+		},
+		Images: ImageSettings{
+			Impact: &[]pkg.Level{pkg.Error}[0],
+		},
+	}
+
+	// Test rule-specific impact retrieval
+	tests := []struct {
+		linterName string
+		ruleName   string
+		expected   pkg.Level
+	}{
+		{"container", "some-rule", pkg.Warn},
+		{"container", "another-rule", pkg.Critical},
+		{"container", "non-existent-rule", pkg.Error}, // Should fall back to linter default
+		{"hooks", "ingress-rule", pkg.Warn},
+		{"hooks", "non-existent-rule", pkg.Error}, // Should fall back to linter default
+		{"images", "any-rule", pkg.Error},         // Should fall back to linter default (no global config)
+	}
+
+	for _, test := range tests {
+		t.Run(test.linterName+"-"+test.ruleName, func(t *testing.T) {
+			impact := linterSettings.GetRuleImpact(test.linterName, test.ruleName)
+			if impact == nil {
+				t.Errorf("Expected impact for %s.%s, got nil", test.linterName, test.ruleName)
+				return
+			}
+			if *impact != test.expected {
+				t.Errorf("Expected impact %v for %s.%s, got %v", test.expected, test.linterName, test.ruleName, *impact)
+			}
+		})
+	}
+}
+
+func TestRuleSettingsInitialization(t *testing.T) {
+	linterSettings := &LintersSettings{}
+
+	// Test that RulesSettings is properly initialized
+	if linterSettings.Container.RulesSettings != nil {
+		t.Error("Expected Container.RulesSettings to be nil initially")
+	}
+
+	// Test rule-specific impact retrieval with nil RulesSettings
+	impact := linterSettings.GetRuleImpact("container", "some-rule")
+	if impact != nil {
+		t.Error("Expected nil impact for non-existent rule when RulesSettings is nil")
+	}
+
+	// Test with initialized RulesSettings
+	linterSettings.Container.RulesSettings = map[string]RuleSettings{
+		"some-rule": {
+			Impact: &[]pkg.Level{pkg.Warn}[0],
+		},
+	}
+
+	impact = linterSettings.GetRuleImpact("container", "some-rule")
+	if impact == nil {
+		t.Error("Expected impact for some-rule, got nil")
+	} else if *impact != pkg.Warn {
+		t.Errorf("Expected impact %v for some-rule, got %v", pkg.Warn, *impact)
+	}
+}
+
+func TestRuleImpactFallback(t *testing.T) {
+	linterSettings := &LintersSettings{
+		Container: ContainerSettings{
+			Impact: &[]pkg.Level{pkg.Warn}[0],
+		},
+	}
+
+	// Test fallback to linter default when no global rule settings
+	impact := linterSettings.GetRuleImpact("container", "any-rule")
+	if impact == nil {
+		t.Error("Expected impact for container rule, got nil")
+		return
+	}
+	if *impact != pkg.Warn {
+		t.Errorf("Expected impact %v for container rule, got %v", pkg.Warn, *impact)
+	}
+}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -41,29 +41,3 @@ type RuntimeLintersSettings struct {
 type RuntimeRootConfig struct {
 	LintersSettings RuntimeLintersSettings
 }
-
-// GetRuleImpactFunc returns the rule impact function for a specific linter
-func (r *RuntimeLintersSettings) GetRuleImpactFunc(linterID, ruleID string) *pkg.Level {
-	switch linterID {
-	case "container":
-		return r.Container.RuleImpactFunc(linterID, ruleID)
-	case "hooks":
-		return r.Hooks.RuleImpactFunc(linterID, ruleID)
-	case "images":
-		return r.Images.RuleImpactFunc(linterID, ruleID)
-	case "license":
-		return r.License.RuleImpactFunc(linterID, ruleID)
-	case "module":
-		return r.Module.RuleImpactFunc(linterID, ruleID)
-	case "no-cyrillic":
-		return r.NoCyrillic.RuleImpactFunc(linterID, ruleID)
-	case "openapi":
-		return r.OpenAPI.RuleImpactFunc(linterID, ruleID)
-	case "rbac":
-		return r.Rbac.RuleImpactFunc(linterID, ruleID)
-	case "templates":
-		return r.Templates.RuleImpactFunc(linterID, ruleID)
-	default:
-		return nil
-	}
-}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+type RuleImpactFunc func(linterID, ruleID string) *pkg.Level
+
+type RuntimeLinterSettings struct {
+	Impact         *pkg.Level
+	RulesSettings  map[string]RuleSettings
+	RuleImpactFunc RuleImpactFunc
+}
+
+type RuntimeLintersSettings struct {
+	Container  RuntimeLinterSettings
+	Hooks      RuntimeLinterSettings
+	Images     RuntimeLinterSettings
+	License    RuntimeLinterSettings
+	Module     RuntimeLinterSettings
+	NoCyrillic RuntimeLinterSettings
+	OpenAPI    RuntimeLinterSettings
+	Rbac       RuntimeLinterSettings
+	Templates  RuntimeLinterSettings
+}
+
+type RuntimeRootConfig struct {
+	LintersSettings RuntimeLintersSettings
+}
+
+// GetRuleImpactFunc returns the rule impact function for a specific linter
+func (r *RuntimeLintersSettings) GetRuleImpactFunc(linterID, ruleID string) *pkg.Level {
+	switch linterID {
+	case "container":
+		return r.Container.RuleImpactFunc(linterID, ruleID)
+	case "hooks":
+		return r.Hooks.RuleImpactFunc(linterID, ruleID)
+	case "images":
+		return r.Images.RuleImpactFunc(linterID, ruleID)
+	case "license":
+		return r.License.RuleImpactFunc(linterID, ruleID)
+	case "module":
+		return r.Module.RuleImpactFunc(linterID, ruleID)
+	case "no-cyrillic":
+		return r.NoCyrillic.RuleImpactFunc(linterID, ruleID)
+	case "openapi":
+		return r.OpenAPI.RuleImpactFunc(linterID, ruleID)
+	case "rbac":
+		return r.Rbac.RuleImpactFunc(linterID, ruleID)
+	case "templates":
+		return r.Templates.RuleImpactFunc(linterID, ruleID)
+	default:
+		return nil
+	}
+}

--- a/pkg/config/templates_remapper.go
+++ b/pkg/config/templates_remapper.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+func NewTemplatesLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) TemplatesLinterConfig {
+	config := TemplatesLinterConfig{
+		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
+		RulesSettings: make(map[string]RuleConfig),
+		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+	}
+
+	for ruleID, ruleDTO := range userDTO.RulesSettings {
+		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+	}
+	for ruleID, ruleDTO := range globalDTO.RulesSettings {
+		if _, exists := config.RulesSettings[ruleID]; !exists {
+			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
+		}
+	}
+	config.GetRuleImpact = func(ruleID string) *pkg.Level {
+		if rule, exists := config.RulesSettings[ruleID]; exists {
+			return rule.Impact
+		}
+		return config.Impact
+	}
+
+	return config
+}

--- a/pkg/config/templates_remapper.go
+++ b/pkg/config/templates_remapper.go
@@ -1,28 +1,12 @@
 package config
 
-import "github.com/deckhouse/dmt/pkg"
-
 func NewTemplatesLinterConfig(userDTO *UserLinterSettingsDTO, globalDTO *GlobalLinterSettingsDTO) TemplatesLinterConfig {
-	config := TemplatesLinterConfig{
+	rulesSettings, excludeRules, getRuleImpact := newLinterConfig(userDTO, globalDTO)
+
+	return TemplatesLinterConfig{
 		Impact:        mergeImpact(userDTO.Impact, globalDTO.Impact),
-		RulesSettings: make(map[string]RuleConfig),
-		ExcludeRules:  mergeExcludeRules(userDTO.ExcludeRules, globalDTO.ExcludeRules),
+		RulesSettings: rulesSettings,
+		ExcludeRules:  excludeRules,
+		GetRuleImpact: getRuleImpact,
 	}
-
-	for ruleID, ruleDTO := range userDTO.RulesSettings {
-		config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-	}
-	for ruleID, ruleDTO := range globalDTO.RulesSettings {
-		if _, exists := config.RulesSettings[ruleID]; !exists {
-			config.RulesSettings[ruleID] = RuleConfig(ruleDTO)
-		}
-	}
-	config.GetRuleImpact = func(ruleID string) *pkg.Level {
-		if rule, exists := config.RulesSettings[ruleID]; exists {
-			return rule.Impact
-		}
-		return config.Impact
-	}
-
-	return config
 }

--- a/pkg/config/templates_settings.go
+++ b/pkg/config/templates_settings.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/deckhouse/dmt/pkg"
+
+// TemplatesSettings represents templates linter settings
+type TemplatesSettings struct {
+	ExcludeRules      TemplatesExcludeRules        `mapstructure:"exclude-rules"`
+	RulesSettings     map[string]RuleSettings      `mapstructure:"rules-settings"`
+	GrafanaDashboards GrafanaDashboardsExcludeList `mapstructure:"grafana-dashboards"`
+	PrometheusRules   PrometheusRulesExcludeList   `mapstructure:"prometheus-rules"`
+
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+// GetRuleImpact returns the impact level for a specific templates rule
+func (t TemplatesSettings) GetRuleImpact(ruleName string) *pkg.Level {
+	// Check rule-specific settings first
+	if t.RulesSettings != nil {
+		if ruleSettings, exists := t.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
+			return ruleSettings.Impact
+		}
+	}
+	// Fall back to general impact
+	return t.Impact
+}
+
+// TemplatesExcludeRules represents templates-specific exclude rules
+type TemplatesExcludeRules struct {
+	VPAAbsent     KindRuleExcludeList    `mapstructure:"vpa"`
+	PDBAbsent     KindRuleExcludeList    `mapstructure:"pdb"`
+	ServicePort   ServicePortExcludeList `mapstructure:"service-port"`
+	KubeRBACProxy StringRuleExcludeList  `mapstructure:"kube-rbac-proxy"`
+	Ingress       KindRuleExcludeList    `mapstructure:"ingress"`
+}
+
+// GrafanaDashboardsExcludeList represents grafana dashboards exclude list
+type GrafanaDashboardsExcludeList struct {
+	Disable bool `mapstructure:"disable"`
+}
+
+// PrometheusRulesExcludeList represents prometheus rules exclude list
+type PrometheusRulesExcludeList struct {
+	Disable bool `mapstructure:"disable"`
+}

--- a/pkg/config/templates_settings.go
+++ b/pkg/config/templates_settings.go
@@ -36,6 +36,13 @@ func (t *TemplatesSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	return t.Impact
 }
 
+func (t *TemplatesSettings) SetRuleImpact(ruleName string, impact *pkg.Level) {
+	if t.RulesSettings == nil {
+		t.RulesSettings = make(map[string]RuleSettings)
+	}
+	t.RulesSettings[ruleName] = RuleSettings{Impact: impact}
+}
+
 type TemplatesExcludeRules struct {
 	VPAAbsent     KindRuleExcludeList    `mapstructure:"vpa"`
 	PDBAbsent     KindRuleExcludeList    `mapstructure:"pdb"`

--- a/pkg/config/templates_settings.go
+++ b/pkg/config/templates_settings.go
@@ -27,7 +27,7 @@ type TemplatesSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-func (t TemplatesSettings) GetRuleImpact(ruleName string) *pkg.Level {
+func (t *TemplatesSettings) GetRuleImpact(ruleName string) *pkg.Level {
 	if t.RulesSettings != nil {
 		if ruleSettings, exists := t.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact

--- a/pkg/config/templates_settings.go
+++ b/pkg/config/templates_settings.go
@@ -18,7 +18,6 @@ package config
 
 import "github.com/deckhouse/dmt/pkg"
 
-// TemplatesSettings represents templates linter settings
 type TemplatesSettings struct {
 	ExcludeRules      TemplatesExcludeRules        `mapstructure:"exclude-rules"`
 	RulesSettings     map[string]RuleSettings      `mapstructure:"rules-settings"`
@@ -28,19 +27,15 @@ type TemplatesSettings struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 
-// GetRuleImpact returns the impact level for a specific templates rule
 func (t TemplatesSettings) GetRuleImpact(ruleName string) *pkg.Level {
-	// Check rule-specific settings first
 	if t.RulesSettings != nil {
 		if ruleSettings, exists := t.RulesSettings[ruleName]; exists && ruleSettings.Impact != nil {
 			return ruleSettings.Impact
 		}
 	}
-	// Fall back to general impact
 	return t.Impact
 }
 
-// TemplatesExcludeRules represents templates-specific exclude rules
 type TemplatesExcludeRules struct {
 	VPAAbsent     KindRuleExcludeList    `mapstructure:"vpa"`
 	PDBAbsent     KindRuleExcludeList    `mapstructure:"pdb"`
@@ -49,12 +44,10 @@ type TemplatesExcludeRules struct {
 	Ingress       KindRuleExcludeList    `mapstructure:"ingress"`
 }
 
-// GrafanaDashboardsExcludeList represents grafana dashboards exclude list
 type GrafanaDashboardsExcludeList struct {
 	Disable bool `mapstructure:"disable"`
 }
 
-// PrometheusRulesExcludeList represents prometheus rules exclude list
 type PrometheusRulesExcludeList struct {
 	Disable bool `mapstructure:"disable"`
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -197,6 +197,11 @@ func (l *LintRuleErrorsList) add(str string, level pkg.Level) *LintRuleErrorsLis
 		level = *l.maxLevel
 	}
 
+	// Skip adding error if level is Ignored
+	if level == pkg.Ignored {
+		return l
+	}
+
 	e := lintRuleError{
 		LinterID:    strings.ToLower(l.linterID),
 		ModuleID:    l.moduleID,

--- a/pkg/linters/container/container.go
+++ b/pkg/linters/container/container.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
@@ -31,6 +32,7 @@ type Container struct {
 	name, desc string
 	cfg        *config.ContainerSettings
 	ErrorList  *errors.LintRuleErrorsList
+	moduleCfg  *config.ModuleConfig
 }
 
 func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Container {
@@ -39,7 +41,15 @@ func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Contai
 		desc:      "Lint container objects",
 		cfg:       &cfg.LintersSettings.Container,
 		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Container.Impact),
+		moduleCfg: cfg,
 	}
+}
+
+func (l *Container) GetRuleImpact(ruleName string) *pkg.Level {
+	if l.moduleCfg != nil {
+		return l.moduleCfg.LintersSettings.GetRuleImpact(ID, ruleName)
+	}
+	return l.cfg.Impact
 }
 
 func (l *Container) Run(m *module.Module) {

--- a/pkg/linters/container/container_test.go
+++ b/pkg/linters/container/container_test.go
@@ -6,12 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 func TestContainer_NameAndDesc(t *testing.T) {
-	cfg := &config.ModuleConfig{}
+	errorLevel := pkg.Error
+	cfg := &config.ModuleConfig{
+		LintersSettings: &config.LintersSettings{
+			Container: config.ContainerSettings{
+				Impact: &errorLevel,
+			},
+		},
+	}
 	errList := errors.NewLintRuleErrorsList()
 	linter := New(cfg, errList)
 
@@ -20,7 +28,14 @@ func TestContainer_NameAndDesc(t *testing.T) {
 }
 
 func TestContainer_Run_NilModule(_ *testing.T) {
-	cfg := &config.ModuleConfig{}
+	errorLevel := pkg.Error
+	cfg := &config.ModuleConfig{
+		LintersSettings: &config.LintersSettings{
+			Container: config.ContainerSettings{
+				Impact: &errorLevel,
+			},
+		},
+	}
 	errList := errors.NewLintRuleErrorsList()
 	linter := New(cfg, errList)
 
@@ -29,7 +44,14 @@ func TestContainer_Run_NilModule(_ *testing.T) {
 }
 
 func TestContainer_Run_EmptyModule(t *testing.T) {
-	cfg := &config.ModuleConfig{}
+	errorLevel := pkg.Error
+	cfg := &config.ModuleConfig{
+		LintersSettings: &config.LintersSettings{
+			Container: config.ContainerSettings{
+				Impact: &errorLevel,
+			},
+		},
+	}
 	errList := errors.NewLintRuleErrorsList()
 	linter := New(cfg, errList)
 

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/container/rules"
 )
@@ -42,10 +43,10 @@ func (l *Container) applyContainerRules(object storage.StoreObject, errorList *e
 
 	for _, rule := range objectRules {
 		ruleImpact := l.GetRuleImpact(rule.ruleName)
-		if ruleImpact != nil {
+		if ruleImpact != nil && *ruleImpact != pkg.Ignored {
 			ruleErrorList := errorList.WithMaxLevel(ruleImpact)
 			rule.ruleFunc(object, ruleErrorList)
-		} else {
+		} else if ruleImpact == nil {
 			rule.ruleFunc(object, errorList)
 		}
 	}
@@ -79,10 +80,10 @@ func (l *Container) applyContainerRules(object storage.StoreObject, errorList *e
 
 	for _, rule := range containerRules {
 		ruleImpact := l.GetRuleImpact(rule.ruleName)
-		if ruleImpact != nil {
+		if ruleImpact != nil && *ruleImpact != pkg.Ignored {
 			ruleErrorList := errorList.WithMaxLevel(ruleImpact)
 			rule.ruleFunc(object, allContainers, ruleErrorList)
-		} else {
+		} else if ruleImpact == nil {
 			rule.ruleFunc(object, allContainers, errorList)
 		}
 	}
@@ -109,10 +110,10 @@ func (l *Container) applyContainerRules(object storage.StoreObject, errorList *e
 
 	for _, rule := range notInitContainerRules {
 		ruleImpact := l.GetRuleImpact(rule.ruleName)
-		if ruleImpact != nil {
+		if ruleImpact != nil && *ruleImpact != pkg.Ignored {
 			ruleErrorList := errorList.WithMaxLevel(ruleImpact)
 			rule.ruleFunc(object, containers, ruleErrorList)
-		} else {
+		} else if ruleImpact == nil {
 			rule.ruleFunc(object, containers, errorList)
 		}
 	}

--- a/pkg/linters/images/images.go
+++ b/pkg/linters/images/images.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/images/rules"
@@ -32,6 +33,7 @@ type Images struct {
 	name, desc string
 	cfg        *config.ImageSettings
 	ErrorList  *errors.LintRuleErrorsList
+	moduleCfg  *config.ModuleConfig
 }
 
 func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Images {
@@ -40,7 +42,15 @@ func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Images
 		desc:      "Lint docker images",
 		cfg:       &cfg.LintersSettings.Images,
 		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Images.Impact),
+		moduleCfg: cfg,
 	}
+}
+
+func (l *Images) GetRuleImpact(ruleName string) *pkg.Level {
+	if l.moduleCfg != nil {
+		return l.moduleCfg.LintersSettings.GetRuleImpact(ID, ruleName)
+	}
+	return l.cfg.Impact
 }
 
 func (l *Images) Run(m *module.Module) {
@@ -50,10 +60,38 @@ func (l *Images) Run(m *module.Module) {
 
 	errorList := l.ErrorList.WithModule(m.GetName())
 
-	rules.NewImageRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList)
-	rules.NewDistrolessRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList)
-	rules.NewWerfRule(l.cfg.Werf.Disable).LintWerfFile(m.GetName(), m.GetWerfFile(), errorList)
-	rules.NewPatchesRule(l.cfg.Patches.Disable).CheckPatches(m.GetPath(), errorList)
+	// Apply rule-specific impact for each rule
+	imageRuleImpact := l.GetRuleImpact("dockerfile")
+	if imageRuleImpact != nil {
+		imageErrorList := errorList.WithMaxLevel(imageRuleImpact)
+		rules.NewImageRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), imageErrorList)
+	} else {
+		rules.NewImageRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList)
+	}
+
+	distrolessRuleImpact := l.GetRuleImpact("distroless")
+	if distrolessRuleImpact != nil {
+		distrolessErrorList := errorList.WithMaxLevel(distrolessRuleImpact)
+		rules.NewDistrolessRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), distrolessErrorList)
+	} else {
+		rules.NewDistrolessRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList)
+	}
+
+	werfRuleImpact := l.GetRuleImpact("werf")
+	if werfRuleImpact != nil {
+		werfErrorList := errorList.WithMaxLevel(werfRuleImpact)
+		rules.NewWerfRule(l.cfg.Werf.Disable).LintWerfFile(m.GetName(), m.GetWerfFile(), werfErrorList)
+	} else {
+		rules.NewWerfRule(l.cfg.Werf.Disable).LintWerfFile(m.GetName(), m.GetWerfFile(), errorList)
+	}
+
+	patchesRuleImpact := l.GetRuleImpact("patches")
+	if patchesRuleImpact != nil {
+		patchesErrorList := errorList.WithMaxLevel(patchesRuleImpact)
+		rules.NewPatchesRule(l.cfg.Patches.Disable).CheckPatches(m.GetPath(), patchesErrorList)
+	} else {
+		rules.NewPatchesRule(l.cfg.Patches.Disable).CheckPatches(m.GetPath(), errorList)
+	}
 }
 
 func (l *Images) Name() string {

--- a/pkg/linters/module/module.go
+++ b/pkg/linters/module/module.go
@@ -39,7 +39,7 @@ func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Module
 		name:      ID,
 		desc:      "Lint module rules",
 		cfg:       &cfg.LintersSettings.Module,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Module.Impact),
+		ErrorList: errorList.WithLinterID(ID),
 		moduleCfg: cfg,
 	}
 }

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -160,6 +160,10 @@ func (l *Templates) Run(m *module.Module) {
 		registryErrorList := errorList.WithMaxLevel(registryRuleImpact)
 		rules.NewRegistryRule().CheckRegistrySecret(m, registryErrorList)
 	} else {
+		// werf file
+		// The following line is commented out because the Werf rule validation is not currently required.
+		// If needed in the future, uncomment and ensure the rule is properly configured.
+		// rules.NewWerfRule().ValidateWerfTemplates(m, errorList)
 		rules.NewRegistryRule().CheckRegistrySecret(m, errorList)
 	}
 }

--- a/pkg/rule.go
+++ b/pkg/rule.go
@@ -54,6 +54,8 @@ func (r *StringRule) Enabled(str string) bool {
 	return true
 }
 
+type StringRuleExcludeList []StringRuleExclude
+
 type PrefixRule struct {
 	ExcludeRules []PrefixRuleExclude
 }
@@ -81,6 +83,8 @@ func (r *KindRule) Enabled(kind, name string) bool {
 
 	return true
 }
+
+type KindRuleExcludeList []KindRuleExclude
 
 type ContainerRule struct {
 	ExcludeRules []ContainerRuleExclude


### PR DESCRIPTION
## Description

Added support for rule-specific impact configuration at the module level, allowing you to override the severity level (error/warn/ignored) for specific linter rules.

## What's added

### 1. **Rule-specific Impact in Linter Settings**
- Added the `RulesSettings map[string]RuleSettings` field to all linter settings structures
- Added the `GetRuleImpact(ruleName string) *pkg.Level` and `SetRuleImpact(ruleName string, impact *pkg.Level)` methods for all linter settings
- Support for rule-specific impact for all linters: `module`, `container`, `hooks`, `images`, `no-cyrillic`, `openapi`, `rbac`, `templates`

### 2. **Rule Impact Function in Error System**
- Added type `RuleImpactFunc func(linterID, ruleID string) *pkg.Level` in `pkg/errors/errors.go`
- Added the `ruleImpactFunc RuleImpactFunc` field to the `LintRuleErrorsList` structure
- Updated the `add` method to apply rule-specific impact before `maxLevel`

### 3. **Improved error display**
- Updated the emoji display logic in `internal/manager/manager.go`

### 4. DTO/Runtime Architecture Separation

- Added Runtime structures in pkg/config/runtime.go:
`RuntimeRootConfig`, `RuntimeLintersSettings` for execution

- Added remapper functions in pkg/config/remapper.go:
ToRuntime() methods for converting DTO -> Runtime with global settings merging

- Added adapter functions in pkg/config/adapter.go:
ToLintersSettings() for backward compatibility with existing linters

### 5. Configuration Loading Refactoring

- Updated module loading in internal/module/module.go. Now loads configuration using DTO -> Runtime -> Legacy flow
- Proper separation of concerns between data loading and business logic
- Now uses RuleImpactFunc for applying rule-specific impact

### Local module configuration (`dmt-config.yaml` in the module folder):
```yaml
linters-settings:
  module:
    impact: error
    rules-settings:
      definition-file:
        impact: warn
      helmignore:
        impact: warn
      oss:
        impact: ignored
  container:
    impact: error
    rules-settings:
      api-version:
        impact: warn
      image-digest:
        impact: ignored
```

## Tests
| Linter            | No rule | With rule | Waiting for   |
| ------------------ | ---------------- | --------------- | --------------------- |
| object-api-version | 🐒 (error)       | ⚠️ (warning)    | api-version: warn     |
| definition-file    | 🐒 (error)       | ⚠️ (warning)    | definition-file: warn |
| helmignore         | 🐒 (error)       | ⚠️ (warning)    | helmignore: warn      |
| image-digest       | 🐒 (error)       | ignored          | image-digest: ignored |
| oss                | 🐒 (error)       | ignored          | oss: ignored          |
| no specific rules  | 🐒 (error)       | 🐒 (error)      | as in it   |