### PR TITLE
[dmt] Fix empty license check

### DIFF
--- a/pkg/linters/module/rules/license.go
+++ b/pkg/linters/module/rules/license.go
@@ -96,6 +96,9 @@ func filterFiles(rootPath, path string) bool {
 	if f.IsDir() {
 		return false
 	}
+	if f.Size() == 0 {
+		return false
+	}
 	path = fsutils.Rel(rootPath, path)
 	if fileToCheckRe.MatchString(path) && !fileToSkipRe.MatchString(path) {
 		return true


### PR DESCRIPTION
We should not check license files if they are empty.

### Tests:

File data: Nil

Before:
```
🐒 [license (#module)]
     Message:      unsupported file type:
                   %filepath%
     Module:       %modulename%
     FilePath:     %filepath%
```
After:
No errors