### PR TITLE
[dmt ]Configuration Architecture Overhaul (feature-flags as a warn level rules)

### DIFF
--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -78,7 +78,7 @@ func runLint(dir string) error {
 	mng.PrintResult()
 
 	metrics.SetDmtInfo()
-	metrics.SetLinterWarningsMetrics(cfg.GlobalSettings)
+	metrics.SetLinterWarningsMetrics(&cfg.GlobalSettings)
 	metrics.SetDmtRuntimeDuration()
 	metrics.SetDmtRuntimeDurationSeconds()
 

--- a/cmd/dmt/main.go
+++ b/cmd/dmt/main.go
@@ -78,7 +78,7 @@ func runLint(dir string) error {
 	mng.PrintResult()
 
 	metrics.SetDmtInfo()
-	metrics.SetLinterWarningsMetrics(&cfg.GlobalSettings)
+	metrics.SetLinterWarningsMetrics(cfg.GlobalSettings)
 	metrics.SetDmtRuntimeDuration()
 	metrics.SetDmtRuntimeDurationSeconds()
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -116,8 +116,6 @@ func (m *Manager) initManager(dir string) *Manager {
 			continue
 		}
 
-		// mdl.MergeRootConfig(m.cfg)
-
 		m.Modules = append(m.Modules, mdl)
 	}
 
@@ -172,14 +170,14 @@ func (m *Manager) Run() {
 
 func getLintersForModule(cfg *pkg.LintersSettings, errList *errors.LintRuleErrorsList) []Linter {
 	return []Linter{
-		openapi.New(cfg, errList),
-		no_cyrillic.New(cfg, errList),
-		container.New(cfg, errList),
-		templates.New(cfg, errList),
-		images.New(cfg.Image, errList),
-		rbac.New(cfg, errList),
-		hooks.New(cfg, errList),
-		moduleLinter.New(cfg, errList),
+		openapi.New(&cfg.OpenAPI, errList),
+		no_cyrillic.New(&cfg.NoCyrillic, errList),
+		container.New(&cfg.Container, errList),
+		templates.New(&cfg.Templates, errList),
+		images.New(&cfg.Image, errList),
+		rbac.New(&cfg.RBAC, errList),
+		hooks.New(&cfg.Hooks, errList),
+		moduleLinter.New(&cfg.Module, errList),
 	}
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -107,7 +107,7 @@ func (m *Manager) initManager(dir string) *Manager {
 			// linting errors are already logged
 			continue
 		}
-		mdl, err := module.NewModule(paths[i], &vals, globalValues, errorList)
+		mdl, err := module.NewModule(paths[i], &vals, globalValues, m.cfg, errorList)
 		if err != nil {
 			errorList.
 				WithFilePath(paths[i]).WithModule(moduleName).
@@ -116,7 +116,7 @@ func (m *Manager) initManager(dir string) *Manager {
 			continue
 		}
 
-		mdl.MergeRootConfig(m.cfg)
+		// mdl.MergeRootConfig(m.cfg)
 
 		m.Modules = append(m.Modules, mdl)
 	}
@@ -170,13 +170,13 @@ func (m *Manager) Run() {
 	wg.Wait()
 }
 
-func getLintersForModule(cfg *config.ModuleConfig, errList *errors.LintRuleErrorsList) []Linter {
+func getLintersForModule(cfg *pkg.LintersSettings, errList *errors.LintRuleErrorsList) []Linter {
 	return []Linter{
 		openapi.New(cfg, errList),
 		no_cyrillic.New(cfg, errList),
 		container.New(cfg, errList),
 		templates.New(cfg, errList),
-		images.New(cfg, errList),
+		images.New(cfg.Image, errList),
 		rbac.New(cfg, errList),
 		hooks.New(cfg, errList),
 		moduleLinter.New(cfg, errList),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -68,7 +68,7 @@ func SetDmtInfo() {
 	})
 }
 
-func SetLinterWarningsMetrics(cfg global.Global) {
+func SetLinterWarningsMetrics(cfg *global.Global) {
 	v := reflect.ValueOf(&cfg.Linters).Elem()
 	for i := range v.NumField() {
 		field := v.Field(i)
@@ -80,7 +80,7 @@ func SetLinterWarningsMetrics(cfg global.Global) {
 				metrics.CounterAdd("dmt_linter_info", 1, prometheus.Labels{
 					"id":     metrics.id,
 					"linter": strings.ToLower(fType.Name),
-					"level":  linterConfig.Impact.String(),
+					"level":  linterConfig.Impact,
 				})
 			}
 		}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -16,9 +16,9 @@ func Test_SetLinterWarningsMetrics_AddsWarningsForAllLinters(t *testing.T) {
 	metrics = GetClient(".")
 	cfg := global.Global{
 		Linters: global.Linters{
-			Container:  global.LinterConfig{Impact: ptr.To(pkg.Warn)},
+			Container:  global.ContainerLinterConfig{},
 			Hooks:      global.LinterConfig{Impact: ptr.To(pkg.Warn)},
-			Images:     global.LinterConfig{Impact: ptr.To(pkg.Warn)},
+			Images:     global.ImagesLinterConfig{},
 			License:    global.LinterConfig{Impact: ptr.To(pkg.Warn)},
 			Module:     global.LinterConfig{Impact: ptr.To(pkg.Warn)},
 			NoCyrillic: global.LinterConfig{Impact: ptr.To(pkg.Warn)},
@@ -27,6 +27,9 @@ func Test_SetLinterWarningsMetrics_AddsWarningsForAllLinters(t *testing.T) {
 			Templates:  global.LinterConfig{Impact: ptr.To(pkg.Warn)},
 		},
 	}
+	cfg.Linters.Container.Impact = ptr.To(pkg.Warn)
+	cfg.Linters.Images.Impact = ptr.To(pkg.Warn)
+
 	SetLinterWarningsMetrics(cfg)
 	num, err := testutil.GatherAndCount(metrics.Gatherer, "dmt_linter_info")
 	require.NoError(t, err)
@@ -50,10 +53,13 @@ func Test_SetLinterWarningsMetrics_AddsWarningsForSpecificLinters(t *testing.T) 
 	metrics = GetClient(".")
 	cfg := global.Global{
 		Linters: global.Linters{
-			Container: global.LinterConfig{Impact: ptr.To(pkg.Warn)},
+			Container: global.ContainerLinterConfig{},
 			Hooks:     global.LinterConfig{Impact: nil},
 		},
 	}
+
+	cfg.Linters.Container.Impact = ptr.To(pkg.Warn)
+
 	SetLinterWarningsMetrics(cfg)
 	num, err := testutil.GatherAndCount(metrics.Gatherer, "dmt_linter_info")
 	require.NoError(t, err)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -26,6 +26,7 @@ func Test_SetLinterWarningsMetrics_AddsWarningsForAllLinters(t *testing.T) {
 			Templates:  global.LinterConfig{Impact: pkg.Warn.String()},
 		},
 	}
+
 	cfg.Linters.Container.Impact = pkg.Warn.String()
 	cfg.Linters.Images.Impact = pkg.Warn.String()
 
@@ -53,7 +54,7 @@ func Test_SetLinterWarningsMetrics_AddsWarningsForSpecificLinters(t *testing.T) 
 	cfg := &global.Global{
 		Linters: global.Linters{
 			Container: global.ContainerLinterConfig{},
-			Hooks:     global.LinterConfig{Impact: ""},
+			Hooks:     global.LinterConfig{},
 		},
 	}
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config/global"
@@ -14,21 +13,21 @@ import (
 func Test_SetLinterWarningsMetrics_AddsWarningsForAllLinters(t *testing.T) {
 	metrics = nil
 	metrics = GetClient(".")
-	cfg := global.Global{
+	cfg := &global.Global{
 		Linters: global.Linters{
 			Container:  global.ContainerLinterConfig{},
-			Hooks:      global.LinterConfig{Impact: ptr.To(pkg.Warn)},
+			Hooks:      global.LinterConfig{Impact: pkg.Warn.String()},
 			Images:     global.ImagesLinterConfig{},
-			License:    global.LinterConfig{Impact: ptr.To(pkg.Warn)},
-			Module:     global.LinterConfig{Impact: ptr.To(pkg.Warn)},
-			NoCyrillic: global.LinterConfig{Impact: ptr.To(pkg.Warn)},
-			OpenAPI:    global.LinterConfig{Impact: ptr.To(pkg.Warn)},
-			Rbac:       global.LinterConfig{Impact: ptr.To(pkg.Warn)},
-			Templates:  global.LinterConfig{Impact: ptr.To(pkg.Warn)},
+			License:    global.LinterConfig{Impact: pkg.Warn.String()},
+			Module:     global.LinterConfig{Impact: pkg.Warn.String()},
+			NoCyrillic: global.LinterConfig{Impact: pkg.Warn.String()},
+			OpenAPI:    global.LinterConfig{Impact: pkg.Warn.String()},
+			Rbac:       global.LinterConfig{Impact: pkg.Warn.String()},
+			Templates:  global.LinterConfig{Impact: pkg.Warn.String()},
 		},
 	}
-	cfg.Linters.Container.Impact = ptr.To(pkg.Warn)
-	cfg.Linters.Images.Impact = ptr.To(pkg.Warn)
+	cfg.Linters.Container.Impact = pkg.Warn.String()
+	cfg.Linters.Images.Impact = pkg.Warn.String()
 
 	SetLinterWarningsMetrics(cfg)
 	num, err := testutil.GatherAndCount(metrics.Gatherer, "dmt_linter_info")
@@ -39,7 +38,7 @@ func Test_SetLinterWarningsMetrics_AddsWarningsForAllLinters(t *testing.T) {
 func Test_SetLinterWarningsMetrics_NoWarningsWhenNoLinters(t *testing.T) {
 	metrics = nil
 	metrics = GetClient(".")
-	cfg := global.Global{
+	cfg := &global.Global{
 		Linters: global.Linters{},
 	}
 	SetLinterWarningsMetrics(cfg)
@@ -51,14 +50,14 @@ func Test_SetLinterWarningsMetrics_NoWarningsWhenNoLinters(t *testing.T) {
 func Test_SetLinterWarningsMetrics_AddsWarningsForSpecificLinters(t *testing.T) {
 	metrics = nil
 	metrics = GetClient(".")
-	cfg := global.Global{
+	cfg := &global.Global{
 		Linters: global.Linters{
 			Container: global.ContainerLinterConfig{},
-			Hooks:     global.LinterConfig{Impact: nil},
+			Hooks:     global.LinterConfig{Impact: ""},
 		},
 	}
 
-	cfg.Linters.Container.Impact = ptr.To(pkg.Warn)
+	cfg.Linters.Container.Impact = pkg.Warn.String()
 
 	SetLinterWarningsMetrics(cfg)
 	num, err := testutil.GatherAndCount(metrics.Gatherer, "dmt_linter_info")

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -5,7 +5,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apa	linterSettings.NoCyrillic.ExcludeRules.Files = pkg.StringRuleExcludeList(configSettings.NoCyrillic.NoCyrillicExcludeRules.Files)
+	linterSettings.NoCyrillic.ExcludeRules.Directories = pkg.PrefixRuleExcludeList(configSettings.NoCyrillic.NoCyrillicExcludeRules.Directories)e.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,6 +35,7 @@ import (
 	"github.com/deckhouse/dmt/internal/werf"
 	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg/config/global"
 	dmtErrors "github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -134,9 +136,10 @@ func (m *Module) GetModuleConfig() *pkg.LintersSettings {
 	return m.linterConfig
 }
 
-func RemapLinterSettings(configSettings *config.LintersSettings) *pkg.LintersSettings {
+func remapLinterSettings(configSettings *config.LintersSettings, globalConfig *global.Linters) *pkg.LintersSettings {
 	linterSettings := &pkg.LintersSettings{}
 
+	// Set linter-level impact levels
 	linterSettings.Container.SetLevel(configSettings.Container.Impact)
 	linterSettings.Image.SetLevel(configSettings.Images.Impact)
 	linterSettings.NoCyrillic.SetLevel(configSettings.NoCyrillic.Impact)
@@ -146,11 +149,111 @@ func RemapLinterSettings(configSettings *config.LintersSettings) *pkg.LintersSet
 	linterSettings.Hooks.SetLevel(configSettings.Hooks.Impact)
 	linterSettings.Module.SetLevel(configSettings.Module.Impact)
 
-	linterSettings.Image.Rules.DistrolessRule.SetLevel(configSettings.Images.Rules.DistrolessRule.Impact, configSettings.Images.Impact)
-	linterSettings.Image.Rules.ImageRule.SetLevel(configSettings.Images.Rules.ImageRule.Impact, configSettings.Images.Impact)
-	linterSettings.Image.Rules.PatchesRule.SetLevel(configSettings.Images.Rules.PatchesRule.Impact, configSettings.Images.Impact)
-	linterSettings.Image.Rules.WerfRule.SetLevel(configSettings.Images.Rules.WerfRule.Impact, configSettings.Images.Impact)
-	linterSettings.Container.Rules.RecommendedLabelsRule.SetLevel(configSettings.Container.RecommendedLabelsRule.Impact, configSettings.Container.Impact)
+	// Container linter rules
+	linterSettings.Container.Rules.RecommendedLabelsRule.SetLevel(globalConfig.Container.RecommendedLabelsRule.Impact, configSettings.Container.Impact)
+
+	// Image linter rules
+	linterSettings.Image.Rules.DistrolessRule.SetLevel(globalConfig.Images.Rules.DistrolessRule.Impact, configSettings.Images.Impact)
+	linterSettings.Image.Rules.ImageRule.SetLevel(globalConfig.Images.Rules.ImageRule.Impact, configSettings.Images.Impact)
+	linterSettings.Image.Rules.PatchesRule.SetLevel(globalConfig.Images.Rules.PatchesRule.Impact, configSettings.Images.Impact)
+	linterSettings.Image.Rules.WerfRule.SetLevel(globalConfig.Images.Rules.WerfRule.Impact, configSettings.Images.Impact)
+
+	// NoCyrillic linter rules
+	linterSettings.NoCyrillic.Rules.NoCyrillicRule.SetLevel("", configSettings.NoCyrillic.Impact)
+
+	// OpenAPI linter rules
+	linterSettings.OpenAPI.Rules.EnumRule.SetLevel("", configSettings.OpenAPI.Impact)
+	linterSettings.OpenAPI.Rules.HARule.SetLevel("", configSettings.OpenAPI.Impact)
+	linterSettings.OpenAPI.Rules.CRDsRule.SetLevel("", configSettings.OpenAPI.Impact)
+	linterSettings.OpenAPI.Rules.KeysRule.SetLevel("", configSettings.OpenAPI.Impact)
+
+	// Templates linter rules
+	linterSettings.Templates.Rules.VPARule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.PDBRule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.IngressRule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.PrometheusRule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.GrafanaRule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.KubeRBACProxyRule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.ServicePortRule.SetLevel("", configSettings.Templates.Impact)
+	linterSettings.Templates.Rules.ClusterDomainRule.SetLevel("", configSettings.Templates.Impact)
+
+	// RBAC linter rules
+	linterSettings.RBAC.Rules.UserAuthRule.SetLevel("", configSettings.Rbac.Impact)
+	linterSettings.RBAC.Rules.BindingRule.SetLevel("", configSettings.Rbac.Impact)
+	linterSettings.RBAC.Rules.PlacementRule.SetLevel("", configSettings.Rbac.Impact)
+	linterSettings.RBAC.Rules.WildcardsRule.SetLevel("", configSettings.Rbac.Impact)
+
+	// Hooks linter rules
+	linterSettings.Hooks.Rules.HooksRule.SetLevel("", configSettings.Hooks.Impact)
+
+	// Module linter rules
+	linterSettings.Module.Rules.DefinitionFileRule.SetLevel("", configSettings.Module.Impact)
+	linterSettings.Module.Rules.OSSRule.SetLevel("", configSettings.Module.Impact)
+	linterSettings.Module.Rules.ConversionRule.SetLevel("", configSettings.Module.Impact)
+	linterSettings.Module.Rules.HelmignoreRule.SetLevel("", configSettings.Module.Impact)
+	linterSettings.Module.Rules.LicenseRule.SetLevel("", configSettings.Module.Impact)
+	linterSettings.Module.Rules.RequarementsRule.SetLevel("", configSettings.Module.Impact)
+
+	// Exclude Rules Mapping
+	// Container exclude rules
+	linterSettings.Container.ExcludeRules.ControllerSecurityContext = configSettings.Container.ExcludeRules.ControllerSecurityContext.Get()
+	linterSettings.Container.ExcludeRules.DNSPolicy = configSettings.Container.ExcludeRules.DNSPolicy.Get()
+	linterSettings.Container.ExcludeRules.HostNetworkPorts = configSettings.Container.ExcludeRules.HostNetworkPorts.Get()
+	linterSettings.Container.ExcludeRules.Ports = configSettings.Container.ExcludeRules.Ports.Get()
+	linterSettings.Container.ExcludeRules.ReadOnlyRootFilesystem = configSettings.Container.ExcludeRules.ReadOnlyRootFilesystem.Get()
+	linterSettings.Container.ExcludeRules.ImageDigest = configSettings.Container.ExcludeRules.ImageDigest.Get()
+	linterSettings.Container.ExcludeRules.Resources = configSettings.Container.ExcludeRules.Resources.Get()
+	linterSettings.Container.ExcludeRules.SecurityContext = configSettings.Container.ExcludeRules.SecurityContext.Get()
+	linterSettings.Container.ExcludeRules.Liveness = configSettings.Container.ExcludeRules.Liveness.Get()
+	linterSettings.Container.ExcludeRules.Readiness = configSettings.Container.ExcludeRules.Readiness.Get()
+	linterSettings.Container.ExcludeRules.Description = pkg.StringRuleExcludeList(configSettings.Container.ExcludeRules.Description)
+
+	// Image exclude rules
+	linterSettings.Image.ExcludeRules.SkipImageFilePathPrefix = pkg.PrefixRuleExcludeList(configSettings.Images.ExcludeRules.SkipImageFilePathPrefix)
+	linterSettings.Image.ExcludeRules.SkipDistrolessFilePathPrefix = pkg.PrefixRuleExcludeList(configSettings.Images.ExcludeRules.SkipDistrolessFilePathPrefix)
+
+	// Image settings
+	linterSettings.Image.Patches.Disable = configSettings.Images.Patches.Disable
+	linterSettings.Image.Werf.Disable = configSettings.Images.Werf.Disable
+
+	// NoCyrillic exclude rules
+	linterSettings.NoCyrillic.ExcludeRules.Files = pkg.StringRuleExcludeList(configSettings.NoCyrillic.NoCyrillicExcludeRules.Files)
+	linterSettings.NoCyrillic.ExcludeRules.Directories = pkg.PrefixRuleExcludeList(configSettings.NoCyrillic.NoCyrillicExcludeRules.Directories)
+
+	// OpenAPI exclude rules
+	linterSettings.OpenAPI.ExcludeRules.KeyBannedNames = configSettings.OpenAPI.OpenAPIExcludeRules.KeyBannedNames
+	linterSettings.OpenAPI.ExcludeRules.EnumFileExcludes = configSettings.OpenAPI.OpenAPIExcludeRules.EnumFileExcludes
+	linterSettings.OpenAPI.ExcludeRules.HAAbsoluteKeysExcludes = pkg.StringRuleExcludeList(configSettings.OpenAPI.OpenAPIExcludeRules.HAAbsoluteKeysExcludes)
+	linterSettings.OpenAPI.ExcludeRules.CRDNamesExcludes = pkg.StringRuleExcludeList(configSettings.OpenAPI.OpenAPIExcludeRules.CRDNamesExcludes)
+
+	// Templates exclude rules
+	linterSettings.Templates.ExcludeRules.VPAAbsent = configSettings.Templates.ExcludeRules.VPAAbsent.Get()
+	linterSettings.Templates.ExcludeRules.PDBAbsent = configSettings.Templates.ExcludeRules.PDBAbsent.Get()
+	linterSettings.Templates.ExcludeRules.ServicePort = configSettings.Templates.ExcludeRules.ServicePort.Get()
+	linterSettings.Templates.ExcludeRules.KubeRBACProxy = pkg.StringRuleExcludeList(configSettings.Templates.ExcludeRules.KubeRBACProxy)
+	linterSettings.Templates.ExcludeRules.Ingress = configSettings.Templates.ExcludeRules.Ingress.Get()
+
+	// Templates settings
+	linterSettings.Templates.PrometheusRuleSettings.Disable = configSettings.Templates.PrometheusRules.Disable
+	linterSettings.Templates.GrafanaDashboardsSettings.Disable = configSettings.Templates.GrafanaDashboards.Disable
+
+	// RBAC exclude rules
+	linterSettings.RBAC.ExcludeRules.BindingSubject = pkg.StringRuleExcludeList(configSettings.Rbac.ExcludeRules.BindingSubject)
+	linterSettings.RBAC.ExcludeRules.Placement = configSettings.Rbac.ExcludeRules.Placement.Get()
+	linterSettings.RBAC.ExcludeRules.Wildcards = configSettings.Rbac.ExcludeRules.Wildcards.Get()
+
+	// Hooks settings
+	linterSettings.Hooks.IngressRuleSettings.Disable = configSettings.Hooks.Ingress.Disable
+
+	// Module exclude rules
+	linterSettings.Module.ExcludeRules.License.Files = pkg.StringRuleExcludeList(configSettings.Module.ExcludeRules.License.Files)
+	linterSettings.Module.ExcludeRules.License.Directories = pkg.PrefixRuleExcludeList(configSettings.Module.ExcludeRules.License.Directories)
+
+	// Module settings
+	linterSettings.Module.OSSRuleSettings.Disable = configSettings.Module.OSS.Disable
+	linterSettings.Module.DefinitionFileRuleSettings.Disable = configSettings.Module.DefinitionFile.Disable
+	linterSettings.Module.ConversionsRuleSettings.Disable = configSettings.Module.Conversions.Disable
+	linterSettings.Module.HelmignoreRuleSettings.Disable = configSettings.Module.Helmignore.Disable
 
 	return linterSettings
 }
@@ -193,7 +296,7 @@ func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, r
 
 	cfg.LintersSettings.MergeGlobal(&rootConfig.GlobalSettings.Linters)
 
-	module.linterConfig = RemapLinterSettings(&cfg.LintersSettings)
+	module.linterConfig = remapLinterSettings(&cfg.LintersSettings, &rootConfig.GlobalSettings.Linters)
 
 	return module, nil
 }

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -135,32 +135,16 @@ func (m *Module) GetModuleConfig() *pkg.LintersSettings {
 }
 
 func RemapLinterSettings(configSettings *config.LintersSettings) *pkg.LintersSettings {
-	linterSettings := &pkg.LintersSettings{
-		Container: pkg.ContainerLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.Container.Impact},
-		},
-		Image: pkg.ImageLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.Images.Impact},
-		},
-		NoCyrillic: pkg.NoCyrillicLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.NoCyrillic.Impact},
-		},
-		OpenAPI: pkg.OpenAPILinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.OpenAPI.Impact},
-		},
-		Templates: pkg.TemplatesLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.Templates.Impact},
-		},
-		RBAC: pkg.RBACLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.Rbac.Impact},
-		},
-		Hooks: pkg.HooksLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.Hooks.Impact},
-		},
-		Module: pkg.ModuleLinterConfig{
-			LinterConfig: pkg.LinterConfig{Impact: configSettings.Module.Impact},
-		},
-	}
+	linterSettings := &pkg.LintersSettings{}
+
+	linterSettings.Container.SetLevel(configSettings.Container.Impact)
+	linterSettings.Image.SetLevel(configSettings.Images.Impact)
+	linterSettings.NoCyrillic.SetLevel(configSettings.NoCyrillic.Impact)
+	linterSettings.OpenAPI.SetLevel(configSettings.OpenAPI.Impact)
+	linterSettings.Templates.SetLevel(configSettings.Templates.Impact)
+	linterSettings.RBAC.SetLevel(configSettings.Rbac.Impact)
+	linterSettings.Hooks.SetLevel(configSettings.Hooks.Impact)
+	linterSettings.Module.SetLevel(configSettings.Module.Impact)
 
 	linterSettings.Image.Rules.DistrolessRule.SetLevel(configSettings.Images.Rules.DistrolessRule.Impact, configSettings.Images.Impact)
 	linterSettings.Image.Rules.ImageRule.SetLevel(configSettings.Images.Rules.ImageRule.Impact, configSettings.Images.Impact)

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -135,17 +135,12 @@ func (m *Module) GetModuleConfig() *pkg.LintersSettings {
 }
 
 func RemapLinterSettings(configSettings *config.LintersSettings) *pkg.LintersSettings {
-	return &pkg.LintersSettings{
+	linterSettings := &pkg.LintersSettings{
 		Container: pkg.ContainerLinterConfig{
 			LinterConfig: pkg.LinterConfig{Impact: configSettings.Container.Impact},
 		},
 		Image: pkg.ImageLinterConfig{
 			LinterConfig: pkg.LinterConfig{Impact: configSettings.Images.Impact},
-			Rules: pkg.ImageLinterRules{
-				DistrolessRule: pkg.RuleConfig{
-					impact: configSettings.Images.Rules.DistrolessRule.Impact,
-				},
-			},
 		},
 		NoCyrillic: pkg.NoCyrillicLinterConfig{
 			LinterConfig: pkg.LinterConfig{Impact: configSettings.NoCyrillic.Impact},
@@ -166,6 +161,14 @@ func RemapLinterSettings(configSettings *config.LintersSettings) *pkg.LintersSet
 			LinterConfig: pkg.LinterConfig{Impact: configSettings.Module.Impact},
 		},
 	}
+
+	linterSettings.Image.Rules.DistrolessRule.SetLevel(configSettings.Images.Rules.DistrolessRule.Impact)
+	linterSettings.Image.Rules.ImageRule.SetLevel(configSettings.Images.Rules.ImageRule.Impact)
+	linterSettings.Image.Rules.PatchesRule.SetLevel(configSettings.Images.Rules.PatchesRule.Impact)
+	linterSettings.Image.Rules.WerfRule.SetLevel(configSettings.Images.Rules.WerfRule.Impact)
+	linterSettings.Container.Rules.RecommendedLabelsRule.SetLevel(configSettings.Container.RecommendedLabelsRule.Impact)
+
+	return linterSettings
 }
 
 func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, rootConfig *config.RootConfig, errorList *dmtErrors.LintRuleErrorsList) (*Module, error) {

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -32,6 +32,7 @@ import (
 	"github.com/deckhouse/dmt/internal/storage"
 	"github.com/deckhouse/dmt/internal/values"
 	"github.com/deckhouse/dmt/internal/werf"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
 	dmtErrors "github.com/deckhouse/dmt/pkg/errors"
 )
@@ -49,7 +50,7 @@ type Module struct {
 	objectStore *storage.UnstructuredObjectStore
 	werfFile    string
 
-	linterConfig *config.ModuleConfig
+	linterConfig *pkg.LintersSettings
 }
 
 type ModuleList []*Module
@@ -126,7 +127,7 @@ func (m *Module) GetWerfFile() string {
 	return m.werfFile
 }
 
-func (m *Module) GetModuleConfig() *config.ModuleConfig {
+func (m *Module) GetModuleConfig() *pkg.LintersSettings {
 	if m == nil {
 		return nil
 	}
@@ -137,7 +138,7 @@ func (m *Module) MergeRootConfig(cfg *config.RootConfig) {
 	m.linterConfig.LintersSettings.MergeGlobal(&cfg.GlobalSettings.Linters)
 }
 
-func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, errorList *dmtErrors.LintRuleErrorsList) (*Module, error) {
+func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, rootConfig *config.RootConfig, errorList *dmtErrors.LintRuleErrorsList) (*Module, error) {
 	module, err := newModuleFromPath(path)
 	if err != nil {
 		return nil, err
@@ -172,7 +173,11 @@ func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, e
 		return nil, fmt.Errorf("can not parse module config: %w", err)
 	}
 
-	module.linterConfig = cfg
+	// merge with root config
+	// remap to linters config
+	// mergedConfig:= MergeRootConfig(m.cfg)
+
+	module.linterConfig = // remapConfigToLintersSettings(mergedConfig)
 
 	return module, nil
 }

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -162,11 +162,11 @@ func RemapLinterSettings(configSettings *config.LintersSettings) *pkg.LintersSet
 		},
 	}
 
-	linterSettings.Image.Rules.DistrolessRule.SetLevel(configSettings.Images.Rules.DistrolessRule.Impact)
-	linterSettings.Image.Rules.ImageRule.SetLevel(configSettings.Images.Rules.ImageRule.Impact)
-	linterSettings.Image.Rules.PatchesRule.SetLevel(configSettings.Images.Rules.PatchesRule.Impact)
-	linterSettings.Image.Rules.WerfRule.SetLevel(configSettings.Images.Rules.WerfRule.Impact)
-	linterSettings.Container.Rules.RecommendedLabelsRule.SetLevel(configSettings.Container.RecommendedLabelsRule.Impact)
+	linterSettings.Image.Rules.DistrolessRule.SetLevel(configSettings.Images.Rules.DistrolessRule.Impact, configSettings.Images.Impact)
+	linterSettings.Image.Rules.ImageRule.SetLevel(configSettings.Images.Rules.ImageRule.Impact, configSettings.Images.Impact)
+	linterSettings.Image.Rules.PatchesRule.SetLevel(configSettings.Images.Rules.PatchesRule.Impact, configSettings.Images.Impact)
+	linterSettings.Image.Rules.WerfRule.SetLevel(configSettings.Images.Rules.WerfRule.Impact, configSettings.Images.Impact)
+	linterSettings.Container.Rules.RecommendedLabelsRule.SetLevel(configSettings.Container.RecommendedLabelsRule.Impact, configSettings.Container.Impact)
 
 	return linterSettings
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -12,8 +12,22 @@ func (rc *RuleConfig) GetLevel() *Level {
 	return rc.impact
 }
 
-func (rc *RuleConfig) SetLevel(level *Level) {
-	rc.impact = level
+func (rc *RuleConfig) SetLevel(level, backoff *Level) {
+	if level != nil {
+		rc.impact = level
+
+		return
+	}
+
+	if backoff != nil {
+		rc.impact = backoff
+
+		return
+	}
+
+	lvl := Error
+	rc.impact = &lvl
+
 }
 
 func (rc *RuleConfig) SetStringLevel(current, backoff string) {
@@ -37,16 +51,6 @@ func (rc *RuleConfig) SetStringLevel(current, backoff string) {
 
 func (lc *LinterConfig) SetLevel(level *Level) {
 	lc.Impact = level
-}
-
-func (clc *ContainerLinterConfig) GetRuleImpact(ruleID string) *Level {
-	switch ruleID {
-	case "recommended-labels":
-		if level := clc.Rules.RecommendedLabelsRule.GetLevel(); level != nil {
-			return level
-		}
-	}
-	return clc.Impact
 }
 
 type LintersSettings struct {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,5 +1,7 @@
 package pkg
 
+import "github.com/deckhouse/dmt/pkg"
+
 type LinterConfig struct {
 	Impact *Level
 }
@@ -14,6 +16,22 @@ func (rc *RuleConfig) GetLevel() *Level {
 
 func (rc *RuleConfig) SetLevel(level *Level) {
 	rc.impact = level
+}
+
+func (rc *RuleConfig) SetStringLevel(current, backoff string) {
+	if current != "" {
+		rc.impact = pkg.ParseStringToLevel(current)
+
+		return
+	}
+
+	if backoff != "" {
+		rc.impact = pkg.ParseStringToLevel(backoff)
+
+		return
+	}
+
+	rc.impact = pkg.Error
 }
 
 func (lc *LinterConfig) SetLevel(level *Level) {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,0 +1,141 @@
+package pkg
+
+type LinterConfig struct {
+	Impact *Level
+}
+
+type RuleConfig struct {
+	impact *Level
+}
+
+func (rc *RuleConfig) GetLevel() *Level {
+	return rc.impact
+}
+
+func (rc *RuleConfig) SetLevel(level *Level) {
+	rc.impact = level
+}
+
+func (lc *LinterConfig) SetLevel(level *Level) {
+	lc.Impact = level
+}
+
+func (ilc *ImageLinterConfig) GetRuleImpact(ruleID string) *Level {
+	switch ruleID {
+	case "distroless":
+		if level := ilc.Rules.DistrolessRule.GetLevel(); level != nil {
+			return level
+		}
+	case "image":
+		if level := ilc.Rules.ImageRule.GetLevel(); level != nil {
+			return level
+		}
+	case "patches":
+		if level := ilc.Rules.PatchesRule.GetLevel(); level != nil {
+			return level
+		}
+	case "werf":
+		if level := ilc.Rules.WerfRule.GetLevel(); level != nil {
+			return level
+		}
+	}
+	return ilc.Impact
+}
+
+func (clc *ContainerLinterConfig) GetRuleImpact(ruleID string) *Level {
+	switch ruleID {
+	case "recommended-labels":
+		if level := clc.Rules.RecommendedLabelsRule.GetLevel(); level != nil {
+			return level
+		}
+	}
+	return clc.Impact
+}
+
+type LintersSettings struct {
+	Container ContainerLinterConfig
+	Image     ImageLinterConfig
+}
+
+type ContainerLinterConfig struct {
+	LinterConfig
+	Rules        ContainerLinterRules
+	ExcludeRules ContainerExcludeRules
+}
+
+type ImageLinterConfig struct {
+	LinterConfig
+	Rules        ImageLinterRules
+	ExcludeRules ImageExcludeRules
+	Patches      PatchesRuleSettings
+	Werf         WerfRuleSettings
+}
+
+type PatchesRuleSettings struct {
+	Disable bool
+}
+
+type WerfRuleSettings struct {
+	Disable bool
+}
+
+type ImageLinterRules struct {
+	DistrolessRule RuleConfig
+	ImageRule      RuleConfig
+	PatchesRule    RuleConfig
+	WerfRule       RuleConfig
+}
+
+type ImageExcludeRules struct {
+}
+
+type ContainerLinterRules struct {
+	RecommendedLabelsRule RuleConfig
+}
+
+type ContainerExcludeRules struct {
+	ControllerSecurityContext KindRuleExcludeList
+	DNSPolicy                 KindRuleExcludeList
+
+	HostNetworkPorts       ContainerRuleExcludeList
+	Ports                  ContainerRuleExcludeList
+	ReadOnlyRootFilesystem ContainerRuleExcludeList
+	ImageDigest            ContainerRuleExcludeList
+	Resources              ContainerRuleExcludeList
+	SecurityContext        ContainerRuleExcludeList
+	Liveness               ContainerRuleExcludeList
+	Readiness              ContainerRuleExcludeList
+
+	Description StringRuleExcludeList
+}
+
+type StringRuleExcludeList []string
+
+func (l StringRuleExcludeList) Get() []StringRuleExclude {
+	result := make([]StringRuleExclude, 0, len(l))
+	for idx := range l {
+		result = append(result, StringRuleExclude(l[idx]))
+	}
+	return result
+}
+
+type KindRuleExcludeList []KindRuleExclude
+
+func (l KindRuleExcludeList) Get() []KindRuleExclude {
+	result := make([]KindRuleExclude, 0, len(l))
+	for idx := range l {
+		result = append(result, l[idx])
+	}
+	return result
+}
+
+// ContainerRuleExcludeList represents a list of container exclusions
+type ContainerRuleExcludeList []ContainerRuleExclude
+
+func (l ContainerRuleExcludeList) Get() []ContainerRuleExclude {
+	result := make([]ContainerRuleExclude, 0, len(l))
+	for idx := range l {
+		result = append(result, l[idx])
+	}
+	return result
+}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -4,6 +4,18 @@ type LinterConfig struct {
 	Impact *Level
 }
 
+func (rc *LinterConfig) SetLevel(level string) {
+	if level != "" {
+		impact := ParseStringToLevel(level)
+		rc.Impact = &impact
+
+		return
+	}
+
+	lvl := Error
+	rc.Impact = &lvl
+}
+
 type RuleConfig struct {
 	impact *Level
 }
@@ -12,22 +24,23 @@ func (rc *RuleConfig) GetLevel() *Level {
 	return rc.impact
 }
 
-func (rc *RuleConfig) SetLevel(level, backoff *Level) {
-	if level != nil {
-		rc.impact = level
+func (rc *RuleConfig) SetLevel(level, backoff string) {
+	if level != "" {
+		impact := ParseStringToLevel(level)
+		rc.impact = &impact
 
 		return
 	}
 
-	if backoff != nil {
-		rc.impact = backoff
+	if backoff != "" {
+		impact := ParseStringToLevel(level)
+		rc.impact = &impact
 
 		return
 	}
 
 	lvl := Error
 	rc.impact = &lvl
-
 }
 
 func (rc *RuleConfig) SetStringLevel(current, backoff string) {
@@ -47,10 +60,6 @@ func (rc *RuleConfig) SetStringLevel(current, backoff string) {
 
 	level := Error
 	rc.impact = &level
-}
-
-func (lc *LinterConfig) SetLevel(level *Level) {
-	lc.Impact = level
 }
 
 type LintersSettings struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ import (
 
 // RootConfig encapsulates the config data specified in the YAML config file.
 type RootConfig struct {
-	GlobalSettings global.Global `mapstructure:"global"`
+	GlobalSettings *global.Global `mapstructure:"global"`
 }
 
 type ModuleConfig struct {
@@ -45,7 +45,9 @@ func calculateImpact(backoff, input string) string {
 }
 
 func NewDefaultRootConfig(dir string) (*RootConfig, error) {
-	cfg := &RootConfig{}
+	cfg := &RootConfig{
+		GlobalSettings: &global.Global{},
+	}
 
 	if err := NewLoader(cfg, dir).Load(); err != nil {
 		return nil, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,18 +30,18 @@ type ModuleConfig struct {
 	LintersSettings LintersSettings `mapstructure:"linters-settings"`
 }
 
-func calculateImpact(v, input *pkg.Level) *pkg.Level {
-	if input != nil {
-		return input
+func calculateImpact(backoff, input string) string {
+	if backoff != "" {
+		return backoff
 	}
 
-	if v != nil {
-		return v
+	if input != "" {
+		return input
 	}
 
 	lvl := pkg.Error
 
-	return &lvl
+	return lvl.String()
 }
 
 func NewDefaultRootConfig(dir string) (*RootConfig, error) {

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -23,18 +23,39 @@ type Global struct {
 }
 
 type Linters struct {
-	Container  LinterConfig `mapstructure:"container"`
-	Hooks      LinterConfig `mapstructure:"hooks"`
-	Images     LinterConfig `mapstructure:"images"`
-	License    LinterConfig `mapstructure:"license"`
-	Module     LinterConfig `mapstructure:"module"`
-	NoCyrillic LinterConfig `mapstructure:"no-cyrillic"`
-	OpenAPI    LinterConfig `mapstructure:"openapi"`
-	Rbac       LinterConfig `mapstructure:"rbac"`
-	Templates  LinterConfig `mapstructure:"templates"`
+	Container  ContainerLinterConfig `mapstructure:"container"`
+	Hooks      LinterConfig          `mapstructure:"hooks"`
+	Images     ImagesLinterConfig    `mapstructure:"images"`
+	License    LinterConfig          `mapstructure:"license"`
+	Module     LinterConfig          `mapstructure:"module"`
+	NoCyrillic LinterConfig          `mapstructure:"no-cyrillic"`
+	OpenAPI    LinterConfig          `mapstructure:"openapi"`
+	Rbac       LinterConfig          `mapstructure:"rbac"`
+	Templates  LinterConfig          `mapstructure:"templates"`
 }
 
 type LinterConfig struct {
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
+type ContainerLinterConfig struct {
+	LinterConfig
+	RecommendedLabelsRule RuleConfig `mapstructure:"recommended-labels"`
+}
+
+type ImagesLinterConfig struct {
+	LinterConfig
+	Rules Rules `mapstructure:"rules"`
+}
+
+type Rules struct {
+	DistrolessRule RuleConfig `mapstructure:"distroless"`
+	ImageRule      RuleConfig `mapstructure:"image"`
+	PatchesRule    RuleConfig `mapstructure:"patches"`
+	WerfRule       RuleConfig `mapstructure:"werf"`
+}
+
+type RuleConfig struct {
 	Impact *pkg.Level `mapstructure:"impact"`
 }
 

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -35,7 +35,7 @@ type Linters struct {
 }
 
 type LinterConfig struct {
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type ContainerLinterConfig struct {
@@ -56,9 +56,9 @@ type Rules struct {
 }
 
 type RuleConfig struct {
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 func (c LinterConfig) IsWarn() bool {
-	return c.Impact != nil && *c.Impact == pkg.Warn
+	return c.Impact == pkg.Warn.String()
 }

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -33,7 +33,7 @@ type LintersSettings struct {
 }
 
 type RuleConfig struct {
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 func (cfg *LintersSettings) MergeGlobal(lcfg *global.Linters) {
@@ -59,7 +59,7 @@ type ContainerSettings struct {
 
 	RecommendedLabelsRule RuleConfig `mapstructure:"recommended-labels"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type ContainerExcludeRules struct {
@@ -81,7 +81,7 @@ type ContainerExcludeRules struct {
 type HooksSettings struct {
 	Ingress HooksIngressRuleSetting `mapstructure:"ingress"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type HooksIngressRuleSetting struct {
@@ -97,7 +97,7 @@ type ImageSettings struct {
 	Patches PatchesRuleSettings `mapstructure:"patches"`
 	Werf    WerfRuleSettings    `mapstructure:"werf"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type ImageExcludeRules struct {
@@ -120,7 +120,7 @@ type ModuleSettings struct {
 	Conversions    ConversionsRuleSettings          `mapstructure:"conversions"`
 	Helmignore     HelmignoreRuleSettings           `mapstructure:"helmignore"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type ModuleExcludeRules struct {
@@ -165,7 +165,7 @@ type LicenseExcludeRule struct {
 type NoCyrillicSettings struct {
 	NoCyrillicExcludeRules NoCyrillicExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type NoCyrillicExcludeRules struct {
@@ -176,7 +176,7 @@ type NoCyrillicExcludeRules struct {
 type OpenAPISettings struct {
 	OpenAPIExcludeRules OpenAPIExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type OpenAPIExcludeRules struct {
@@ -189,7 +189,7 @@ type OpenAPIExcludeRules struct {
 type RbacSettings struct {
 	ExcludeRules RBACExcludeRules `mapstructure:"exclude-rules"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type RBACExcludeRules struct {
@@ -203,7 +203,7 @@ type TemplatesSettings struct {
 	GrafanaDashboards GrafanaDashboardsExcludeList `mapstructure:"grafana-dashboards"`
 	PrometheusRules   PrometheusRulesExcludeList   `mapstructure:"prometheus-rules"`
 
-	Impact *pkg.Level `mapstructure:"impact"`
+	Impact string `mapstructure:"impact"`
 }
 
 type TemplatesExcludeRules struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -32,6 +32,10 @@ type LintersSettings struct {
 	Templates  TemplatesSettings  `mapstructure:"templates"`
 }
 
+type RuleConfig struct {
+	Impact *pkg.Level `mapstructure:"impact"`
+}
+
 func (cfg *LintersSettings) MergeGlobal(lcfg *global.Linters) {
 	cfg.OpenAPI.Impact = calculateImpact(cfg.OpenAPI.Impact, lcfg.OpenAPI.Impact)
 	cfg.NoCyrillic.Impact = calculateImpact(cfg.NoCyrillic.Impact, lcfg.NoCyrillic.Impact)
@@ -41,10 +45,19 @@ func (cfg *LintersSettings) MergeGlobal(lcfg *global.Linters) {
 	cfg.Rbac.Impact = calculateImpact(cfg.Rbac.Impact, lcfg.Rbac.Impact)
 	cfg.Hooks.Impact = calculateImpact(cfg.Hooks.Impact, lcfg.Hooks.Impact)
 	cfg.Module.Impact = calculateImpact(cfg.Module.Impact, lcfg.Module.Impact)
+
+	cfg.Container.RecommendedLabelsRule.Impact = calculateImpact(cfg.Container.RecommendedLabelsRule.Impact, lcfg.Container.RecommendedLabelsRule.Impact)
+
+	cfg.Images.Rules.DistrolessRule.Impact = calculateImpact(cfg.Images.Rules.DistrolessRule.Impact, lcfg.Images.Rules.DistrolessRule.Impact)
+	cfg.Images.Rules.ImageRule.Impact = calculateImpact(cfg.Images.Rules.ImageRule.Impact, lcfg.Images.Rules.ImageRule.Impact)
+	cfg.Images.Rules.PatchesRule.Impact = calculateImpact(cfg.Images.Rules.PatchesRule.Impact, lcfg.Images.Rules.PatchesRule.Impact)
+	cfg.Images.Rules.WerfRule.Impact = calculateImpact(cfg.Images.Rules.WerfRule.Impact, lcfg.Images.Rules.WerfRule.Impact)
 }
 
 type ContainerSettings struct {
 	ExcludeRules ContainerExcludeRules `mapstructure:"exclude-rules"`
+
+	RecommendedLabelsRule RuleConfig `mapstructure:"recommended-labels"`
 
 	Impact *pkg.Level `mapstructure:"impact"`
 }
@@ -79,6 +92,8 @@ type HooksIngressRuleSetting struct {
 type ImageSettings struct {
 	ExcludeRules ImageExcludeRules `mapstructure:"exclude-rules"`
 
+	Rules Rules `mapstructure:"rules"`
+
 	Patches PatchesRuleSettings `mapstructure:"patches"`
 	Werf    WerfRuleSettings    `mapstructure:"werf"`
 
@@ -88,6 +103,13 @@ type ImageSettings struct {
 type ImageExcludeRules struct {
 	SkipImageFilePathPrefix      PrefixRuleExcludeList `mapstructure:"skip-image-file-path-prefix"`
 	SkipDistrolessFilePathPrefix PrefixRuleExcludeList `mapstructure:"skip-distroless-file-path-prefix"`
+}
+
+type Rules struct {
+	DistrolessRule RuleConfig `mapstructure:"distroless"`
+	ImageRule      RuleConfig `mapstructure:"image"`
+	PatchesRule    RuleConfig `mapstructure:"patches"`
+	WerfRule       RuleConfig `mapstructure:"werf"`
 }
 
 type ModuleSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -45,19 +45,10 @@ func (cfg *LintersSettings) MergeGlobal(lcfg *global.Linters) {
 	cfg.Rbac.Impact = calculateImpact(cfg.Rbac.Impact, lcfg.Rbac.Impact)
 	cfg.Hooks.Impact = calculateImpact(cfg.Hooks.Impact, lcfg.Hooks.Impact)
 	cfg.Module.Impact = calculateImpact(cfg.Module.Impact, lcfg.Module.Impact)
-
-	cfg.Container.RecommendedLabelsRule.Impact = calculateImpact(cfg.Container.RecommendedLabelsRule.Impact, lcfg.Container.RecommendedLabelsRule.Impact)
-
-	cfg.Images.Rules.DistrolessRule.Impact = calculateImpact(cfg.Images.Rules.DistrolessRule.Impact, lcfg.Images.Rules.DistrolessRule.Impact)
-	cfg.Images.Rules.ImageRule.Impact = calculateImpact(cfg.Images.Rules.ImageRule.Impact, lcfg.Images.Rules.ImageRule.Impact)
-	cfg.Images.Rules.PatchesRule.Impact = calculateImpact(cfg.Images.Rules.PatchesRule.Impact, lcfg.Images.Rules.PatchesRule.Impact)
-	cfg.Images.Rules.WerfRule.Impact = calculateImpact(cfg.Images.Rules.WerfRule.Impact, lcfg.Images.Rules.WerfRule.Impact)
 }
 
 type ContainerSettings struct {
 	ExcludeRules ContainerExcludeRules `mapstructure:"exclude-rules"`
-
-	RecommendedLabelsRule RuleConfig `mapstructure:"recommended-labels"`
 
 	Impact string `mapstructure:"impact"`
 }
@@ -92,8 +83,6 @@ type HooksIngressRuleSetting struct {
 type ImageSettings struct {
 	ExcludeRules ImageExcludeRules `mapstructure:"exclude-rules"`
 
-	Rules Rules `mapstructure:"rules"`
-
 	Patches PatchesRuleSettings `mapstructure:"patches"`
 	Werf    WerfRuleSettings    `mapstructure:"werf"`
 
@@ -103,13 +92,6 @@ type ImageSettings struct {
 type ImageExcludeRules struct {
 	SkipImageFilePathPrefix      PrefixRuleExcludeList `mapstructure:"skip-image-file-path-prefix"`
 	SkipDistrolessFilePathPrefix PrefixRuleExcludeList `mapstructure:"skip-distroless-file-path-prefix"`
-}
-
-type Rules struct {
-	DistrolessRule RuleConfig `mapstructure:"distroless"`
-	ImageRule      RuleConfig `mapstructure:"image"`
-	PatchesRule    RuleConfig `mapstructure:"patches"`
-	WerfRule       RuleConfig `mapstructure:"werf"`
 }
 
 type ModuleSettings struct {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -169,7 +169,6 @@ func (l *Loader) setConfigDir() error {
 
 func customDecoderHook() viper.DecoderConfigOption {
 	return viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
-		StringToLevelHookFunc(),
 		// Default hooks (https://github.com/spf13/viper/blob/518241257478c557633ab36e474dfcaeb9a3c623/viper.go#L135-L138).
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
-	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
@@ -31,7 +29,6 @@ import (
 
 	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/internal/logger"
-	"github.com/deckhouse/dmt/pkg"
 )
 
 type LoaderOptions struct {
@@ -180,21 +177,4 @@ func customDecoderHook() viper.DecoderConfigOption {
 		// Needed for forbidigo, and output.formats.
 		mapstructure.TextUnmarshallerHookFunc(),
 	))
-}
-
-func StringToLevelHookFunc() mapstructure.DecodeHookFuncType {
-	return func(
-		f reflect.Type,
-		t reflect.Type,
-		data any) (any, error) {
-		if f.Kind() != reflect.String || f.Kind() == reflect.Pointer {
-			return data, nil
-		}
-
-		if !strings.Contains(t.String(), "Level") {
-			return data, nil
-		}
-
-		return pkg.ParseStringToLevel(data.(string)), nil
-	}
 }

--- a/pkg/linters/container/container.go
+++ b/pkg/linters/container/container.go
@@ -19,7 +19,6 @@ package container
 import (
 	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -34,61 +33,13 @@ type Container struct {
 	ErrorList  *errors.LintRuleErrorsList
 }
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Container {
-	containerCfg := convertToContainerLinterConfig(&cfg.LintersSettings.Container)
+func New(containerCfg *pkg.ContainerLinterConfig, errorList *errors.LintRuleErrorsList) *Container {
 	return &Container{
 		name:      ID,
 		desc:      "Lint container objects",
 		cfg:       containerCfg,
 		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(containerCfg.Impact),
 	}
-}
-
-func convertToContainerLinterConfig(oldCfg *config.ContainerSettings) *pkg.ContainerLinterConfig {
-	newCfg := &pkg.ContainerLinterConfig{}
-	newCfg.Impact = oldCfg.Impact
-
-	newCfg.Rules.RecommendedLabelsRule.SetLevel(oldCfg.RecommendedLabelsRule.Impact)
-
-	newCfg.ExcludeRules = pkg.ContainerExcludeRules{
-		ControllerSecurityContext: convertKindRuleExcludeList(oldCfg.ExcludeRules.ControllerSecurityContext),
-		DNSPolicy:                 convertKindRuleExcludeList(oldCfg.ExcludeRules.DNSPolicy),
-		HostNetworkPorts:          convertContainerRuleExcludeList(oldCfg.ExcludeRules.HostNetworkPorts),
-		Ports:                     convertContainerRuleExcludeList(oldCfg.ExcludeRules.Ports),
-		ReadOnlyRootFilesystem:    convertContainerRuleExcludeList(oldCfg.ExcludeRules.ReadOnlyRootFilesystem),
-		ImageDigest:               convertContainerRuleExcludeList(oldCfg.ExcludeRules.ImageDigest),
-		Resources:                 convertContainerRuleExcludeList(oldCfg.ExcludeRules.Resources),
-		SecurityContext:           convertContainerRuleExcludeList(oldCfg.ExcludeRules.SecurityContext),
-		Liveness:                  convertContainerRuleExcludeList(oldCfg.ExcludeRules.Liveness),
-		Readiness:                 convertContainerRuleExcludeList(oldCfg.ExcludeRules.Readiness),
-		Description:               convertStringRuleExcludeList(oldCfg.ExcludeRules.Description),
-	}
-
-	return newCfg
-}
-
-func convertKindRuleExcludeList(oldList config.KindRuleExcludeList) pkg.KindRuleExcludeList {
-	newList := make(pkg.KindRuleExcludeList, len(oldList))
-	for i, item := range oldList {
-		newList[i] = pkg.KindRuleExclude{Kind: item.Kind, Name: item.Name}
-	}
-	return newList
-}
-
-func convertContainerRuleExcludeList(oldList config.ContainerRuleExcludeList) pkg.ContainerRuleExcludeList {
-	newList := make(pkg.ContainerRuleExcludeList, len(oldList))
-	for i, item := range oldList {
-		newList[i] = pkg.ContainerRuleExclude{Kind: item.Kind, Name: item.Name, Container: item.Container}
-	}
-	return newList
-}
-
-func convertStringRuleExcludeList(oldList config.StringRuleExcludeList) pkg.StringRuleExcludeList {
-	newList := make(pkg.StringRuleExcludeList, len(oldList))
-	for i, item := range oldList {
-		newList[i] = string(item)
-	}
-	return newList
 }
 
 func (l *Container) Run(m *module.Module) {

--- a/pkg/linters/container/container.go
+++ b/pkg/linters/container/container.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
@@ -29,17 +30,65 @@ const (
 // Container linter
 type Container struct {
 	name, desc string
-	cfg        *config.ContainerSettings
+	cfg        *pkg.ContainerLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
 func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Container {
+	containerCfg := convertToContainerLinterConfig(&cfg.LintersSettings.Container)
 	return &Container{
 		name:      ID,
 		desc:      "Lint container objects",
-		cfg:       &cfg.LintersSettings.Container,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Container.Impact),
+		cfg:       containerCfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(containerCfg.Impact),
 	}
+}
+
+func convertToContainerLinterConfig(oldCfg *config.ContainerSettings) *pkg.ContainerLinterConfig {
+	newCfg := &pkg.ContainerLinterConfig{}
+	newCfg.Impact = oldCfg.Impact
+
+	newCfg.Rules.RecommendedLabelsRule.SetLevel(oldCfg.RecommendedLabelsRule.Impact)
+
+	newCfg.ExcludeRules = pkg.ContainerExcludeRules{
+		ControllerSecurityContext: convertKindRuleExcludeList(oldCfg.ExcludeRules.ControllerSecurityContext),
+		DNSPolicy:                 convertKindRuleExcludeList(oldCfg.ExcludeRules.DNSPolicy),
+		HostNetworkPorts:          convertContainerRuleExcludeList(oldCfg.ExcludeRules.HostNetworkPorts),
+		Ports:                     convertContainerRuleExcludeList(oldCfg.ExcludeRules.Ports),
+		ReadOnlyRootFilesystem:    convertContainerRuleExcludeList(oldCfg.ExcludeRules.ReadOnlyRootFilesystem),
+		ImageDigest:               convertContainerRuleExcludeList(oldCfg.ExcludeRules.ImageDigest),
+		Resources:                 convertContainerRuleExcludeList(oldCfg.ExcludeRules.Resources),
+		SecurityContext:           convertContainerRuleExcludeList(oldCfg.ExcludeRules.SecurityContext),
+		Liveness:                  convertContainerRuleExcludeList(oldCfg.ExcludeRules.Liveness),
+		Readiness:                 convertContainerRuleExcludeList(oldCfg.ExcludeRules.Readiness),
+		Description:               convertStringRuleExcludeList(oldCfg.ExcludeRules.Description),
+	}
+
+	return newCfg
+}
+
+func convertKindRuleExcludeList(oldList config.KindRuleExcludeList) pkg.KindRuleExcludeList {
+	newList := make(pkg.KindRuleExcludeList, len(oldList))
+	for i, item := range oldList {
+		newList[i] = pkg.KindRuleExclude{Kind: item.Kind, Name: item.Name}
+	}
+	return newList
+}
+
+func convertContainerRuleExcludeList(oldList config.ContainerRuleExcludeList) pkg.ContainerRuleExcludeList {
+	newList := make(pkg.ContainerRuleExcludeList, len(oldList))
+	for i, item := range oldList {
+		newList[i] = pkg.ContainerRuleExclude{Kind: item.Kind, Name: item.Name, Container: item.Container}
+	}
+	return newList
+}
+
+func convertStringRuleExcludeList(oldList config.StringRuleExcludeList) pkg.StringRuleExcludeList {
+	newList := make(pkg.StringRuleExcludeList, len(oldList))
+	for i, item := range oldList {
+		newList[i] = string(item)
+	}
+	return newList
 }
 
 func (l *Container) Run(m *module.Module) {

--- a/pkg/linters/container/container_test.go
+++ b/pkg/linters/container/container_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 func TestContainer_NameAndDesc(t *testing.T) {
-	cfg := &config.ModuleConfig{}
+	cfg := &pkg.ContainerLinterConfig{}
 	errList := errors.NewLintRuleErrorsList()
 	linter := New(cfg, errList)
 
@@ -20,7 +20,7 @@ func TestContainer_NameAndDesc(t *testing.T) {
 }
 
 func TestContainer_Run_NilModule(_ *testing.T) {
-	cfg := &config.ModuleConfig{}
+	cfg := &pkg.ContainerLinterConfig{}
 	errList := errors.NewLintRuleErrorsList()
 	linter := New(cfg, errList)
 
@@ -29,7 +29,7 @@ func TestContainer_Run_NilModule(_ *testing.T) {
 }
 
 func TestContainer_Run_EmptyModule(t *testing.T) {
-	cfg := &config.ModuleConfig{}
+	cfg := &pkg.ContainerLinterConfig{}
 	errList := errors.NewLintRuleErrorsList()
 	linter := New(cfg, errList)
 

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -27,7 +27,7 @@ import (
 func (l *Container) applyContainerRules(object storage.StoreObject, errorList *errors.LintRuleErrorsList) {
 	errorList = errorList.WithFilePath(object.GetPath())
 
-	rules.NewRecommendedLabelsRule().ObjectRecommendedLabels(object, errorList.WithRule("recommended-labels").WithMaxLevel(l.cfg.GetRuleImpact("recommended-labels")))
+	rules.NewRecommendedLabelsRule().ObjectRecommendedLabels(object, errorList.WithRule("recommended-labels").WithMaxLevel(l.cfg.Rules.RecommendedLabelsRule.GetLevel()))
 	rules.NewNamespaceLabelsRule().ObjectNamespaceLabels(object, errorList)
 	rules.NewAPIVersionRule().ObjectAPIVersion(object, errorList)
 	rules.NewPriorityClassRule().ObjectPriorityClass(object, errorList)

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -27,21 +27,15 @@ import (
 func (l *Container) applyContainerRules(object storage.StoreObject, errorList *errors.LintRuleErrorsList) {
 	errorList = errorList.WithFilePath(object.GetPath())
 
-	objectRules := []func(storage.StoreObject, *errors.LintRuleErrorsList){
-		rules.NewRecommendedLabelsRule().ObjectRecommendedLabels,
-		rules.NewNamespaceLabelsRule().ObjectNamespaceLabels,
-		rules.NewAPIVersionRule().ObjectAPIVersion,
-		rules.NewPriorityClassRule().ObjectPriorityClass,
-		rules.NewDNSPolicyRule(l.cfg.ExcludeRules.DNSPolicy.Get()).
-			ObjectDNSPolicy,
-		rules.NewControllerSecurityContextRule(l.cfg.ExcludeRules.ControllerSecurityContext.Get()).
-			ControllerSecurityContext,
-		rules.NewRevisionHistoryLimitRule().ObjectRevisionHistoryLimit,
-	}
-
-	for _, rule := range objectRules {
-		rule(object, errorList)
-	}
+	rules.NewRecommendedLabelsRule().ObjectRecommendedLabels(object, errorList.WithRule("recommended-labels").WithMaxLevel(l.cfg.GetRuleImpact("recommended-labels")))
+	rules.NewNamespaceLabelsRule().ObjectNamespaceLabels(object, errorList)
+	rules.NewAPIVersionRule().ObjectAPIVersion(object, errorList)
+	rules.NewPriorityClassRule().ObjectPriorityClass(object, errorList)
+	rules.NewDNSPolicyRule(l.cfg.ExcludeRules.DNSPolicy.Get()).
+		ObjectDNSPolicy(object, errorList)
+	rules.NewControllerSecurityContextRule(l.cfg.ExcludeRules.ControllerSecurityContext.Get()).
+		ControllerSecurityContext(object, errorList)
+	rules.NewRevisionHistoryLimitRule().ObjectRevisionHistoryLimit(object, errorList)
 
 	allContainers, err := object.GetAllContainers()
 	if err != nil {

--- a/pkg/linters/container/rules_test.go
+++ b/pkg/linters/container/rules_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/deckhouse/dmt/internal/storage"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 func TestApplyContainerRules_NoContainers(t *testing.T) {
-	cfg := &config.ContainerSettings{}
+	cfg := &pkg.ContainerLinterConfig{}
 	errList := errors.NewLintRuleErrorsList()
 	linter := &Container{cfg: cfg}
 
@@ -49,7 +49,7 @@ func TestApplyContainerRules_NoContainers(t *testing.T) {
 }
 
 func TestApplyContainerRules_ContainersError(t *testing.T) {
-	cfg := &config.ContainerSettings{}
+	cfg := &pkg.ContainerLinterConfig{}
 	errList := errors.NewLintRuleErrorsList()
 	linter := &Container{cfg: cfg}
 
@@ -68,7 +68,7 @@ func TestApplyContainerRules_ContainersError(t *testing.T) {
 }
 
 func TestApplyContainerRules_AllRules(t *testing.T) {
-	cfg := &config.ContainerSettings{}
+	cfg := &pkg.ContainerLinterConfig{}
 	errList := errors.NewLintRuleErrorsList()
 	linter := &Container{cfg: cfg}
 

--- a/pkg/linters/hooks/hooks.go
+++ b/pkg/linters/hooks/hooks.go
@@ -18,7 +18,7 @@ package hooks
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/hooks/rules"
 )
@@ -26,18 +26,18 @@ import (
 // Hooks linter
 type Hooks struct {
 	name, desc string
-	cfg        *config.HooksSettings
+	cfg        *pkg.HooksLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
 const ID = "hooks"
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Hooks {
+func New(cfg *pkg.HooksLinterConfig, errorList *errors.LintRuleErrorsList) *Hooks {
 	return &Hooks{
 		name:      ID,
 		desc:      "Lint hooks",
-		cfg:       &cfg.LintersSettings.Hooks,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Hooks.Impact),
+		cfg:       cfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.Impact),
 	}
 }
 

--- a/pkg/linters/hooks/rules/rules.go
+++ b/pkg/linters/hooks/rules/rules.go
@@ -29,7 +29,6 @@ import (
 	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/internal/storage"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -38,13 +37,13 @@ type HookRule struct {
 	pkg.BoolRule
 }
 
-func NewHookRule(cfg *config.HooksSettings) *HookRule {
+func NewHookRule(cfg *pkg.HooksLinterConfig) *HookRule {
 	return &HookRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: "ingress",
 		},
 		BoolRule: pkg.BoolRule{
-			Exclude: cfg.Ingress.Disable,
+			Exclude: cfg.IngressRuleSettings.Disable,
 		},
 	}
 }

--- a/pkg/linters/images/images.go
+++ b/pkg/linters/images/images.go
@@ -35,8 +35,8 @@ type Images struct {
 	ErrorList  *errors.LintRuleErrorsList
 }
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Images {
-	imageCfg := convertToImageLinterConfig(&cfg.LintersSettings.Images)
+func New(cfg *pkg.LintersSettings, errorList *errors.LintRuleErrorsList) *Images {
+	imageCfg := convertToImageLinterConfig(&cfg.Image)
 	return &Images{
 		name:      ID,
 		desc:      "Lint docker images",

--- a/pkg/linters/images/images.go
+++ b/pkg/linters/images/images.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/images/rules"
@@ -30,17 +31,33 @@ const (
 // Images linter
 type Images struct {
 	name, desc string
-	cfg        *config.ImageSettings
+	cfg        *pkg.ImageLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
 func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Images {
+	imageCfg := convertToImageLinterConfig(&cfg.LintersSettings.Images)
 	return &Images{
 		name:      ID,
 		desc:      "Lint docker images",
-		cfg:       &cfg.LintersSettings.Images,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Images.Impact),
+		cfg:       imageCfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(imageCfg.Impact),
 	}
+}
+
+func convertToImageLinterConfig(oldCfg *config.ImageSettings) *pkg.ImageLinterConfig {
+	newCfg := &pkg.ImageLinterConfig{}
+	newCfg.Impact = oldCfg.Impact
+
+	newCfg.Rules.DistrolessRule.SetLevel(oldCfg.Rules.DistrolessRule.Impact)
+	newCfg.Rules.ImageRule.SetLevel(oldCfg.Rules.ImageRule.Impact)
+	newCfg.Rules.PatchesRule.SetLevel(oldCfg.Rules.PatchesRule.Impact)
+	newCfg.Rules.WerfRule.SetLevel(oldCfg.Rules.WerfRule.Impact)
+
+	newCfg.Patches.Disable = oldCfg.Patches.Disable
+	newCfg.Werf.Disable = oldCfg.Werf.Disable
+
+	return newCfg
 }
 
 func (l *Images) Run(m *module.Module) {
@@ -50,10 +67,27 @@ func (l *Images) Run(m *module.Module) {
 
 	errorList := l.ErrorList.WithModule(m.GetName())
 
-	rules.NewImageRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList)
-	rules.NewDistrolessRule(l.cfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList)
-	rules.NewWerfRule(l.cfg.Werf.Disable).LintWerfFile(m.GetName(), m.GetWerfFile(), errorList)
-	rules.NewPatchesRule(l.cfg.Patches.Disable).CheckPatches(m.GetPath(), errorList)
+	oldCfg := l.convertToOldConfig()
+
+	rules.NewImageRule(oldCfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList.WithRule("image").WithMaxLevel(l.cfg.GetRuleImpact("image")))
+	rules.NewDistrolessRule(oldCfg).CheckImageNamesInDockerFiles(m.GetPath(), errorList.WithRule("distroless").WithMaxLevel(l.cfg.GetRuleImpact("distroless")))
+	rules.NewWerfRule(l.cfg.Werf.Disable).LintWerfFile(m.GetName(), m.GetWerfFile(), errorList.WithRule("werf").WithMaxLevel(l.cfg.GetRuleImpact("werf")))
+	rules.NewPatchesRule(l.cfg.Patches.Disable).CheckPatches(m.GetPath(), errorList.WithRule("patches").WithMaxLevel(l.cfg.GetRuleImpact("patches")))
+}
+
+func (l *Images) convertToOldConfig() *config.ImageSettings {
+	return &config.ImageSettings{
+		ExcludeRules: config.ImageExcludeRules{},
+		Rules: config.Rules{
+			DistrolessRule: config.RuleConfig{Impact: l.cfg.Rules.DistrolessRule.GetLevel()},
+			ImageRule:      config.RuleConfig{Impact: l.cfg.Rules.ImageRule.GetLevel()},
+			PatchesRule:    config.RuleConfig{Impact: l.cfg.Rules.PatchesRule.GetLevel()},
+			WerfRule:       config.RuleConfig{Impact: l.cfg.Rules.WerfRule.GetLevel()},
+		},
+		Patches: config.PatchesRuleSettings{Disable: l.cfg.Patches.Disable},
+		Werf:    config.WerfRuleSettings{Disable: l.cfg.Werf.Disable},
+		Impact:  l.cfg.Impact,
+	}
 }
 
 func (l *Images) Name() string {

--- a/pkg/linters/images/rules/distroless.go
+++ b/pkg/linters/images/rules/distroless.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -47,7 +46,7 @@ type DistrolessRule struct {
 	pkg.PrefixRule
 }
 
-func NewDistrolessRule(cfg *config.ImageSettings) *DistrolessRule {
+func NewDistrolessRule(cfg *pkg.ImageLinterConfig) *DistrolessRule {
 	return &DistrolessRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: distrolessRuleName,

--- a/pkg/linters/images/rules/image.go
+++ b/pkg/linters/images/rules/image.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -60,13 +59,13 @@ type ImageRule struct {
 	pkg.PrefixRule
 }
 
-func NewImageRule(cfg *config.ImageSettings) *ImageRule {
+func NewImageRule(cfg *pkg.ImageLinterConfig) *ImageRule {
 	return &ImageRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: dockerfileRuleName,
 		},
 		PrefixRule: pkg.PrefixRule{
-			ExcludeRules: cfg.ExcludeRules.SkipImageFilePathPrefix.Get(),
+			ExcludeRules: cfg.ExcludeRules.SkipDistrolessFilePathPrefix.Get(),
 		},
 	}
 }

--- a/pkg/linters/module/module.go
+++ b/pkg/linters/module/module.go
@@ -18,7 +18,7 @@ package module
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/module/rules"
 )
@@ -26,18 +26,18 @@ import (
 // Module linter
 type Module struct {
 	name, desc string
-	cfg        *config.ModuleSettings
+	cfg        *pkg.ModuleLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
 const ID = "module"
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Module {
+func New(cfg *pkg.ModuleLinterConfig, errorList *errors.LintRuleErrorsList) *Module {
 	return &Module{
 		name:      ID,
 		desc:      "Lint module rules",
-		cfg:       &cfg.LintersSettings.Module,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Module.Impact),
+		cfg:       cfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.Impact),
 	}
 }
 
@@ -48,10 +48,10 @@ func (l *Module) Run(m *module.Module) {
 
 	errorList := l.ErrorList.WithModule(m.GetName())
 
-	rules.NewDefinitionFileRule(l.cfg.DefinitionFile.Disable).CheckDefinitionFile(m.GetPath(), errorList)
-	rules.NewOSSRule(l.cfg.OSS.Disable).OssModuleRule(m.GetPath(), errorList)
-	rules.NewConversionsRule(l.cfg.Conversions.Disable).CheckConversions(m.GetPath(), errorList)
-	rules.NewHelmignoreRule(l.cfg.Helmignore.Disable).CheckHelmignore(m.GetPath(), errorList)
+	rules.NewDefinitionFileRule(l.cfg.DefinitionFileRuleSettings.Disable).CheckDefinitionFile(m.GetPath(), errorList)
+	rules.NewOSSRule(l.cfg.OSSRuleSettings.Disable).OssModuleRule(m.GetPath(), errorList)
+	rules.NewConversionsRule(l.cfg.ConversionsRuleSettings.Disable).CheckConversions(m.GetPath(), errorList)
+	rules.NewHelmignoreRule(l.cfg.HelmignoreRuleSettings.Disable).CheckHelmignore(m.GetPath(), errorList)
 	rules.NewLicenseRule(l.cfg.ExcludeRules.License.Files.Get(), l.cfg.ExcludeRules.License.Directories.Get()).
 		CheckFiles(m, errorList)
 	rules.NewRequirementsRule().CheckRequirements(m.GetPath(), errorList)

--- a/pkg/linters/no-cyrillic/no_cyrillic.go
+++ b/pkg/linters/no-cyrillic/no_cyrillic.go
@@ -19,7 +19,7 @@ package nocyrillic
 import (
 	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/no-cyrillic/rules"
 )
@@ -35,16 +35,16 @@ var (
 // NoCyrillic linter
 type NoCyrillic struct {
 	name, desc string
-	cfg        *config.NoCyrillicSettings
+	cfg        *pkg.NoCyrillicLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *NoCyrillic {
+func New(cfg *pkg.NoCyrillicLinterConfig, errorList *errors.LintRuleErrorsList) *NoCyrillic {
 	return &NoCyrillic{
 		name:      ID,
 		desc:      "NoCyrillic will check all files in the modules for contains cyrillic symbols",
-		cfg:       &cfg.LintersSettings.NoCyrillic,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.NoCyrillic.Impact),
+		cfg:       cfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.Impact),
 	}
 }
 
@@ -56,8 +56,8 @@ func (l *NoCyrillic) Run(m *module.Module) {
 	}
 
 	filesRule := rules.NewFilesRule(
-		l.cfg.NoCyrillicExcludeRules.Files.Get(),
-		l.cfg.NoCyrillicExcludeRules.Directories.Get())
+		l.cfg.ExcludeRules.Files.Get(),
+		l.cfg.ExcludeRules.Directories.Get())
 
 	files := fsutils.GetFiles(m.GetPath(), false, fsutils.FilterFileByExtensions(fileExtensions...))
 	for _, fileName := range files {

--- a/pkg/linters/openapi/openapi.go
+++ b/pkg/linters/openapi/openapi.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/deckhouse/dmt/internal/fsutils"
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/openapi/rules"
 )
@@ -31,16 +31,16 @@ import (
 // OpenAPI linter
 type OpenAPI struct {
 	name, desc string
-	cfg        *config.OpenAPISettings
+	cfg        *pkg.OpenAPILinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *OpenAPI {
+func New(cfg *pkg.OpenAPILinterConfig, errorList *errors.LintRuleErrorsList) *OpenAPI {
 	return &OpenAPI{
 		name:      "openapi",
 		desc:      "Linter will check openapi values is correct",
-		cfg:       &cfg.LintersSettings.OpenAPI,
-		ErrorList: errorList.WithLinterID("openapi").WithMaxLevel(cfg.LintersSettings.OpenAPI.Impact),
+		cfg:       cfg,
+		ErrorList: errorList.WithLinterID("openapi").WithMaxLevel(cfg.Impact),
 	}
 }
 

--- a/pkg/linters/openapi/rules/crds.go
+++ b/pkg/linters/openapi/rules/crds.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -43,13 +42,13 @@ var (
 	sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
 )
 
-func NewDeckhouseCRDsRule(cfg *config.OpenAPISettings, rootPath string) *DeckhouseCRDsRule {
+func NewDeckhouseCRDsRule(cfg *pkg.OpenAPILinterConfig, rootPath string) *DeckhouseCRDsRule {
 	return &DeckhouseCRDsRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: "deckhouse-crds",
 		},
 		StringRule: pkg.StringRule{
-			ExcludeRules: cfg.OpenAPIExcludeRules.CRDNamesExcludes.Get(),
+			ExcludeRules: cfg.ExcludeRules.CRDNamesExcludes.Get(),
 		},
 		rootPath: rootPath,
 	}

--- a/pkg/linters/openapi/rules/crds_test.go
+++ b/pkg/linters/openapi/rules/crds_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -520,9 +520,9 @@ spec:
 			filePath, cleanup := createTempFile(t, tt.content)
 			defer cleanup()
 
-			cfg := &config.OpenAPISettings{}
+			cfg := &pkg.OpenAPILinterConfig{}
 			if tt.name == "excluded CRD name" {
-				cfg.OpenAPIExcludeRules.CRDNamesExcludes = []string{"excluded.deckhouse.io"}
+				cfg.ExcludeRules.CRDNamesExcludes = []string{"excluded.deckhouse.io"}
 			}
 
 			rule := NewDeckhouseCRDsRule(cfg, "test")

--- a/pkg/linters/openapi/rules/enum.go
+++ b/pkg/linters/openapi/rules/enum.go
@@ -26,12 +26,11 @@ import (
 
 	"github.com/deckhouse/dmt/internal/openapi"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 type EnumRule struct {
-	cfg      *config.OpenAPISettings
+	cfg      *pkg.OpenAPILinterConfig
 	rootPath string
 	pkg.RuleMeta
 }
@@ -40,7 +39,7 @@ var (
 	arrayPathRegex = regexp.MustCompile(`[\d+]`)
 )
 
-func NewEnumRule(cfg *config.OpenAPISettings, rootPath string) *EnumRule {
+func NewEnumRule(cfg *pkg.OpenAPILinterConfig, rootPath string) *EnumRule {
 	return &EnumRule{
 		cfg: cfg,
 		RuleMeta: pkg.RuleMeta{
@@ -62,14 +61,14 @@ func (e *EnumRule) Run(path string, errorList *errors.LintRuleErrorsList) {
 }
 
 type enumValidator struct {
-	cfg *config.OpenAPISettings
+	cfg *pkg.OpenAPILinterConfig
 
 	excludes map[string]struct{}
 }
 
-func newEnumValidator(cfg *config.OpenAPISettings) enumValidator {
+func newEnumValidator(cfg *pkg.OpenAPILinterConfig) enumValidator {
 	excludes := make(map[string]struct{})
-	for _, exc := range cfg.OpenAPIExcludeRules.EnumFileExcludes {
+	for _, exc := range cfg.ExcludeRules.EnumFileExcludes {
 		excludes[exc+".enum"] = struct{}{}
 	}
 	return enumValidator{

--- a/pkg/linters/openapi/rules/enum_test.go
+++ b/pkg/linters/openapi/rules/enum_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -166,8 +166,8 @@ components:
 			filePath, cleanup := createTempFile(t, tt.content)
 			defer cleanup()
 
-			cfg := &config.OpenAPISettings{
-				OpenAPIExcludeRules: config.OpenAPIExcludeRules{
+			cfg := &pkg.OpenAPILinterConfig{
+				ExcludeRules: pkg.OpenAPIExcludeRules{
 					EnumFileExcludes: tt.excludeFiles,
 				},
 			}

--- a/pkg/linters/openapi/rules/ha.go
+++ b/pkg/linters/openapi/rules/ha.go
@@ -24,25 +24,24 @@ import (
 
 	"github.com/deckhouse/dmt/internal/openapi"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 type HARule struct {
-	cfg *config.OpenAPISettings
+	cfg *pkg.OpenAPILinterConfig
 	pkg.RuleMeta
 	pkg.StringRule
 	rootPath string
 }
 
-func NewHARule(cfg *config.OpenAPISettings, rootPath string) *HARule {
+func NewHARule(cfg *pkg.OpenAPILinterConfig, rootPath string) *HARule {
 	return &HARule{
 		cfg: cfg,
 		RuleMeta: pkg.RuleMeta{
 			Name: "high-availability",
 		},
 		StringRule: pkg.StringRule{
-			ExcludeRules: cfg.OpenAPIExcludeRules.HAAbsoluteKeysExcludes.Get(),
+			ExcludeRules: cfg.ExcludeRules.HAAbsoluteKeysExcludes.Get(),
 		},
 		rootPath: rootPath,
 	}

--- a/pkg/linters/openapi/rules/keys.go
+++ b/pkg/linters/openapi/rules/keys.go
@@ -24,17 +24,16 @@ import (
 
 	"github.com/deckhouse/dmt/internal/openapi"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
 type KeysRule struct {
-	cfg *config.OpenAPISettings
+	cfg *pkg.OpenAPILinterConfig
 	pkg.RuleMeta
 	rootPath string
 }
 
-func NewKeysRule(cfg *config.OpenAPISettings, rootPath string) *KeysRule {
+func NewKeysRule(cfg *pkg.OpenAPILinterConfig, rootPath string) *KeysRule {
 	return &KeysRule{
 		cfg: cfg,
 		RuleMeta: pkg.RuleMeta{
@@ -59,9 +58,9 @@ type keyValidator struct {
 	bannedNames []string
 }
 
-func newKeyValidator(cfg *config.OpenAPISettings) keyValidator {
+func newKeyValidator(cfg *pkg.OpenAPILinterConfig) keyValidator {
 	return keyValidator{
-		bannedNames: cfg.OpenAPIExcludeRules.KeyBannedNames,
+		bannedNames: cfg.ExcludeRules.KeyBannedNames,
 	}
 }
 

--- a/pkg/linters/openapi/rules/keys_test.go
+++ b/pkg/linters/openapi/rules/keys_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -107,8 +107,8 @@ components:
 			filePath, cleanup := createTempFile(t, tt.content)
 			defer cleanup()
 
-			cfg := &config.OpenAPISettings{
-				OpenAPIExcludeRules: config.OpenAPIExcludeRules{
+			cfg := &pkg.OpenAPILinterConfig{
+				ExcludeRules: pkg.OpenAPIExcludeRules{
 					KeyBannedNames: tt.bannedNames,
 				},
 			}

--- a/pkg/linters/rbac/rbac.go
+++ b/pkg/linters/rbac/rbac.go
@@ -18,7 +18,7 @@ package rbac
 
 import (
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/rbac/rules"
 )
@@ -30,16 +30,16 @@ const (
 // Rbac linter
 type Rbac struct {
 	name, desc string
-	cfg        *config.RbacSettings
+	cfg        *pkg.RBACLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Rbac {
+func New(cfg *pkg.RBACLinterConfig, errorList *errors.LintRuleErrorsList) *Rbac {
 	return &Rbac{
 		name:      ID,
 		desc:      "Lint rbac objects",
-		cfg:       &cfg.LintersSettings.Rbac,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Rbac.Impact),
+		cfg:       cfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.Impact),
 	}
 }
 

--- a/pkg/linters/templates/rules/grafana.go
+++ b/pkg/linters/templates/rules/grafana.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/deckhouse/dmt/internal/module"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 
 	"os"
@@ -33,10 +32,10 @@ const (
 	GrafanaRuleName = "grafana"
 )
 
-func NewGrafanaRule(cfg *config.TemplatesSettings) *GrafanaRule {
+func NewGrafanaRule(cfg *pkg.TemplatesLinterConfig) *GrafanaRule {
 	var exclude bool
 	if cfg != nil {
-		exclude = cfg.GrafanaDashboards.Disable
+		exclude = cfg.GrafanaDashboardsSettings.Disable
 	}
 	return &GrafanaRule{
 		RuleMeta: pkg.RuleMeta{

--- a/pkg/linters/templates/rules/prometheus_rules.go
+++ b/pkg/linters/templates/rules/prometheus_rules.go
@@ -31,7 +31,6 @@ import (
 	"github.com/deckhouse/dmt/internal/promtool"
 	"github.com/deckhouse/dmt/internal/storage"
 	"github.com/deckhouse/dmt/pkg"
-	"github.com/deckhouse/dmt/pkg/config"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -39,10 +38,10 @@ const (
 	PrometheusRuleName = "prometheus-rules"
 )
 
-func NewPrometheusRule(cfg *config.TemplatesSettings) *PrometheusRule {
+func NewPrometheusRule(cfg *pkg.TemplatesLinterConfig) *PrometheusRule {
 	var exclude bool
 	if cfg != nil {
-		exclude = cfg.PrometheusRules.Disable
+		exclude = cfg.PrometheusRuleSettings.Disable
 	}
 	return &PrometheusRule{
 		RuleMeta: pkg.RuleMeta{

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/deckhouse/dmt/internal/module"
-	"github.com/deckhouse/dmt/pkg/config"
+	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 	"github.com/deckhouse/dmt/pkg/linters/templates/rules"
 )
@@ -33,16 +33,16 @@ const (
 // Templates linter
 type Templates struct {
 	name, desc string
-	cfg        *config.TemplatesSettings
+	cfg        *pkg.TemplatesLinterConfig
 	ErrorList  *errors.LintRuleErrorsList
 }
 
-func New(cfg *config.ModuleConfig, errorList *errors.LintRuleErrorsList) *Templates {
+func New(cfg *pkg.TemplatesLinterConfig, errorList *errors.LintRuleErrorsList) *Templates {
 	return &Templates{
 		name:      ID,
 		desc:      "Lint templates",
-		cfg:       &cfg.LintersSettings.Templates,
-		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.LintersSettings.Templates.Impact),
+		cfg:       cfg,
+		ErrorList: errorList.WithLinterID(ID).WithMaxLevel(cfg.Impact),
 	}
 }
 


### PR DESCRIPTION
### 🎯 **Overview**
This PR implements a major architectural refactoring that completely restructures DMT's configuration system, moving from a monolithic approach to a granular, type-safe configuration architecture. This enables fine-grained control over linter behavior, rule-level configuration, and improved maintainability.

### 🏗️ **Core Architecture Changes**

#### **1. New Configuration Type System (config.go)**
Complete introduction of a comprehensive configuration hierarchy:

- **`LinterConfig`**: Base configuration for all linters with impact levels
- **`RuleConfig`**: Granular rule-level configuration with fallback mechanisms  
- **`LintersSettings`**: Top-level orchestrator for all linter configurations
- **Domain-Specific Configs**: Specialized configuration for each linter domain:
  - `ContainerLinterConfig`, `ImageLinterConfig`, `OpenAPILinterConfig`
  - `TemplatesLinterConfig`, `RBACLinterConfig`, `HooksLinterConfig`
  - `ModuleLinterConfig`, `NoCyrillicLinterConfig`

#### **2. Rule-Level Granularity**
```yaml
# Before: Only linter-level configuration
linters-settings:
  images:
    impact: warn

# After: Both linter and rule-level configuration  
linters-settings:
  images:
    impact: warn
    rules:
      distroless: 
        impact: error
      werf:
        impact: critical
```

