### PR TITLE
[dmt] Validate oss.yaml versions

### DIFF
--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -144,21 +144,26 @@ Validates the `oss.yaml` file containing open-source software attribution.
 - ✅ Valid YAML structure
 - ✅ At least one project is described
 - ✅ Each project has required fields:
-  - `id` - Project identifier (must not be empty)
-  - `version` - Project version (must not be empty, should be valid semver) See ADR "platform-security/2026-01-21-oss-yaml-werf.md"
+  - `id` - Project identifier (must not be empty and must be unique within the file)
+  - `version` or `versions` - Project version definition (must not be empty, should be valid semver) See ADR "platform-security/2026-01-21-oss-yaml-werf.md"
   - `name` - Project name (must not be empty)
   - `description` - Project description (must not be empty)
   - `link` - Valid project URL (must not be empty, must be valid URL)
   - `license` - Valid license identifier (must not be empty)
   - `logo` (optional) - Valid logo URL (must be valid URL if provided)
+- ✅ A project may use `versions` instead of `version` when the component has several context-dependent versions. Each `versions[]` item must contain a non-empty `version` value.
 
 **Error Messages:**
 - `Module should have oss.yaml` - File is missing from module root
 - `Invalid oss.yaml: <error>` - File exists but contains invalid YAML or structure
 - `no projects described` - File exists but contains an empty list
 - `id must not be empty` - Project entry is missing the `id` field
+- `id must be unique; duplicate id "<id>" already used by project #<n>` - Project id is duplicated
 - `version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.` - Project entry is missing the `version` field
 - `version must be valid semver: <error>` (Warning) - Version is provided but not in valid semantic versioning format
+- `version and versions must not be used together` - Project entry contains both simple and conditional version definitions
+- `versions[].version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.` - Conditional version entry is missing the `version` field
+- `versions[].version must be valid semver: <error>` (Warning) - Conditional version is provided but not in valid semantic versioning format
 - `name must not be empty` - Project entry is missing the `name` field
 - `description must not be empty` - Project entry is missing the `description` field
 - `link must not be empty` - Project entry is missing the `link` field
@@ -183,6 +188,21 @@ Validates the `oss.yaml` file containing open-source software attribution.
   description: Monitoring system and time series database
   link: https://prometheus.io/
   license: Apache-2.0
+
+- id: example-service
+  name: Example service
+  description: Example service used in module images
+  link: https://github.com/example/example-service
+  license: Apache-2.0
+  versions:
+    - condition:
+        k8s: "1.31"
+      name: version for k8s 1.31
+      version: 1.2.1
+    - condition:
+        k8s: "1.32"
+      name: version for k8s 1.32
+      version: 1.2.2
 ```
 
 ---

--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -145,13 +145,14 @@ Validates the `oss.yaml` file containing open-source software attribution.
 - ✅ At least one project is described
 - ✅ Each project has required fields:
   - `id` - Project identifier (must not be empty and must be unique within the file)
-  - `version` or `versions` - Project version definition (must not be empty, should be valid semver) See ADR "platform-security/2026-01-21-oss-yaml-werf.md"
+  - `version` or `versions` - Project version definition (must not be empty; may use any format used by the OSS project)
   - `name` - Project name (must not be empty)
   - `description` - Project description (must not be empty)
   - `link` - Valid project URL (must not be empty, must be valid URL)
   - `license` - Valid license identifier (must not be empty)
   - `logo` (optional) - Valid logo URL (must be valid URL if provided)
 - ✅ A project may use `versions` instead of `version` when the component has several context-dependent versions. Each `versions[]` item must contain a non-empty `version` value.
+- ✅ dmt checks version values for semver compatibility because semver is the most common format. If the OSS project uses another version format and the value is correct, ignore the warning.
 
 **Error Messages:**
 - `Module should have oss.yaml` - File is missing from module root
@@ -160,10 +161,10 @@ Validates the `oss.yaml` file containing open-source software attribution.
 - `id must not be empty` - Project entry is missing the `id` field
 - `id must be unique; duplicate id "<id>" already used by project #<n>` - Project id is duplicated
 - `version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.` - Project entry is missing the `version` field
