### PR TITLE
[dmt] Fix bilingual rule: exclude test files from doc-ru scanning

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -341,6 +341,7 @@ func mapSimpleLinterRules(linterSettings *pkg.LintersSettings, configSettings *c
 	linterSettings.OpenAPI.Rules.HARule.SetLevel("", openAPIImpact)
 	linterSettings.OpenAPI.Rules.CRDsRule.SetLevel("", openAPIImpact)
 	linterSettings.OpenAPI.Rules.KeysRule.SetLevel("", openAPIImpact)
+	linterSettings.OpenAPI.Rules.BilingualRule.SetLevel("", openAPIImpact)
 
 	// RBAC rules
 	rbacImpact := configSettings.Rbac.Impact

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -108,10 +108,11 @@ type OpenAPILinterConfig struct {
 	ExcludeRules OpenAPIExcludeRules
 }
 type OpenAPILinterRules struct {
-	EnumRule RuleConfig
-	HARule   RuleConfig
-	CRDsRule RuleConfig
-	KeysRule RuleConfig
+	EnumRule      RuleConfig
+	HARule        RuleConfig
+	CRDsRule      RuleConfig
+	KeysRule      RuleConfig
+	BilingualRule RuleConfig
 }
 
 type OpenAPIExcludeRules struct {

--- a/pkg/linters/openapi/README.md
+++ b/pkg/linters/openapi/README.md
@@ -14,6 +14,7 @@ Proper OpenAPI schema validation is critical for module configuration, ensuring 
 | [high-availability](#high-availability) | Validates highAvailability field has no default value | ✅ | enabled |
 | [keys](#keys) | Validates property names don't use banned names | ✅ | enabled |
 | [deckhouse-crds](#deckhouse-crds) | Validates Deckhouse CRD structure and metadata | ✅ | enabled |
+| [bilingual](#bilingual) | Validates translation files (`doc-ru-`) exist for OpenAPI and CRD files | ✅ | enabled |
 
 ## Rule Details
 
@@ -606,6 +607,90 @@ linters-settings:
 
 **Note:** Only CRDs with `deckhouse.io` in their name are validated by this rule. Third-party CRDs are automatically skipped.
 
+### bilingual
+
+**Purpose:** Ensures that OpenAPI schema files and CRD files have corresponding Russian translation files (`doc-ru-` prefix). This maintains bilingual documentation for all resource definitions, which is required for proper documentation generation in Deckhouse modules.
+
+**Description:**
+
+Validates that every resource file in `openapi/` and `crds/` directories has a corresponding translation file with the `doc-ru-` prefix. Also checks for orphaned translation files that have no corresponding base file.
+
+**What it checks:**
+
+1. For each YAML file in `openapi/` (except `values.yaml` and test files): checks that a `doc-ru-` prefixed counterpart exists in the same directory
+2. For each YAML file in `crds/` (except test files): checks that a `doc-ru-` prefixed counterpart exists in the same directory
+3. For each `doc-ru-` file: checks that the corresponding base file exists (detects orphaned translations)
+
+**Why it matters:**
+
+1. **Bilingual Documentation**: Deckhouse modules require documentation in both English and Russian
+2. **Documentation Completeness**: Missing translations lead to incomplete module documentation
+3. **Consistency**: Keeps resource files and their translations in sync
+4. **Orphan Detection**: Finds stale translation files that no longer have a base resource
+
+**Examples:**
+
+❌ **Incorrect** - Missing translation for OpenAPI config:
+
+```
+openapi/
+  config-values.yaml        # ❌ No doc-ru- counterpart
+  values.yaml               # Skipped (internal values)
+```
+
+**Error:**
+```
+Error: translation file is missing: expected "doc-ru-config-values.yaml" in the same directory
+```
+
+❌ **Incorrect** - Missing translation for CRD:
+
+```
+crds/
+  my-resource.yaml          # ❌ No doc-ru- counterpart
+```
+
+**Error:**
+```
+Error: translation file is missing: expected "doc-ru-my-resource.yaml" in the same directory
+```
+
+❌ **Incorrect** - Orphaned translation file:
+
+```
+crds/
+  doc-ru-old-resource.yaml  # ❌ No base file (old-resource.yaml is missing)
+```
+
+**Error:**
+```
+Error: translation file has no corresponding base file: expected "old-resource.yaml"
+```
+
+✅ **Correct** - All files have translations:
+
+```
+openapi/
+  config-values.yaml        # ✅ Has doc-ru- counterpart
+  doc-ru-config-values.yaml # ✅ Has base file
+  values.yaml               # Skipped (internal values)
+
+crds/
+  my-resource.yaml          # ✅ Has doc-ru- counterpart
+  doc-ru-my-resource.yaml   # ✅ Has base file
+```
+
+**Configuration:**
+
+```yaml
+# .dmt.yaml
+linters-settings:
+  openapi:
+    impact: error  # Controls the impact level for all openapi rules including bilingual
+```
+
+---
+
 ## Configuration
 
 The OpenAPI linter can be configured at the module level with rule-specific exclusions.
@@ -980,6 +1065,51 @@ Error: CRD contains "deprecated" key at path "spec.versions[].schema.openAPIV3Sc
        type: string
        description: Replacement for the deprecated oldField
    ```
+
+### Issue: Missing translation file for OpenAPI or CRD
+
+**Symptom:**
+```
+Error: translation file is missing: expected "doc-ru-config-values.yaml" in the same directory
+```
+
+**Cause:** A resource file in `openapi/` or `crds/` directory doesn't have a corresponding `doc-ru-` translation file.
+
+**Solutions:**
+
+1. **Create the translation file:**
+
+   ```bash
+   # For openapi files
+   cp openapi/config-values.yaml openapi/doc-ru-config-values.yaml
+   # Edit doc-ru-config-values.yaml to add Russian descriptions
+
+   # For CRD files
+   cp crds/my-resource.yaml crds/doc-ru-my-resource.yaml
+   # Edit doc-ru-my-resource.yaml to add Russian descriptions
+   ```
+
+2. **Translation file naming convention:**
+
+   | Base file | Translation file |
+   |-----------|-----------------|
+   | `config-values.yaml` | `doc-ru-config-values.yaml` |
+   | `instance_class.yaml` | `doc-ru-instance_class.yaml` |
+   | `crds/my-resource.yaml` | `crds/doc-ru-my-resource.yaml` |
+
+### Issue: Orphaned translation file
+
+**Symptom:**
+```
+Error: translation file has no corresponding base file: expected "old-resource.yaml"
+```
+
+**Cause:** A `doc-ru-` translation file exists without a corresponding base resource file. This typically happens when a resource file was renamed or deleted but its translation was not.
+
+**Solutions:**
+
+1. **Remove the orphaned translation file** if the base resource was intentionally deleted
+2. **Rename the translation file** to match the new base file name
 
 ### Issue: Enum validation in complex nested structures
 

--- a/pkg/linters/openapi/openapi.go
+++ b/pkg/linters/openapi/openapi.go
@@ -148,6 +148,9 @@ func filterDocRuOpenAPIFiles(rootPath, path string) bool {
 	if !strings.HasPrefix(filename, "doc-ru-") {
 		return false
 	}
+	if strings.HasSuffix(filename, "-tests.yaml") {
+		return false
+	}
 
 	return openapiYamlRegex.MatchString(relPath)
 }
@@ -157,6 +160,9 @@ func filterDocRuCRDFiles(rootPath, path string) bool {
 	filename := filepath.Base(relPath)
 
 	if !strings.HasPrefix(filename, "doc-ru-") {
+		return false
+	}
+	if strings.HasSuffix(filename, "-tests.yaml") {
 		return false
 	}
 

--- a/pkg/linters/openapi/openapi.go
+++ b/pkg/linters/openapi/openapi.go
@@ -68,6 +68,34 @@ func (o *OpenAPI) Run(m *module.Module) {
 		keyValidator.Run(file, errorLists)
 		crdValidator.Run(m.GetName(), file, errorLists)
 	}
+
+	// bilingual check: ensure doc-ru- translation files exist
+	bilingualErrorList := errorLists.WithMaxLevel(o.cfg.Rules.BilingualRule.GetLevel())
+	bilingualValidator := rules.NewBilingualRule(o.cfg, m.GetPath())
+
+	// check openAPI files have translations (excluding values.yaml)
+	for _, file := range openAPIFiles {
+		if isValuesFile(file) {
+			continue
+		}
+		bilingualValidator.Run(file, bilingualErrorList)
+	}
+
+	// check CRD files have translations
+	for _, file := range crdFiles {
+		bilingualValidator.Run(file, bilingualErrorList)
+	}
+
+	// check orphaned doc-ru- files (translation without base file)
+	docRuOpenAPIFiles := fsutils.GetFiles(m.GetPath(), true, filterDocRuOpenAPIFiles)
+	for _, file := range docRuOpenAPIFiles {
+		bilingualValidator.Run(file, bilingualErrorList)
+	}
+
+	docRuCRDFiles := fsutils.GetFiles(m.GetPath(), true, filterDocRuCRDFiles)
+	for _, file := range docRuCRDFiles {
+		bilingualValidator.Run(file, bilingualErrorList)
+	}
 }
 
 func (o *OpenAPI) Name() string {
@@ -106,4 +134,31 @@ func filterCRDsfiles(rootPath, path string) bool {
 	}
 
 	return crdsYamlRegex.MatchString(path)
+}
+
+func isValuesFile(path string) bool {
+	filename := filepath.Base(path)
+	return filename == "values.yaml" || filename == "values.yml"
+}
+
+func filterDocRuOpenAPIFiles(rootPath, path string) bool {
+	relPath := fsutils.Rel(rootPath, path)
+	filename := filepath.Base(relPath)
+
+	if !strings.HasPrefix(filename, "doc-ru-") {
+		return false
+	}
+
+	return openapiYamlRegex.MatchString(relPath)
+}
+
+func filterDocRuCRDFiles(rootPath, path string) bool {
+	relPath := fsutils.Rel(rootPath, path)
+	filename := filepath.Base(relPath)
+
+	if !strings.HasPrefix(filename, "doc-ru-") {
+		return false
+	}
+
+	return crdsYamlRegex.MatchString(relPath)
 }

--- a/pkg/linters/openapi/rules/bilingual.go
+++ b/pkg/linters/openapi/rules/bilingual.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rules
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,6 +68,6 @@ func (r *BilingualRule) Run(path string, errorList *errors.LintRuleErrorsList) {
 
 	if _, err := os.Stat(docRuPath); os.IsNotExist(err) {
 		errorList.WithFilePath(shortPath).
-			Errorf("translation file is missing: expected %q in the same directory", fmt.Sprintf("%s%s", docRuPrefix, filename))
+			Errorf("translation file is missing: expected %q in the same directory", docRuPrefix+filename)
 	}
 }

--- a/pkg/linters/openapi/rules/bilingual.go
+++ b/pkg/linters/openapi/rules/bilingual.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const docRuPrefix = "doc-ru-"
+
+type BilingualRule struct {
+	pkg.RuleMeta
+	rootPath string
+}
+
+func NewBilingualRule(_ *pkg.OpenAPILinterConfig, rootPath string) *BilingualRule {
+	return &BilingualRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: "bilingual",
+		},
+		rootPath: rootPath,
+	}
+}
+
+// Run checks that the given resource file has a corresponding doc-ru- translation file.
+func (r *BilingualRule) Run(path string, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName())
+
+	shortPath := fsutils.Rel(r.rootPath, path)
+	filename := filepath.Base(path)
+	dir := filepath.Dir(path)
+
+	if strings.HasPrefix(filename, docRuPrefix) {
+		// For doc-ru- files, check that the base file exists
+		baseFilename := strings.TrimPrefix(filename, docRuPrefix)
+		basePath := filepath.Join(dir, baseFilename)
+
+		if _, err := os.Stat(basePath); os.IsNotExist(err) {
+			errorList.WithFilePath(shortPath).
+				Errorf("translation file has no corresponding base file: expected %q", baseFilename)
+		}
+
+		return
+	}
+
+	// For base files, check that the doc-ru- counterpart exists
+	docRuPath := filepath.Join(dir, docRuPrefix+filename)
+
+	if _, err := os.Stat(docRuPath); os.IsNotExist(err) {
+		errorList.WithFilePath(shortPath).
+			Errorf("translation file is missing: expected %q in the same directory", fmt.Sprintf("%s%s", docRuPrefix, filename))
+	}
+}

--- a/pkg/linters/openapi/rules/bilingual_test.go
+++ b/pkg/linters/openapi/rules/bilingual_test.go
@@ -1,0 +1,102 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+func TestBilingualRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		files      map[string]string
+		checkFile  string
+		wantErrors []string
+	}{
+		{
+			name: "base file with translation present",
+			files: map[string]string{
+				"config-values.yaml":        "type: object",
+				"doc-ru-config-values.yaml": "type: object",
+			},
+			checkFile:  "config-values.yaml",
+			wantErrors: nil,
+		},
+		{
+			name: "base file without translation",
+			files: map[string]string{
+				"config-values.yaml": "type: object",
+			},
+			checkFile:  "config-values.yaml",
+			wantErrors: []string{"translation file is missing: expected \"doc-ru-config-values.yaml\""},
+		},
+		{
+			name: "doc-ru file with base file present",
+			files: map[string]string{
+				"config-values.yaml":        "type: object",
+				"doc-ru-config-values.yaml": "type: object",
+			},
+			checkFile:  "doc-ru-config-values.yaml",
+			wantErrors: nil,
+		},
+		{
+			name: "orphaned doc-ru file without base file",
+			files: map[string]string{
+				"doc-ru-config-values.yaml": "type: object",
+			},
+			checkFile:  "doc-ru-config-values.yaml",
+			wantErrors: []string{"translation file has no corresponding base file: expected \"config-values.yaml\""},
+		},
+		{
+			name: "CRD base file without translation",
+			files: map[string]string{
+				"my-crd.yaml": "apiVersion: apiextensions.k8s.io/v1",
+			},
+			checkFile:  "my-crd.yaml",
+			wantErrors: []string{"translation file is missing: expected \"doc-ru-my-crd.yaml\""},
+		},
+		{
+			name: "CRD base file with translation",
+			files: map[string]string{
+				"my-crd.yaml":        "apiVersion: apiextensions.k8s.io/v1",
+				"doc-ru-my-crd.yaml": "apiVersion: apiextensions.k8s.io/v1",
+			},
+			checkFile:  "my-crd.yaml",
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			for name, content := range tt.files {
+				err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600)
+				require.NoError(t, err)
+			}
+
+			cfg := &pkg.OpenAPILinterConfig{}
+			rule := NewBilingualRule(cfg, dir)
+			errorList := errors.NewLintRuleErrorsList()
+
+			filePath := filepath.Join(dir, tt.checkFile)
+			rule.Run(filePath, errorList)
+
+			errs := errorList.GetErrors()
+			if tt.wantErrors == nil {
+				assert.Empty(t, errs)
+			} else {
+				assert.Len(t, errs, len(tt.wantErrors))
+				for i, err := range errs {
+					assert.Contains(t, err.Text, tt.wantErrors[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/linters/openapi/rules/bilingual_test.go
+++ b/pkg/linters/openapi/rules/bilingual_test.go
@@ -70,6 +70,15 @@ func TestBilingualRule(t *testing.T) {
 			checkFile:  "my-crd.yaml",
 			wantErrors: nil,
 		},
+		{
+			name: "file in subdirectory with translation",
+			files: map[string]string{
+				"crds/sub/my-crd.yaml":        "apiVersion: apiextensions.k8s.io/v1",
+				"crds/sub/doc-ru-my-crd.yaml": "apiVersion: apiextensions.k8s.io/v1",
+			},
+			checkFile:  "crds/sub/my-crd.yaml",
+			wantErrors: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -77,7 +86,10 @@ func TestBilingualRule(t *testing.T) {
 			dir := t.TempDir()
 
 			for name, content := range tt.files {
-				err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600)
+				fullPath := filepath.Join(dir, name)
+				err := os.MkdirAll(filepath.Dir(fullPath), 0o755)
+				require.NoError(t, err)
+				err = os.WriteFile(fullPath, []byte(content), 0o600)
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
## Summary

Fixes for the bilingual rule introduced in #350:

- **Exclude `*-tests.yaml` files from doc-ru orphan scanning**: The new `filterDocRuOpenAPIFiles` and `filterDocRuCRDFiles` functions didn't exclude test files, causing false positive "orphaned translation file" errors for test translation files.
- **Remove unnecessary `fmt.Sprintf`**: Replaced with simple string concatenation (`docRuPrefix+filename`).
- **Add subdirectory test case**: Ensure bilingual rule works for files in nested directories (verified with `crds/sub/my-crd.yaml`).

## Related

- PR #350