### PR TITLE
[dmt] Fixing unnecessary license finds

### DIFF
--- a/pkg/linters/module/rules/license_parser.go
+++ b/pkg/linters/module/rules/license_parser.go
@@ -319,7 +319,7 @@ func (p *LicenseParser) extractWithStyle(header string, style CommentStyle) stri
 				content = strings.TrimSpace(content)
 
 				// Check if this might be start of license
-				if !inLicense && (strings.Contains(content, "Copyright") || strings.Contains(content, "copyright")) {
+				if !inLicense && strings.HasPrefix(strings.ToLower(content), "copyright") {
 					inLicense = true
 				}
 


### PR DESCRIPTION
Sometimes there are comments in the code such as `//go:generate go tool mockgen -write_source_comment -copyright_file=…/…/…/…/hack/copyright.txt -destination=…/mocks/mock_callbacks.go -source=cache.go -typed -package=mocks`, which is why the linter considered them licenses.
Licenses currently always start with the words "Copyright", which covers most cases.