### PR TITLE
[fix] Checking version for deckhouse weight

### DIFF
--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -38,8 +38,7 @@ import (
 )
 
 const (
-	DefinitionFileRuleName    = "definition-file"
-	MinDeckhouseVersionWeight = "1.72.0"
+	DefinitionFileRuleName = "definition-file"
 )
 
 // Valid edition values
@@ -283,35 +282,6 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 
 	if yml.Critical && yml.Weight == 0 {
 		errorList.Error("Field 'weight' must not be zero for critical modules")
-	}
-
-	if !yml.Critical && yml.Weight > 0 {
-		yml.validateModuleWithWeight(errorList)
-	}
-}
-
-func (m *DeckhouseModule) validateModuleWithWeight(errorList *errors.LintRuleErrorsList) {
-	deckhouseReq := ""
-	if m.Requirements != nil {
-		deckhouseReq = m.Requirements.Deckhouse
-	}
-
-	if deckhouseReq == "" {
-		errorList.Errorf("Non-critical module with 'weight' field requires 'requirements.deckhouse: \">= 1.72\"' or higher")
-		return
-	}
-
-	constraint, err := semver.NewConstraint(deckhouseReq)
-	if err != nil {
-		errorList.Errorf("Invalid deckhouse requirement %q: %s", deckhouseReq, err)
-		return
-	}
-
-	minVersion := semver.MustParse(MinDeckhouseVersionWeight)
-	if constraint.Check(minVersion) {
-		errorList.Errorf("Field `weight` must be removed for non-critical module when 'requirements.deckhouse' allows >= %s (current: %q)",
-			MinDeckhouseVersionWeight,
-			deckhouseReq)
 	}
 }
 

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	DefinitionFileRuleName = "definition-file"
+	DefinitionFileRuleName    = "definition-file"
+	MinDeckhouseVersionWeight = "1.72.0"
 )
 
 // Valid edition values
@@ -285,7 +286,33 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 	}
 
 	if !yml.Critical && yml.Weight > 0 {
-		errorList.Warn("Unnecessary field 'weight' must be removed for non-critical module")
+		yml.validateVersionForWeight(errorList)
+	}
+}
+
+func (m *DeckhouseModule) validateVersionForWeight(errorList *errors.LintRuleErrorsList) {
+	deckhouseReq := ""
+	if m.Requirements != nil {
+		deckhouseReq = m.Requirements.Deckhouse
+	}
+
+	if deckhouseReq == "" {
+		errorList.Errorf("Non-critical module with 'weight' field requires 'requirements.deckhouse: \">= 1.72\"' or higher")
+		return
+	}
+
+	constraint, err := semver.NewConstraint(deckhouseReq)
+	if err != nil {
+		errorList.Errorf("Invalid deckhouse requirement %q: %s", deckhouseReq, err)
+		return
+	}
+
+	minVersion := semver.MustParse(MinDeckhouseVersionWeight)
+	if !constraint.Check(minVersion) {
+		errorList.Errorf(
+			"Non-critical module with 'weight' field requires 'requirements.deckhouse: \">= 1.72\"' or higher, but current requirement is %q",
+			deckhouseReq,
+		)
 	}
 }
 

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -308,7 +308,9 @@ func (m *DeckhouseModule) validateVersionForWeight(errorList *errors.LintRuleErr
 	}
 
 	minVersion := semver.MustParse(MinDeckhouseVersionWeight)