-- `version should be valid semver: <error>` (Warning) - Version is provided but not in valid semantic versioning format
+- `version "<version>" is not semver-compatible; if this version is correct for the OSS project, ignore this warning: <error>` (Warning) - Version is provided but not in valid semantic versioning format
 - `version and versions must not be used together` - Project entry contains both simple and conditional version definitions
 - `versions[].version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.` - Conditional version entry is missing the `version` field
-- `versions[].version should be valid semver: <error>` (Warning) - Conditional version is provided but not in valid semantic versioning format
+- `versions[].version "<version>" is not semver-compatible; if this version is correct for the OSS project, ignore this warning: <error>` (Warning) - Conditional version is provided but not in valid semantic versioning format
 - `name must not be empty` - Project entry is missing the `name` field
 - `description must not be empty` - Project entry is missing the `description` field
 - `link must not be empty` - Project entry is missing the `link` field

--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -160,10 +160,10 @@ Validates the `oss.yaml` file containing open-source software attribution.
 - `id must not be empty` - Project entry is missing the `id` field
 - `id must be unique; duplicate id "<id>" already used by project #<n>` - Project id is duplicated
 - `version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.` - Project entry is missing the `version` field
-- `version must be valid semver: <error>` (Warning) - Version is provided but not in valid semantic versioning format
+- `version should be valid semver: <error>` (Warning) - Version is provided but not in valid semantic versioning format
 - `version and versions must not be used together` - Project entry contains both simple and conditional version definitions
 - `versions[].version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.` - Conditional version entry is missing the `version` field
-- `versions[].version must be valid semver: <error>` (Warning) - Conditional version is provided but not in valid semantic versioning format
+- `versions[].version should be valid semver: <error>` (Warning) - Conditional version is provided but not in valid semantic versioning format
 - `name must not be empty` - Project entry is missing the `name` field
 - `description must not be empty` - Project entry is missing the `description` field
 - `link must not be empty` - Project entry is missing the `link` field

