### PR TITLE
[dmt] feat: add no-lang-key rule for documentation front matter

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -307,6 +307,7 @@ func mapDocumentationRules(linterSettings *pkg.LintersSettings, configSettings *
 	rules.BilingualRule.SetLevel(globalRules.BilingualRule.Impact, fallbackImpact)
 	rules.ReadmeRule.SetLevel(globalRules.ReadmeRule.Impact, fallbackImpact)
 	rules.CyrillicInEnglishRule.SetLevel(globalRules.NoCyrillicExcludeRules.Impact, fallbackImpact)
+	rules.NoLangKeyRule.SetLevel(globalRules.NoLangKeyRule.Impact, fallbackImpact)
 }
 
 func mapModuleRules(linterSettings *pkg.LintersSettings, configSettings *config.LintersSettings, globalConfig *global.Linters) {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -86,6 +86,7 @@ type DocumentationLinterRules struct {
 	ReadmeRule            RuleConfig
 	BilingualRule         RuleConfig
 	CyrillicInEnglishRule RuleConfig
+	NoLangKeyRule         RuleConfig
 }
 
 type NoCyrillicLinterConfig struct {

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -94,6 +94,7 @@ type DocumentationRules struct {
 	BilingualRule          RuleConfig `mapstructure:"bilingual"`
 	ReadmeRule             RuleConfig `mapstructure:"readme"`
 	NoCyrillicExcludeRules RuleConfig `mapstructure:"cyrillic-in-english"`
+	NoLangKeyRule          RuleConfig `mapstructure:"no-lang-key"`
 }
 
 type OpenAPILinterConfig struct {

--- a/pkg/linters/docs/README.md
+++ b/pkg/linters/docs/README.md
@@ -13,6 +13,7 @@ Proper documentation is critical for Deckhouse modules as it helps users underst
 | [readme](#readme) | Validates presence of README.md in docs/ directory | ✅ | enabled |
 | [bilingual](#bilingual) | Validates documentation exists in both English and Russian | ✅ | enabled |
 | [cyrillic-in-english](#cyrillic-in-english) | Validates English documentation doesn't contain cyrillic characters | ✅ | enabled |
+| [no-lang-key](#no-lang-key) | Validates documentation front matter doesn't contain `lang` key | ✅ | enabled |
 
 ## Rule Details
 
@@ -296,6 +297,98 @@ linters-settings:
         exclude:
           - docs/GLOSSARY.md      # Contains technical terms in multiple languages
 ```
+
+### no-lang-key
+
+**Purpose:** Ensures that documentation files don't contain the `lang` key in their YAML front matter. The language of the document should be determined by its file name convention (e.g., `.ru.md` suffix for Russian) rather than by a `lang` field in the front matter.
+
+**Description:**
+
+Markdown documentation files in `docs/` should not include a `lang:` key in their YAML front matter block. The language is already encoded in the file naming convention (`.md` for English, `.ru.md` for Russian), so an additional `lang` field is redundant and can cause inconsistencies.
+
+**What it checks:**
+
+1. Scans all `.md` files in `docs/` directory (top-level only)
+2. Extracts the YAML front matter (content between the first pair of `---` delimiters)
+3. Checks for the presence of a `lang:` key in the front matter
+4. Reports the exact line number where the `lang` key is found
+
+**Why it matters:**
+
+Having a `lang` key in the front matter is redundant because the documentation system already determines the language from the file name suffix. It can also lead to inconsistencies if the `lang` value doesn't match the actual file language. Removing it simplifies the documentation structure and prevents potential mismatches.
+
+**Examples:**
+
+:x: **Incorrect** - Front matter with `lang` key:
+
+```markdown
+---
+title: "Module dashboard"
+lang: ru
+description: "Web interface for Kubernetes Dashboard."
+---
+
+## Authentication
+...
+```
+
+**Error:**
+```
+Documentation contains 'lang' key in front matter; this field should be removed
+File: docs/README.ru.md
+Line 3: front matter contains 'lang' key which should be removed
+```
+
+:x: **Incorrect** - Front matter with `lang` key and additional metadata:
+
+```markdown
+---
+title: "Module dashboard"
+lang: ru
+description: "Web interface."
+webIfaces:
+- name: dashboard
+---
+```
+
+:white_check_mark: **Correct** - Front matter without `lang` key:
+
+```markdown
+---
+title: "Module dashboard"
+description: "Web interface for Kubernetes Dashboard."
+---
+
+## Authentication
+...
+```
+
+:white_check_mark: **Correct** - Front matter without `lang` key and with additional metadata:
+
+```markdown
+---
+title: "Module dashboard"
+description: "Web interface."
+webIfaces:
+- name: dashboard
+---
+```
+
+**Configuration:**
+
+To exclude specific files from this check:
+
+```yaml
+# .dmt.yaml
+linters-settings:
+  documentation:
+    rules:
+      no-lang-key:
+        exclude:
+          - docs/LEGACY.md      # Legacy file that still uses lang key
+```
+
+---
 
 ## Configuration
 

--- a/pkg/linters/docs/documentation.go
+++ b/pkg/linters/docs/documentation.go
@@ -42,6 +42,8 @@ func (l *Documentation) Run(m *module.Module) {
 	rules.NewBilingualRule().CheckBilingual(m, errorList.WithMaxLevel(l.cfg.Rules.BilingualRule.GetLevel()))
 
 	rules.NewCyrillicInEnglishRule().CheckFiles(m, errorList.WithMaxLevel(l.cfg.Rules.CyrillicInEnglishRule.GetLevel()))
+
+	rules.NewNoLangKeyRule().CheckFiles(m, errorList.WithMaxLevel(l.cfg.Rules.NoLangKeyRule.GetLevel()))
 }
 
 func (l *Documentation) Name() string {

--- a/pkg/linters/docs/rules/no_lang_key.go
+++ b/pkg/linters/docs/rules/no_lang_key.go
@@ -1,0 +1,127 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0
+
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	NoLangKeyRuleName = "no-lang-key"
+)
+
+var (
+	frontMatterDelimiter = regexp.MustCompile(`^---\s*$`)
+	langKeyRe            = regexp.MustCompile(`(?m)^lang:\s`)
+)
+
+func NewNoLangKeyRule() *NoLangKeyRule {
+	return &NoLangKeyRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: NoLangKeyRuleName,
+		},
+	}
+}
+
+type NoLangKeyRule struct {
+	pkg.RuleMeta
+	pkg.PathRule
+}
+
+func (r *NoLangKeyRule) CheckFiles(m pkg.Module, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName())
+
+	modulePath := m.GetPath()
+	if modulePath == "" {
+		return
+	}
+
+	docsPath := filepath.Join(modulePath, "docs")
+	files := fsutils.GetFiles(docsPath, false, fsutils.FilterFileByExtensions(".md"))
+
+	for _, fileName := range files {
+		relFromModule := fsutils.Rel(modulePath, fileName)
+		if filepath.Dir(relFromModule) != "docs" {
+			continue
+		}
+
+		r.checkFile(m, fileName, errorList)
+	}
+}
+
+func (r *NoLangKeyRule) checkFile(m pkg.Module, fileName string, errorList *errors.LintRuleErrorsList) {
+	relPath := fsutils.Rel(m.GetPath(), fileName)
+
+	if !r.Enabled(relPath) {
+		return
+	}
+
+	content, err := os.ReadFile(fileName)
+	if err != nil {
+		errorList.WithFilePath(relPath).WithValue(err.Error()).Error("failed to read file")
+		return
+	}
+
+	frontMatter := extractFrontMatter(string(content))
+	if frontMatter == "" {
+		return
+	}
+
+	if langKeyRe.MatchString(frontMatter) {
+		lineNum := findLangKeyLine(string(content))
+		msg := fmt.Sprintf("Line %d: front matter contains 'lang' key which should be removed", lineNum)
+		errorList.
+			WithFilePath(relPath).
+			WithValue(msg).
+			Error("Documentation contains 'lang' key in front matter; this field should be removed")
+	}
+}
+
+// extractFrontMatter returns the YAML front matter content between the first pair of "---" delimiters.
+// Returns an empty string if no valid front matter is found.
+func extractFrontMatter(content string) string {
+	lines := strings.Split(content, "\n")
+
+	startIdx := -1
+	endIdx := -1
+
+	for i, line := range lines {
+		if frontMatterDelimiter.MatchString(line) {
+			if startIdx == -1 {
+				startIdx = i
+			} else {
+				endIdx = i
+				break
+			}
+		}
+	}
+
+	if startIdx == -1 || endIdx == -1 {
+		return ""
+	}
+
+	return strings.Join(lines[startIdx+1:endIdx], "\n")
+}
+
+// findLangKeyLine returns the 1-based line number where the 'lang:' key appears in the file content.
+func findLangKeyLine(content string) int {
+	lines := strings.Split(content, "\n")
+	langLineRe := regexp.MustCompile(`^lang:\s`)
+
+	for i, line := range lines {
+		if langLineRe.MatchString(line) {
+			return i + 1
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
## Description
Add a new no-lang-key rule to the documentation linter that checks markdown files in docs/ for the presence of a lang: key in YAML front matter. The rule parses the front matter block (between --- delimiters) and reports an error with the exact line number if lang: is found.

## Why do we need it, and what problem does it solve?
The language of a documentation file is already determined by the file naming convention: .md for English and .ru.md for Russian. Having an additional lang: key in the YAML front matter is redundant and can lead to inconsistencies -- for example, a file named README.md (English) could have lang: ru in its front matter, or vice versa. This creates confusion for the documentation build system and for contributors.
This rule enforces a single source of truth for the document language (the file name suffix) and ensures that the lang field is removed from front matter across all module documentation.

## Example
```
🐒 [no-lang-key (#documentation)]
     Message:      Documentation contains 'lang' key in front matter; this field should be removed
     Module:       test-module-with-lang-key
     Value:        Line 3: front matter contains 'lang' key which should be removed
     FilePath:     docs/CONFIGURATION.ru.md
🐒 [no-lang-key (#documentation)]
     Message:      Documentation contains 'lang' key in front matter; this field should be removed
     Module:       test-module-with-lang-key
     Value:        Line 3: front matter contains 'lang' key which should be removed
     FilePath:     docs/README.ru.md 
```