### PR TITLE
[dmt] Ignore "_RU.md" documentation

### DIFF
--- a/pkg/linters/docs/rules/bilingual.go
+++ b/pkg/linters/docs/rules/bilingual.go
@@ -65,13 +65,14 @@ func (r *BilingualRule) CheckBilingual(m pkg.Module, errorList *errors.LintRuleE
 		if !strings.HasPrefix(rel, "docs/") {
 			continue
 		}
-		if !strings.HasSuffix(rel, ".md") || strings.HasSuffix(rel, ".ru.md") || strings.HasSuffix(rel, "_RU.md") {
-			continue
-		}
-
 		base := strings.TrimSuffix(rel, ".md")
 		ruRel := base + ".ru.md"
 		ruRelUpper := base + "_RU.md"
+
+		if !strings.HasSuffix(rel, ".md") || strings.HasSuffix(rel, ruRel) || strings.HasSuffix(rel, ruRelUpper) {
+			continue
+		}
+
 		if _, ok := fileSet[ruRel]; !ok {
 			// TODO: Delete it after renaming to .ru.md view
 			if _, altOk := fileSet[ruRelUpper]; altOk {

--- a/pkg/linters/docs/rules/bilingual.go
+++ b/pkg/linters/docs/rules/bilingual.go
@@ -65,13 +65,18 @@ func (r *BilingualRule) CheckBilingual(m pkg.Module, errorList *errors.LintRuleE
 		if !strings.HasPrefix(rel, "docs/") {
 			continue
 		}
-		if !strings.HasSuffix(rel, ".md") || strings.HasSuffix(rel, ".ru.md") {
+		if !strings.HasSuffix(rel, ".md") || strings.HasSuffix(rel, ".ru.md") || strings.HasSuffix(rel, "_RU.md") {
 			continue
 		}
 
 		base := strings.TrimSuffix(rel, ".md")
 		ruRel := base + ".ru.md"
+		ruRelUpper := base + "_RU.md"
 		if _, ok := fileSet[ruRel]; !ok {
+			// TODO: Delete it after renaming to .ru.md view
+			if _, altOk := fileSet[ruRelUpper]; altOk {
+				continue
+			}
 			errorList.
 				WithFilePath(rel).
 				Error("Russian counterpart is missing: need to create a matching .ru.md in docs/")

--- a/pkg/linters/docs/rules/bilingual.go
+++ b/pkg/linters/docs/rules/bilingual.go
@@ -67,14 +67,14 @@ func (r *BilingualRule) CheckBilingual(m pkg.Module, errorList *errors.LintRuleE
 		}
 		base := strings.TrimSuffix(rel, ".md")
 		ruRel := base + ".ru.md"
+		// TODO: Delete it after renaming to .ru.md view
 		ruRelUpper := base + "_RU.md"
 
-		if !strings.HasSuffix(rel, ".md") || strings.HasSuffix(rel, ruRel) || strings.HasSuffix(rel, ruRelUpper) {
+		if !strings.HasSuffix(rel, ".md") || !strings.HasSuffix(rel, ruRelUpper) || strings.HasSuffix(rel, ruRel) {
 			continue
 		}
 
 		if _, ok := fileSet[ruRel]; !ok {
-			// TODO: Delete it after renaming to .ru.md view
 			if _, altOk := fileSet[ruRelUpper]; altOk {
 				continue
 			}

--- a/pkg/linters/docs/rules/cyrillic_in_english.go
+++ b/pkg/linters/docs/rules/cyrillic_in_english.go
@@ -24,7 +24,7 @@ var (
 	cyrPointerRe       = regexp.MustCompile(`[А-Яа-яЁё]`)
 	cyrFillerRe        = regexp.MustCompile(`[^А-Яа-яЁё]`)
 	russianDocRe       = regexp.MustCompile(`\.ru\.md$`)
-	russianDocUpperRe  = regexp.MustCompile(`_RU\.md$`)
+	russianDocUpperRe  = regexp.MustCompile(`(?i)_ru\.md$`)
 	markdownExtensions = []string{".md", ".markdown"}
 )
 

--- a/pkg/linters/docs/rules/cyrillic_in_english.go
+++ b/pkg/linters/docs/rules/cyrillic_in_english.go
@@ -24,6 +24,7 @@ var (
 	cyrPointerRe       = regexp.MustCompile(`[А-Яа-яЁё]`)
 	cyrFillerRe        = regexp.MustCompile(`[^А-Яа-яЁё]`)
 	russianDocRe       = regexp.MustCompile(`\.ru\.md$`)
+	russianDocUpperRe  = regexp.MustCompile(`_RU\.md$`)
 	markdownExtensions = []string{".md", ".markdown"}
 )
 
@@ -69,6 +70,11 @@ func (r *CyrillicInEnglishRule) checkFile(m pkg.Module, fileName string, errorLi
 	}
 
 	if russianDocRe.MatchString(fileName) {
+		return
+	}
+
+	// TODO: Delete it after renaming to .ru.md view
+	if russianDocUpperRe.MatchString(fileName) {
 		return
 	}
 


### PR DESCRIPTION
Currently, deckhouse contains many files with names *_RU.md
This leads to multiple errors and it is impossible to rename them quickly and without problems.
At the moment, we ignore such files in order not to cause problems in deckhouse and plan to remove this fallback in the future.