### PR TITLE
[dmt] Documentation linter must checks only in /docs directory

### DIFF
--- a/pkg/linters/docs/rules/bilingual.go
+++ b/pkg/linters/docs/rules/bilingual.go
@@ -54,6 +54,10 @@ func (r *BilingualRule) CheckBilingual(m pkg.Module, errorList *errors.LintRuleE
 	fileSet := make(map[string]struct{}, len(files))
 	for _, f := range files {
 		rel := fsutils.Rel(modulePath, f)
+		// include only files directly under docs/ (exclude nested paths)
+		if filepath.Dir(rel) != "docs" {
+			continue
+		}
 		fileSet[rel] = struct{}{}
 	}
 

--- a/pkg/linters/docs/rules/bilingual.go
+++ b/pkg/linters/docs/rules/bilingual.go
@@ -54,7 +54,7 @@ func (r *BilingualRule) CheckBilingual(m pkg.Module, errorList *errors.LintRuleE
 	fileSet := make(map[string]struct{}, len(files))
 	for _, f := range files {
 		rel := fsutils.Rel(modulePath, f)
-		// include only files directly under docs/ (exclude nested paths)
+		// only consider top-level docs/* files
 		if filepath.Dir(rel) != "docs" {
 			continue
 		}

--- a/pkg/linters/docs/rules/cyrillic_in_english.go
+++ b/pkg/linters/docs/rules/cyrillic_in_english.go
@@ -52,6 +52,11 @@ func (r *CyrillicInEnglishRule) CheckFiles(m pkg.Module, errorList *errors.LintR
 	files := fsutils.GetFiles(docsPath, false, fsutils.FilterFileByExtensions(markdownExtensions...))
 
 	for _, fileName := range files {
+		relFromModule := fsutils.Rel(modulePath, fileName)
+		// only consider top-level docs/* files
+		if filepath.Dir(relFromModule) != "docs" {
+			continue
+		}
 		r.checkFile(m, fileName, errorList)
 	}
 }


### PR DESCRIPTION
Documentation should be checked only in the /docs directory without subfolders.