-	if !constraint.Check(minVersion) {
+	if constraint.Check(minVersion) {
+		errorList.Errorf("Field 'weight' must be removed for non-critical module when 'requirements.deckhouse' is %q or higher", deckhouseReq)
+	} else {
 		errorList.Errorf(
 			"Non-critical module with 'weight' field requires 'requirements.deckhouse: \">= 1.72\"' or higher, but current requirement is %q",
 			deckhouseReq,

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -40,6 +40,7 @@ import (
 const (
 	DefinitionFileRuleName    = "definition-file"
 	MinDeckhouseVersionWeight = "1.72.0"
+	BelowMinDeckhouseVersion  = "1.71.0"
 )
 
 // Valid edition values
@@ -309,13 +310,11 @@ func (m *DeckhouseModule) validateVersionForWeight(errorList *errors.LintRuleErr
 
 	minVersion := semver.MustParse(MinDeckhouseVersionWeight)
 	if constraint.Check(minVersion) {
-		errorList.Errorf("Field 'weight' must be removed for non-critical module when 'requirements.deckhouse' is %q or higher", deckhouseReq)
-	} else {
-		errorList.Errorf(
-			"Non-critical module with 'weight' field requires 'requirements.deckhouse: \">= 1.72\"' or higher, but current requirement is %q",
-			deckhouseReq,
-		)
+		errorList.Errorf("Field `weight` must be removed for non-critical module when 'requirements.deckhouse' allows >= %s (current: %q)",
+			MinDeckhouseVersionWeight,
+			deckhouseReq)
 	}
+
 }
 
 func (m ModuleRequirements) validateRequirements(errorList *errors.LintRuleErrorsList) {

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -40,7 +40,6 @@ import (
 const (
 	DefinitionFileRuleName    = "definition-file"
 	MinDeckhouseVersionWeight = "1.72.0"
-	BelowMinDeckhouseVersion  = "1.71.0"
 )
 
 // Valid edition values
@@ -287,11 +286,11 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 	}
 
 	if !yml.Critical && yml.Weight > 0 {
-		yml.validateVersionForWeight(errorList)
+		yml.validateModuleWithWeight(errorList)
 	}
 }
 
-func (m *DeckhouseModule) validateVersionForWeight(errorList *errors.LintRuleErrorsList) {
+func (m *DeckhouseModule) validateModuleWithWeight(errorList *errors.LintRuleErrorsList) {
 	deckhouseReq := ""
 	if m.Requirements != nil {
 		deckhouseReq = m.Requirements.Deckhouse
@@ -314,7 +313,6 @@ func (m *DeckhouseModule) validateVersionForWeight(errorList *errors.LintRuleErr
 			MinDeckhouseVersionWeight,
 			deckhouseReq)
 	}
-
 }
 
 func (m ModuleRequirements) validateRequirements(errorList *errors.LintRuleErrorsList) {

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -260,13 +260,10 @@ func TestCheckDefinitionFile_NonCriticalModuleWithWeight(t *testing.T) {
 
 	err := os.WriteFile(moduleFilePath, []byte(`
 name: test-non-critical
-weight: 950
+weight: 10
 stage: Experimental
 descriptions:
   en: "Test description"
-requirements:
-  bootstrapped: true
-  deckhouse: ">= 1.71"
 `), 0600)
 	require.NoError(t, err)
 
@@ -274,19 +271,15 @@ requirements:
 	errorList := errors.NewLintRuleErrorsList()
 	rule.CheckDefinitionFile(tempDir, errorList)
 
-	assert.True(t, errorList.ContainsErrors())
+	// Weight warning for non-critical modules is now version-aware and handled in requirements.go,
+	// so CheckDefinitionFile should not produce any warnings about weight for non-critical modules.
+	assert.False(t, errorList.ContainsErrors(), "Expected no errors for non-critical module with weight")
 
-	found := false
 	for _, e := range errorList.GetErrors() {
-		if e.Level == pkg.Error &&
-			strings.Contains(e.Text, "weight") &&
-			strings.Contains(e.Text, "must be removed") {
-			found = true
-			break
+		if e.Level == pkg.Warn && e.Text == "Unnecessary field 'weight' must be removed for non-critical module" {
+			t.Error("Should not produce unconditional weight warning for non-critical modules; this is now version-aware in requirements.go")
 		}
 	}
-
-	assert.True(t, found, "Expected error about removing 'weight'")
 }
 
 func TestCheckDefinitionFile_InvalidStage(t *testing.T) {

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -273,7 +273,31 @@ requirements:
 	errorList := errors.NewLintRuleErrorsList()
 	rule.CheckDefinitionFile(tempDir, errorList)
 
-	assert.False(t, errorList.ContainsErrors(), "Expected no errors for non-critical module with weight and deckhouse requirement >= 1.72")
+	assert.True(t, errorList.ContainsErrors(), "Expected error for non-critical module with weight and deckhouse requirement >= 1.72")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "Field 'weight' must be removed for non-critical module")
+}
+
+func TestCheckDefinitionFile_NonCriticalModuleWithWeightOldDeckhouse(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)
+
+	err := os.WriteFile(moduleFilePath, []byte(`
+name: test-non-critical
+weight: 10
+stage: Experimental
+descriptions:
+  en: "Test description"
+requirements:
+  deckhouse: "< 1.72"
+`), 0600)
+	require.NoError(t, err)
+
+	rule := NewDefinitionFileRule(false)
+	errorList := errors.NewLintRuleErrorsList()
+	rule.CheckDefinitionFile(tempDir, errorList)
+
+	assert.True(t, errorList.ContainsErrors(), "Expected error for non-critical module with weight and deckhouse requirement < 1.72")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "requires 'requirements.deckhouse: \">= 1.72\"' or higher")
 }
 
 func TestCheckDefinitionFile_InvalidStage(t *testing.T) {

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -260,12 +260,13 @@ func TestCheckDefinitionFile_NonCriticalModuleWithWeight(t *testing.T) {
 
 	err := os.WriteFile(moduleFilePath, []byte(`
 name: test-non-critical
-weight: 10
+weight: 950
 stage: Experimental
 descriptions:
   en: "Test description"
 requirements:
-  deckhouse: ">= 1.72"
+  bootstrapped: true
+  deckhouse: ">= 1.71"
 `), 0600)
 	require.NoError(t, err)
 
@@ -273,31 +274,19 @@ requirements:
 	errorList := errors.NewLintRuleErrorsList()
 	rule.CheckDefinitionFile(tempDir, errorList)
 
-	assert.True(t, errorList.ContainsErrors(), "Expected error for non-critical module with weight and deckhouse requirement >= 1.72")
-	assert.Contains(t, errorList.GetErrors()[0].Text, "Field 'weight' must be removed for non-critical module")
-}
+	assert.True(t, errorList.ContainsErrors())
 
-func TestCheckDefinitionFile_NonCriticalModuleWithWeightOldDeckhouse(t *testing.T) {
-	tempDir := t.TempDir()
-	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)
+	found := false
+	for _, e := range errorList.GetErrors() {
+		if e.Level == pkg.Error &&
+			strings.Contains(e.Text, "weight") &&
+			strings.Contains(e.Text, "must be removed") {
+			found = true
+			break
+		}
+	}
 
-	err := os.WriteFile(moduleFilePath, []byte(`
-name: test-non-critical
-weight: 10
-stage: Experimental
-descriptions:
-  en: "Test description"
-requirements:
-  deckhouse: "< 1.72"
-`), 0600)
-	require.NoError(t, err)
-
-	rule := NewDefinitionFileRule(false)
-	errorList := errors.NewLintRuleErrorsList()
-	rule.CheckDefinitionFile(tempDir, errorList)
-
-	assert.True(t, errorList.ContainsErrors(), "Expected error for non-critical module with weight and deckhouse requirement < 1.72")
-	assert.Contains(t, errorList.GetErrors()[0].Text, "requires 'requirements.deckhouse: \">= 1.72\"' or higher")
+	assert.True(t, found, "Expected error about removing 'weight'")
 }
 
 func TestCheckDefinitionFile_InvalidStage(t *testing.T) {

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -264,6 +264,8 @@ weight: 10
 stage: Experimental
 descriptions:
   en: "Test description"
+requirements:
+  deckhouse: ">= 1.72"
 `), 0600)
 	require.NoError(t, err)
 
@@ -271,16 +273,7 @@ descriptions:
 	errorList := errors.NewLintRuleErrorsList()
 	rule.CheckDefinitionFile(tempDir, errorList)
 
-	assert.False(t, errorList.ContainsErrors(), "Expected no errors for non-critical module with weight")
-
-	found := false
-	for _, e := range errorList.GetErrors() {
-		if e.Level == pkg.Warn && e.Text == "Unnecessary field 'weight' must be removed for non-critical module" {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "Expected warning for non-critical module with weight")
+	assert.False(t, errorList.ContainsErrors(), "Expected no errors for non-critical module with weight and deckhouse requirement >= 1.72")
 }
 
 func TestCheckDefinitionFile_InvalidStage(t *testing.T) {

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -254,34 +254,6 @@ descriptions:
 	assert.Contains(t, errorList.GetErrors()[0].Text, "Field 'weight' must not be zero for critical modules")
 }
 
-func TestCheckDefinitionFile_NonCriticalModuleWithWeight(t *testing.T) {
-	tempDir := t.TempDir()
-	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)
-
-	err := os.WriteFile(moduleFilePath, []byte(`
-name: test-non-critical
-weight: 10
-stage: Experimental
-descriptions:
-  en: "Test description"
-`), 0600)
-	require.NoError(t, err)
-
-	rule := NewDefinitionFileRule(false)
-	errorList := errors.NewLintRuleErrorsList()
-	rule.CheckDefinitionFile(tempDir, errorList)
-
-	// Weight warning for non-critical modules is now version-aware and handled in requirements.go,
-	// so CheckDefinitionFile should not produce any warnings about weight for non-critical modules.
-	assert.False(t, errorList.ContainsErrors(), "Expected no errors for non-critical module with weight")
-
-	for _, e := range errorList.GetErrors() {
-		if e.Level == pkg.Warn && e.Text == "Unnecessary field 'weight' must be removed for non-critical module" {
-			t.Error("Should not produce unconditional weight warning for non-critical modules; this is now version-aware in requirements.go")
-		}
-	}
-}
-
 func TestCheckDefinitionFile_InvalidStage(t *testing.T) {
 	tempDir := t.TempDir()
 	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)

--- a/pkg/linters/module/rules/requirements.go
+++ b/pkg/linters/module/rules/requirements.go
@@ -91,17 +91,15 @@ type ComponentRequirement struct {
 	Description   string
 }
 
-// RequirementCheck defines a single requirement check configuration
-// Detector returns true if the rule should be applied to the module
-// Requirements defines the minimum versions required for this rule
-// Description is the rule description
-// Validator is a custom validation function; when set, RunAllChecks calls it instead of validateRequirement
+// RequirementCheck defines a single requirement check configuration.
+// Detector returns true if the check should be applied to the module.
+// When Requirements is non-empty, validateRequirement verifies version constraints.
+// When Requirements is empty, the Description is emitted as the error.
 type RequirementCheck struct {
 	Name         string
 	Requirements []ComponentRequirement
 	Description  string
 	Detector     func(modulePath string, module *DeckhouseModule) bool
-	Validator    func(modulePath string, module *DeckhouseModule, errorList *errors.LintRuleErrorsList)
 }
 
 // RequirementsRegistry holds all requirement checks
@@ -187,10 +185,6 @@ func NewRequirementsRegistry() *RequirementsRegistry {
 				module.Requirements.Bootstrapped &&
 				deckhouseVersionAtLeast(module, MinimalDeckhouseVersionForBootstrappedDeprecation)
 		},
-		Validator: func(_ string, _ *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
-			errorList.Errorf("requirements [bootstrapped_deprecated]: requirements.bootstrapped must be removed for Deckhouse >= %s",
-				MinimalDeckhouseVersionForBootstrappedDeprecation)
-		},
 	})
 
 	// Weight deprecation check - weight must be removed for non-critical modules when Deckhouse >= 1.72
@@ -203,10 +197,6 @@ func NewRequirementsRegistry() *RequirementsRegistry {
 				!module.Critical &&
 				deckhouseVersionAtLeast(module, MinimalDeckhouseVersionForWeightDeprecation)
 		},
-		Validator: func(_ string, _ *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
-			errorList.Errorf("requirements [weight_deprecated]: weight must be removed for non-critical modules when Deckhouse >= %s",
-				MinimalDeckhouseVersionForWeightDeprecation)
-		},
 	})
 
 	return registry
@@ -218,15 +208,9 @@ func (r *RequirementsRegistry) RegisterCheck(check RequirementCheck) {
 }
 
 // RunAllChecks executes all registered requirement checks.
-// When Validator is set, it is called instead of validateRequirement.
 func (r *RequirementsRegistry) RunAllChecks(modulePath string, module *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
 	for _, check := range r.checks {
 		if !check.Detector(modulePath, module) {
-			continue
-		}
-
-		if check.Validator != nil {
-			check.Validator(modulePath, module, errorList)
 			continue
 		}
 
@@ -234,8 +218,14 @@ func (r *RequirementsRegistry) RunAllChecks(modulePath string, module *Deckhouse
 	}
 }
 
-// validateRequirement validates a single requirement check
+// validateRequirement validates a single requirement check.
+// When Requirements is empty the check is a pure detection rule and the Description is emitted as the error.
 func (r *RequirementsRegistry) validateRequirement(check RequirementCheck, modulePath string, module *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
+	if len(check.Requirements) == 0 {
+		errorList.Errorf("requirements [%s]: %s", check.Name, check.Description)
+		return
+	}
+
 	if module == nil {
 		errorList.Errorf("requirements [%s]: %s, module is not defined", check.Name, check.Description)
 		return

--- a/pkg/linters/module/rules/requirements.go
+++ b/pkg/linters/module/rules/requirements.go
@@ -48,6 +48,11 @@ const (
 	// MinimalDeckhouseVersionForModuleSDK03 defines the minimum Deckhouse version required for Module-SDK >= 0.3
 	MinimalDeckhouseVersionForModuleSDK03 = "1.71.0"
 
+	// MinimalDeckhouseVersionForWeightDeprecation defines the version where weight became irrelevant for non-critical modules
+	MinimalDeckhouseVersionForWeightDeprecation = "1.72.0"
+	// MinimalDeckhouseVersionForBootstrappedDeprecation defines the version where bootstrapped was deprecated
+	MinimalDeckhouseVersionForBootstrappedDeprecation = "1.72.0"
+
 	// Common patterns used in Go files
 	AppRunPattern = `\w+\.Run\(`
 )
@@ -90,11 +95,13 @@ type ComponentRequirement struct {
 // Detector returns true if the rule should be applied to the module
 // Requirements defines the minimum versions required for this rule
 // Description is the rule description
+// Validator is a custom validation function; when set, RunAllChecks calls it instead of validateRequirement
 type RequirementCheck struct {
 	Name         string
 	Requirements []ComponentRequirement
 	Description  string
 	Detector     func(modulePath string, module *DeckhouseModule) bool
+	Validator    func(modulePath string, module *DeckhouseModule, errorList *errors.LintRuleErrorsList)
 }
 
 // RequirementsRegistry holds all requirement checks
@@ -170,6 +177,38 @@ func NewRequirementsRegistry() *RequirementsRegistry {
 		},
 	})
 
+	// Bootstrapped deprecation check - bootstrapped must be removed for Deckhouse >= 1.72
+	registry.RegisterCheck(RequirementCheck{
+		Name:        "bootstrapped_deprecated",
+		Description: "requirements.bootstrapped must be removed for Deckhouse >= " + MinimalDeckhouseVersionForBootstrappedDeprecation,
+		Detector: func(_ string, module *DeckhouseModule) bool {
+			return module != nil &&
+				module.Requirements != nil &&
+				module.Requirements.Bootstrapped &&
+				deckhouseVersionAtLeast(module, MinimalDeckhouseVersionForBootstrappedDeprecation)
+		},
+		Validator: func(_ string, _ *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
+			errorList.Errorf("requirements [bootstrapped_deprecated]: requirements.bootstrapped must be removed for Deckhouse >= %s",
+				MinimalDeckhouseVersionForBootstrappedDeprecation)
+		},
+	})
+
+	// Weight deprecation check - weight must be removed for non-critical modules when Deckhouse >= 1.72
+	registry.RegisterCheck(RequirementCheck{
+		Name:        "weight_deprecated",
+		Description: "weight must be removed for non-critical modules when Deckhouse >= " + MinimalDeckhouseVersionForWeightDeprecation,
+		Detector: func(_ string, module *DeckhouseModule) bool {
+			return module != nil &&
+				module.Weight > 0 &&
+				!module.Critical &&
+				deckhouseVersionAtLeast(module, MinimalDeckhouseVersionForWeightDeprecation)
+		},
+		Validator: func(_ string, _ *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
+			errorList.Errorf("requirements [weight_deprecated]: weight must be removed for non-critical modules when Deckhouse >= %s",
+				MinimalDeckhouseVersionForWeightDeprecation)
+		},
+	})
+
 	return registry
 }
 
@@ -178,12 +217,20 @@ func (r *RequirementsRegistry) RegisterCheck(check RequirementCheck) {
 	r.checks = append(r.checks, check)
 }
 
-// RunAllChecks executes all registered requirement checks
+// RunAllChecks executes all registered requirement checks.
+// When Validator is set, it is called instead of validateRequirement.
 func (r *RequirementsRegistry) RunAllChecks(modulePath string, module *DeckhouseModule, errorList *errors.LintRuleErrorsList) {
 	for _, check := range r.checks {
-		if check.Detector(modulePath, module) {
-			r.validateRequirement(check, modulePath, module, errorList)
+		if !check.Detector(modulePath, module) {
+			continue
 		}
+
+		if check.Validator != nil {
+			check.Validator(modulePath, module, errorList)
+			continue
+		}
+
+		r.validateRequirement(check, modulePath, module, errorList)
 	}
 }
 
@@ -358,6 +405,31 @@ func hasOptionalModules(module *DeckhouseModule) bool {
 		}
 	}
 	return false
+}
+
+// deckhouseVersionAtLeast checks if the module's deckhouse version constraint starts at or above minVersion.
+// Returns false if there is no deckhouse requirement or the constraint cannot be parsed.
+func deckhouseVersionAtLeast(module *DeckhouseModule, minVersion string) bool {
+	if module == nil || module.Requirements == nil || module.Requirements.Deckhouse == "" {
+		return false
+	}
+
+	constraint, err := semver.NewConstraint(module.Requirements.Deckhouse)
+	if err != nil {
+		return false
+	}
+
+	minAllowed := findMinimalAllowedVersion(constraint)
+	if minAllowed == nil {
+		return false
+	}
+
+	minVer, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return false
+	}
+
+	return !minAllowed.LessThan(minVer)
 }
 
 func (r *RequirementsRule) CheckRequirements(modulePath string, errorList *errors.LintRuleErrorsList) {

--- a/pkg/linters/module/rules/requirements_edge_cases_test.go
+++ b/pkg/linters/module/rules/requirements_edge_cases_test.go
@@ -546,6 +546,324 @@ func TestHasOptionalModules(t *testing.T) {
 	}
 }
 
+func TestDeckhouseVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		name       string
+		module     *DeckhouseModule
+		minVersion string
+		expected   bool
+	}{
+		{
+			name:       "nil module",
+			module:     nil,
+			minVersion: "1.72.0",
+			expected:   false,
+		},
+		{
+			name: "nil requirements",
+			module: &DeckhouseModule{
+				Name: "test",
+			},
+			minVersion: "1.72.0",
+			expected:   false,
+		},
+		{
+			name: "empty deckhouse constraint",
+			module: &DeckhouseModule{
+				Name:         "test",
+				Requirements: &ModuleRequirements{},
+			},
+			minVersion: "1.72.0",
+			expected:   false,
+		},
+		{
+			name: "deckhouse >= 1.72 with min 1.72",
+			module: &DeckhouseModule{
+				Name: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.72.0",
+					},
+				},
+			},
+			minVersion: "1.72.0",
+			expected:   true,
+		},
+		{
+			name: "deckhouse >= 1.73 with min 1.72",
+			module: &DeckhouseModule{
+				Name: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.73.0",
+					},
+				},
+			},
+			minVersion: "1.72.0",
+			expected:   true,
+		},
+		{
+			name: "deckhouse >= 1.71 with min 1.72",
+			module: &DeckhouseModule{
+				Name: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.71.0",
+					},
+				},
+			},
+			minVersion: "1.72.0",
+			expected:   false,
+		},
+		{
+			name: "deckhouse >= 1.68, < 1.72 with min 1.72",
+			module: &DeckhouseModule{
+				Name: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.68.0, < 1.72.0",
+					},
+				},
+			},
+			minVersion: "1.72.0",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deckhouseVersionAtLeast(tt.module, tt.minVersion)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBootstrappedDeprecationCheck(t *testing.T) {
+	helper := NewTestHelper(t)
+
+	tests := []struct {
+		name           string
+		module         *DeckhouseModule
+		expectedErrors []string
+		description    string
+	}{
+		{
+			name: "deckhouse >= 1.72 with bootstrapped true - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse:    ">= 1.72.0",
+						Bootstrapped: true,
+					},
+				},
+			},
+			expectedErrors: []string{"requirements [bootstrapped_deprecated]: requirements.bootstrapped must be removed for Deckhouse >= 1.72.0"},
+			description:    "Should error when bootstrapped is true and deckhouse >= 1.72",
+		},
+		{
+			name: "deckhouse >= 1.73 with bootstrapped true - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse:    ">= 1.73.0",
+						Bootstrapped: true,
+					},
+				},
+			},
+			expectedErrors: []string{"requirements [bootstrapped_deprecated]: requirements.bootstrapped must be removed for Deckhouse >= 1.72.0"},
+			description:    "Should error when bootstrapped is true and deckhouse >= 1.73",
+		},
+		{
+			name: "deckhouse >= 1.71 with bootstrapped true - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse:    ">= 1.71.0",
+						Bootstrapped: true,
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when deckhouse < 1.72 even with bootstrapped true",
+		},
+		{
+			name: "deckhouse >= 1.72 without bootstrapped - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.72.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when bootstrapped is not set",
+		},
+		{
+			name: "no deckhouse requirement with bootstrapped true - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Bootstrapped: true,
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when no deckhouse requirement is specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			registry := NewRequirementsRegistry()
+			errorList := errors.NewLintRuleErrorsList()
+			registry.RunAllChecks("", tt.module, errorList)
+			helper.AssertErrors(errorList, tt.expectedErrors)
+		})
+	}
+}
+
+func TestWeightDeprecationCheck(t *testing.T) {
+	helper := NewTestHelper(t)
+
+	tests := []struct {
+		name           string
+		module         *DeckhouseModule
+		expectedErrors []string
+		description    string
+	}{
+		{
+			name: "deckhouse >= 1.72 non-critical with weight - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Weight:    950,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.72.0",
+					},
+				},
+			},
+			expectedErrors: []string{"requirements [weight_deprecated]: weight must be removed for non-critical modules when Deckhouse >= 1.72.0"},
+			description:    "Should error when non-critical module has weight and deckhouse >= 1.72",
+		},
+		{
+			name: "deckhouse >= 1.73 non-critical with weight - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Weight:    950,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.73.0",
+					},
+				},
+			},
+			expectedErrors: []string{"requirements [weight_deprecated]: weight must be removed for non-critical modules when Deckhouse >= 1.72.0"},
+			description:    "Should error when non-critical module has weight and deckhouse >= 1.73",
+		},
+		{
+			name: "deckhouse >= 1.71 non-critical with weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Weight:    950,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.71.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when deckhouse < 1.72",
+		},
+		{
+			name: "deckhouse >= 1.71 non-critical with weight and bootstrapped - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Weight:    950,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse:    ">= 1.71",
+						Bootstrapped: true,
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error for pre-1.72 module with weight and bootstrapped (real-world production case)",
+		},
+		{
+			name: "deckhouse >= 1.72 critical with weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Stage:     "Experimental",
+				Critical:  true,
+				Weight:    10,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.72.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error for critical modules regardless of deckhouse version",
+		},
+		{
+			name: "no deckhouse requirement non-critical with weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    950,
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when no deckhouse requirement is specified",
+		},
+		{
+			name: "no deckhouse requirement with requirements section non-critical with weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    950,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Kubernetes: ">= 1.20.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when deckhouse requirement is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			registry := NewRequirementsRegistry()
+			errorList := errors.NewLintRuleErrorsList()
+			registry.RunAllChecks("", tt.module, errorList)
+			helper.AssertErrors(errorList, tt.expectedErrors)
+		})
+	}
+}
+
 func TestOptionalModulesRequirementCheck(t *testing.T) {
 	helper := NewTestHelper(t)
 


### PR DESCRIPTION
Rignt now, we should check if module has weight and if he supports deckhouse >= 1.72. Based on that we should make a decision. 