--- a/pkg/linters/module/rules/oss_library.go
+++ b/pkg/linters/module/rules/oss_library.go
@@ -180,6 +180,7 @@ func assertOssProjectVersion(prefix string, p *ossProject, errorList *errors.Lin
 
 	for i, versionItem := range p.Versions {
 		versionPrefix := fmt.Sprintf("%s.versions[%d]", prefix, i)
+
 		versionValue := strings.TrimSpace(versionItem.Version)
 		if versionValue == "" {
 			errorList.WithObjectID("index=" + versionPrefix + ";").

--- a/pkg/linters/module/rules/oss_library.go
+++ b/pkg/linters/module/rules/oss_library.go
@@ -35,6 +35,7 @@ const (
 	OSSRuleName = "oss"
 )
 
+// NewOSSRule creates an OSS attribution rule instance.
 func NewOSSRule(disable bool) *OSSRule {
 	return &OSSRule{
 		RuleMeta: pkg.RuleMeta{
@@ -56,6 +57,7 @@ const (
 	imagesDir   = "images"
 )
 
+// OssModuleRule validates oss.yaml only for modules that contain image build sources.
 func (r *OSSRule) OssModuleRule(moduleRoot string, errorList *errors.LintRuleErrorsList) {
 	errorList = errorList.WithRule(r.GetName()).WithFilePath(filepath.Join(moduleRoot, ossFilename))
 
@@ -73,6 +75,7 @@ func (r *OSSRule) OssModuleRule(moduleRoot string, errorList *errors.LintRuleErr
 	verifyOssFile(moduleRoot, errorList)
 }
 
+// ossFileErrorMessage formats user-facing errors for missing or invalid oss.yaml.
 func ossFileErrorMessage(err error) string {
 	if os.IsNotExist(err) {
 		return fmt.Sprintf("module has %s folder, so it likely should have %s", imagesDir, ossFilename)
@@ -81,6 +84,7 @@ func ossFileErrorMessage(err error) string {
 	return fmt.Sprintf("invalid %s: %s", ossFilename, err.Error())
 }
 
+// verifyOssFile reads oss.yaml and validates every described OSS project.
 func verifyOssFile(moduleRoot string, errorList *errors.LintRuleErrorsList) {
 	projects, err := readOssFile(moduleRoot)
 	if err != nil {
@@ -116,6 +120,7 @@ func verifyOssFile(moduleRoot string, errorList *errors.LintRuleErrorsList) {
 	}
 }
 
+// assertOssProject validates required attribution fields for one OSS project.
 func assertOssProject(i int, p *ossProject, errorList *errors.LintRuleErrorsList) {
 	// prefix to make it easier navigate among errors
 	prefix := fmt.Sprintf("#%d", i)
@@ -159,6 +164,7 @@ func assertOssProject(i int, p *ossProject, errorList *errors.LintRuleErrorsList
 	}
 }
 
+// assertOssProjectVersion validates simple and conditional version definitions.
 func assertOssProjectVersion(prefix string, p *ossProject, errorList *errors.LintRuleErrorsList) {
 	version := strings.TrimSpace(p.Version)
 	hasVersions := len(p.Versions) > 0
@@ -193,6 +199,7 @@ func assertOssProjectVersion(prefix string, p *ossProject, errorList *errors.Lin
 	}
 }
 
+// assertOssVersionValue warns when a non-empty version is not semver-compatible.
 func assertOssVersionValue(prefix, fieldPath, version string, errorList *errors.LintRuleErrorsList) {
 	if _, err := semver.NewVersion(version); err != nil {
 		errorList.WithObjectID("index=" + prefix + ";").
@@ -200,6 +207,7 @@ func assertOssVersionValue(prefix, fieldPath, version string, errorList *errors.
 	}
 }
 
+// readOssFile loads oss.yaml from the module root and parses its project list.
 func readOssFile(moduleRoot string) ([]ossProject, error) {
 	b, err := os.ReadFile(filepath.Join(moduleRoot, ossFilename))
 	if err != nil {
@@ -209,6 +217,7 @@ func readOssFile(moduleRoot string) ([]ossProject, error) {
 	return parseProjectList(b)
 }
 
+// parseProjectList parses oss.yaml content using strict YAML decoding.
 func parseProjectList(b []byte) ([]ossProject, error) {
 	var projects []ossProject
 

--- a/pkg/linters/module/rules/oss_library.go
+++ b/pkg/linters/module/rules/oss_library.go
@@ -203,7 +203,7 @@ func assertOssProjectVersion(prefix string, p *ossProject, errorList *errors.Lin
 func assertOssVersionValue(prefix, fieldPath, version string, errorList *errors.LintRuleErrorsList) {
 	if _, err := semver.NewVersion(version); err != nil {
 		errorList.WithObjectID("index=" + prefix + ";").
-			Warn(fmt.Sprintf("%s should be valid semver: %v", fieldPath, err))
+			Warn(fmt.Sprintf("%s %q is not semver-compatible; if this version is correct for the OSS project, ignore this warning: %v", fieldPath, version, err))
 	}
 }
 

--- a/pkg/linters/module/rules/oss_library.go
+++ b/pkg/linters/module/rules/oss_library.go
@@ -99,7 +99,19 @@ func verifyOssFile(moduleRoot string, errorList *errors.LintRuleErrorsList) {
 		return
 	}
 
+	projectIDs := make(map[string]int, len(projects))
+
 	for i, p := range projects {
+		if projectID := strings.TrimSpace(p.ID); projectID != "" {
+			if prevIndex, ok := projectIDs[projectID]; ok {
+				prefix := fmt.Sprintf("#%d (id=%s)", i+1, projectID)
+				errorList.WithObjectID("index="+prefix+";").
+					Errorf("id must be unique; duplicate id %q already used by project #%d", projectID, prevIndex)
+			} else {
+				projectIDs[projectID] = i + 1
+			}
+		}
+
 		assertOssProject(i+1, &p, errorList)
 	}
 }
@@ -115,15 +127,7 @@ func assertOssProject(i int, p *ossProject, errorList *errors.LintRuleErrorsList
 		prefix = fmt.Sprintf("#%d (id=%s)", i, p.ID)
 	}
 
-	// Version
-	if strings.TrimSpace(p.Version) == "" {
-		errorList.WithObjectID("index=" + prefix + ";").Error("version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.")
-	} else {
-		_, err := semver.NewVersion(p.Version)
-		if err != nil {
-			errorList.WithObjectID("index=" + prefix + ";").Warn(fmt.Sprintf("version must be valid semver: %v", err))
-		}
-	}
+	assertOssProjectVersion(prefix, p, errorList)
 
 	// Name
 	if strings.TrimSpace(p.Name) == "" {
@@ -155,6 +159,46 @@ func assertOssProject(i int, p *ossProject, errorList *errors.LintRuleErrorsList
 	}
 }
 
+func assertOssProjectVersion(prefix string, p *ossProject, errorList *errors.LintRuleErrorsList) {
+	version := strings.TrimSpace(p.Version)
+	hasVersions := len(p.Versions) > 0
+
+	if version == "" && !hasVersions {
+		errorList.WithObjectID("index=" + prefix + ";").
+			Error("version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.")
+
+		return
+	}
+
+	if version != "" {
+		assertOssVersionValue(prefix, "version", version, errorList)
+	}
+
+	if version != "" && hasVersions {
+		errorList.WithObjectID("index=" + prefix + ";").Error("version and versions must not be used together")
+	}
+
+	for i, versionItem := range p.Versions {
+		versionPrefix := fmt.Sprintf("%s.versions[%d]", prefix, i)
+		versionValue := strings.TrimSpace(versionItem.Version)
+		if versionValue == "" {
+			errorList.WithObjectID("index=" + versionPrefix + ";").
+				Error("versions[].version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting.")
+
+			continue
+		}
+
+		assertOssVersionValue(versionPrefix, "versions[].version", versionValue, errorList)
+	}
+}
+
+func assertOssVersionValue(prefix, fieldPath, version string, errorList *errors.LintRuleErrorsList) {
+	if _, err := semver.NewVersion(version); err != nil {
+		errorList.WithObjectID("index=" + prefix + ";").
+			Warn(fmt.Sprintf("%s must be valid semver: %v", fieldPath, err))
+	}
+}
+
 func readOssFile(moduleRoot string) ([]ossProject, error) {
 	b, err := os.ReadFile(filepath.Join(moduleRoot, ossFilename))
 	if err != nil {
@@ -176,11 +220,18 @@ func parseProjectList(b []byte) ([]ossProject, error) {
 }
 
 type ossProject struct {
-	Name        string `json:"name"`           // example: Dex
-	Description string `json:"description"`    // example: A Federated OpenID Connect Provider with pluggable connectors
-	Link        string `json:"link"`           // example: https://github.com/dexidp/dex
-	Logo        string `json:"logo,omitempty"` // example: https://dexidp.io/img/logos/dex-horizontal-color.png
-	License     string `json:"license"`        // example: Apache License 2.0
-	ID          string `json:"id"`             // example: dexidp/dex
-	Version     string `json:"version"`        // example: 2.0.0
+	Name        string       `json:"name"`           // example: Dex
+	Description string       `json:"description"`    // example: A Federated OpenID Connect Provider with pluggable connectors
+	Link        string       `json:"link"`           // example: https://github.com/dexidp/dex
+	Logo        string       `json:"logo,omitempty"` // example: https://dexidp.io/img/logos/dex-horizontal-color.png
+	License     string       `json:"license"`        // example: Apache License 2.0
+	ID          string       `json:"id"`             // example: dexidp/dex
+	Version     string       `json:"version"`        // example: 2.0.0
+	Versions    []ossVersion `json:"versions,omitempty"`
+}
+
+type ossVersion struct {
+	Condition map[string]any `json:"condition,omitempty"`
+	Name      string         `json:"name,omitempty"`
+	Version   string         `json:"version"`
 }

--- a/pkg/linters/module/rules/oss_library.go
+++ b/pkg/linters/module/rules/oss_library.go
@@ -203,7 +203,7 @@ func assertOssProjectVersion(prefix string, p *ossProject, errorList *errors.Lin
 func assertOssVersionValue(prefix, fieldPath, version string, errorList *errors.LintRuleErrorsList) {
 	if _, err := semver.NewVersion(version); err != nil {
 		errorList.WithObjectID("index=" + prefix + ";").
-			Warn(fmt.Sprintf("%s must be valid semver: %v", fieldPath, err))
+			Warn(fmt.Sprintf("%s should be valid semver: %v", fieldPath, err))
 	}
 }
 

--- a/pkg/linters/module/rules/oss_library_test.go
+++ b/pkg/linters/module/rules/oss_library_test.go
@@ -198,7 +198,7 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
   license: "Apache License 2.0"
 `,
 			},
-			wantWarns: []string{"version should be valid semver"},
+			wantWarns: []string{`version "invalid-version" is not semver-compatible; if this version is correct for the OSS project, ignore this warning`},
 		},
 		{
 			name:            "project with invalid conditional semver version",
@@ -216,7 +216,7 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
       version: "ccm/v30.1.4"
 `,
 			},
-			wantWarns: []string{"versions[].version should be valid semver"},
+			wantWarns: []string{`versions[].version "ccm/v30.1.4" is not semver-compatible; if this version is correct for the OSS project, ignore this warning`},
 		},
 		{
 			name:            "project with version and versions",

--- a/pkg/linters/module/rules/oss_library_test.go
+++ b/pkg/linters/module/rules/oss_library_test.go
@@ -113,6 +113,31 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
 			wantErrors: nil,
 		},
 		{
+			name:            "valid project with conditional versions",
+			createImagesDir: true,
+			setupFiles: map[string]string{
+				"oss.yaml": `
+- id: "example-service"
+  name: "Example service"
+  description: "Example service used in module images"
+  link: "https://github.com/example/example-service"
+  license: "Apache License 2.0"
+  versions:
+    - condition:
+        k8s: "1.31"
+      name: "version for k8s 1.31"
+      version: "1.2.1"
+    - condition:
+        k8s:
+          - "1.32"
+          - "1.33"
+      name: "version for k8s 1.32 and 1.33"
+      version: "1.2.2"
+`,
+			},
+			wantErrors: nil,
+		},
+		{
 			name:            "project with empty id",
 			createImagesDir: true,
 			setupFiles: map[string]string{
@@ -143,6 +168,24 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
 			wantErrors: []string{"version must not be empty. Please fill in the parameter and configure CI (werf files for module images) to use these setting."},
 		},
 		{
+			name:            "project with empty conditional version",
+			createImagesDir: true,
+			setupFiles: map[string]string{
+				"oss.yaml": `
+- id: "example-service"
+  name: "Example service"
+  description: "Example service used in module images"
+  link: "https://github.com/example/example-service"
+  license: "Apache License 2.0"
+  versions:
+    - condition:
+        k8s: "1.31"
+      version: ""
+`,
+			},
+			wantErrors: []string{"versions[].version must not be empty"},
+		},
+		{
 			name:            "project with invalid semver version",
 			createImagesDir: true,
 			setupFiles: map[string]string{
@@ -156,6 +199,43 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
 `,
 			},
 			wantWarns: []string{"version must be valid semver"},
+		},
+		{
+			name:            "project with invalid conditional semver version",
+			createImagesDir: true,
+			setupFiles: map[string]string{
+				"oss.yaml": `
+- id: "example-service"
+  name: "Example service"
+  description: "Example service used in module images"
+  link: "https://github.com/example/example-service"
+  license: "Apache License 2.0"
+  versions:
+    - condition:
+        k8s: "1.31"
+      version: "ccm/v30.1.4"
+`,
+			},
+			wantWarns: []string{"versions[].version must be valid semver"},
+		},
+		{
+			name:            "project with version and versions",
+			createImagesDir: true,
+			setupFiles: map[string]string{
+				"oss.yaml": `
+- id: "example-service"
+  version: "1.2.0"
+  name: "Example service"
+  description: "Example service used in module images"
+  link: "https://github.com/example/example-service"
+  license: "Apache License 2.0"
+  versions:
+    - condition:
+        k8s: "1.31"
+      version: "1.2.1"
+`,
+			},
+			wantErrors: []string{"version and versions must not be used together"},
 		},
 		{
 			name:            "project with empty name",
@@ -268,6 +348,27 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
 `,
 			},
 			wantErrors: []string{"id must not be empty"},
+		},
+		{
+			name:            "duplicate project id",
+			createImagesDir: true,
+			setupFiles: map[string]string{
+				"oss.yaml": `
+- id: "dexidp/dex"
+  version: "2.0.0"
+  name: "Dex"
+  description: "A Federated OpenID Connect Provider with pluggable connectors"
+  link: "https://github.com/dexidp/dex"
+  license: "Apache License 2.0"
+- id: "dexidp/dex"
+  version: "2.1.0"
+  name: "Dex"
+  description: "A Federated OpenID Connect Provider with pluggable connectors"
+  link: "https://github.com/dexidp/dex"
+  license: "Apache License 2.0"
+`,
+			},
+			wantErrors: []string{"id must be unique; duplicate id \"dexidp/dex\" already used by project #1"},
 		},
 	}
 

--- a/pkg/linters/module/rules/oss_library_test.go
+++ b/pkg/linters/module/rules/oss_library_test.go
@@ -198,7 +198,7 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
   license: "Apache License 2.0"
 `,
 			},
-			wantWarns: []string{"version must be valid semver"},
+			wantWarns: []string{"version should be valid semver"},
 		},
 		{
 			name:            "project with invalid conditional semver version",
@@ -216,7 +216,7 @@ func TestOSSRule_OssModuleRule(t *testing.T) {
       version: "ccm/v30.1.4"
 `,
 			},
-			wantWarns: []string{"versions[].version must be valid semver"},
+			wantWarns: []string{"versions[].version should be valid semver"},
 		},
 		{
 			name:            "project with version and versions",


### PR DESCRIPTION
## Summary

Add oss.yaml validation for conditional component versions:

- **Support versions entries**: Allow projects to use versions[] instead of a single version field and validate each versions[].version value.
- **Reject ambiguous version definitions**: Report an error when version and versions are used together for the same project.
- **Validate stable project IDs**: Require project ids to be unique within oss.yaml and document the supported schema.

## Example

Valid conditional versions entry:

```yaml
- id: example-service
  name: Example service
  description: Example service used in module images
  link: https://github.com/example/example-service
  license: Apache License 2.0
  versions:
    - condition:
        k8s: "1.31"
      version: 1.2.1
    - condition:
        k8s: "1.32"
      version: 1.2.2
```

Invalid ambiguous entry:

```yaml
- id: example-service
  version: 1.2.0
  versions:
    - condition:
        k8s: "1.31"
      version: 1.2.1
```

Produces: `version and versions must not be used together`.