### PR TITLE
Fix documentation linter

### DIFF
--- a/pkg/linters/docs/rules/bilingual.go
+++ b/pkg/linters/docs/rules/bilingual.go
@@ -70,7 +70,7 @@ func (r *BilingualRule) CheckBilingual(m pkg.Module, errorList *errors.LintRuleE
 		if _, ok := fileSet[ruRel]; !ok {
 			errorList.
 				WithFilePath(rel).
-				Error("Russian counterpart is missing: create a matching .ru.md in docs/")
+				Error("Russian counterpart is missing: need to create a matching .ru.md in docs/")
 		}
 	}
 }

--- a/pkg/linters/docs/rules/cyrillic_in_english.go
+++ b/pkg/linters/docs/rules/cyrillic_in_english.go
@@ -6,6 +6,7 @@ package rules
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -22,7 +23,7 @@ var (
 	cyrRe              = regexp.MustCompile(`[А-Яа-яЁё]+`)
 	cyrPointerRe       = regexp.MustCompile(`[А-Яа-яЁё]`)
 	cyrFillerRe        = regexp.MustCompile(`[^А-Яа-яЁё]`)
-	russianDocRe       = regexp.MustCompile(`_RU\.md$|_ru\.md$|\.ru\.md$|/ru/.*\.md$|/docs/.*_RU\.md$`)
+	russianDocRe       = regexp.MustCompile(`\.ru\.md$`)
 	markdownExtensions = []string{".md", ".markdown"}
 )
 
@@ -47,7 +48,8 @@ func (r *CyrillicInEnglishRule) CheckFiles(m pkg.Module, errorList *errors.LintR
 		return
 	}
 
-	files := fsutils.GetFiles(modulePath, false, fsutils.FilterFileByExtensions(markdownExtensions...))
+	docsPath := filepath.Join(modulePath, "docs")
+	files := fsutils.GetFiles(docsPath, false, fsutils.FilterFileByExtensions(markdownExtensions...))
 
 	for _, fileName := range files {
 		r.checkFile(m, fileName, errorList)

--- a/pkg/linters/docs/rules/readme.go
+++ b/pkg/linters/docs/rules/readme.go
@@ -36,37 +36,19 @@ func (r *ReadmeRule) CheckReadme(m pkg.Module, errorList *errors.LintRuleErrorsL
 	}
 
 	modulePath := m.GetPath()
+	path := filepath.Join(modulePath, "docs", "README.md")
 
-	readmePaths := []struct {
-		path     string
-		location string
-	}{
-		{filepath.Join(modulePath, "README.md"), "README.md"},
-		{filepath.Join(modulePath, "docs", "README.md"), "docs/README.md"},
-	}
-
-	var foundPath string
-	var foundLocation string
-
-	for _, readmeInfo := range readmePaths {
-		if _, err := os.Stat(readmeInfo.path); err == nil {
-			foundPath = readmeInfo.path
-			foundLocation = readmeInfo.location
-			break
-		}
-	}
-
-	if foundPath == "" {
+	if _, err := os.Stat(path); err != nil {
 		errorList.
-			WithFilePath("README.md").
-			Error("README.md file is missing in module (checked root and docs/ directory)")
+			WithFilePath(path).
+			Error("README.md file is missing in docs/ directory")
 		return
 	}
 
-	info, err := os.Stat(foundPath)
+	info, err := os.Stat(path)
 	if err != nil {
 		errorList.
-			WithFilePath(foundLocation).
+			WithFilePath(path).
 			WithValue(err.Error()).
 			Error("failed to check README.md file")
 		return
@@ -74,7 +56,7 @@ func (r *ReadmeRule) CheckReadme(m pkg.Module, errorList *errors.LintRuleErrorsL
 
 	if info.Size() == 0 {
 		errorList.
-			WithFilePath(foundLocation).
+			WithFilePath(path).
 			Error("README.md file is empty")
 	}
 }


### PR DESCRIPTION
## What happened
The documentation linter only checked for the presence of README.md / README_RU.md pairs in the module root and/or in docs/, plus a few special conditions for empty files. This did not cover the rest of the documentation and did not work as intended.

## What we did
We limited the scope of the check to the module's docs/ folder.
- Checks are only run if <module>/docs exists. The module root (<module>/README*.md) is no longer part of this rule.

We expanded the check to all documentation files in docs/.
The linter collects all *.md files in docs/ and builds correspondences:

- Any file ending in .ru.md is considered the Russian version.
- Any file ending in .md but not .ru.md is considered the English version.
- For each English version (n).md, a pair (n).ru.md is required. The prefix must be strictly .ru (no variants such as .RU, _ru, etc.).
- If there is no pair, an error is emitted.

We removed branches that attempted to search for README.md/README_RU.md in different locations and check them for “emptiness.” Now the linter works according to the same rules for all files in docs/. 

