### PR TITLE
[dmt] Skip test deckhouse repos in registry

### DIFF
--- a/pkg/linters/templates/rules/registry.go
+++ b/pkg/linters/templates/rules/registry.go
@@ -55,9 +55,14 @@ func (r *RegistryRule) CheckRegistrySecret(md *module.Module, errorList *errors.
 		return
 	}
 
-	if getModuleNameFromRepository(md.GetPath()) == "deckhouse" {
-		// Skip registry secret check for deckhouse repository
-		return
+	skipRepos := []string{"deckhouse", "deckhouse-test-1", "deckhouse-test-2"}
+
+	moduleNameFromRepo := getModuleNameFromRepository(md.GetPath())
+	for _, repo := range skipRepos {
+		if moduleNameFromRepo == repo {
+			// Skip registry secret check
+			return
+		}
 	}
 
 	moduleName := md.GetName()


### PR DESCRIPTION
In the test environment, we expect the same behavior as on the main project.

This allows us to test the functionality and fix problems before they are released into the main project.