### PR TITLE
[dmt] Fix --version flag

### DIFF
--- a/cmd/dmt/root.go
+++ b/cmd/dmt/root.go
@@ -48,6 +48,7 @@ func execute() {
 		},
 		Version: version,
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			// TODO: move to separate package
 			flags.Version = version
 			logger.InitLogger(os.Stdout, flags.LogLevel)
 		},


### PR DESCRIPTION
This flag did not work and did not show the version, which is incorrect. 
The version variable has been updated, which makes it possible to post different versions to different channels.

Logs:
```
dmt % VERSION=v0.1.555
go build -ldflags="-s -w -X main.version=$VERSION" -o dmt ./cmd/dmt
dmt % ./dmt --version 
dmt version: v0.1.555
```