### PR TITLE
[dmt] Validate module.yaml consistency with package.yaml

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -318,6 +318,7 @@ func mapModuleRules(linterSettings *pkg.LintersSettings, configSettings *config.
 	rules.LicenseRule.SetLevel(globalRules.LicenseRule.Impact, fallbackImpact)
 	rules.RequarementsRule.SetLevel(globalRules.RequarementsRule.Impact, fallbackImpact)
 	rules.PackageYAMLRule.SetLevel(globalRules.PackageYAMLRule.Impact, fallbackImpact)
+	rules.ModulePackageConsistencyRule.SetLevel(globalRules.ModulePackageConsistencyRule.Impact, fallbackImpact)
 	rules.LegacyReleaseFileRule.SetLevel(globalRules.LegacyReleaseFileRule.Impact, fallbackImpact)
 }
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -220,8 +220,9 @@ type ModuleLinterRules struct {
 	HelmignoreRule        RuleConfig
 	LicenseRule           RuleConfig
 	RequarementsRule      RuleConfig
-	PackageYAMLRule       RuleConfig
-	LegacyReleaseFileRule RuleConfig
+	PackageYAMLRule               RuleConfig
+	ModulePackageConsistencyRule  RuleConfig
+	LegacyReleaseFileRule         RuleConfig
 }
 type OSSRuleSettings struct {
 	Disable bool

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -214,15 +214,15 @@ type ModuleLinterConfig struct {
 	ExcludeRules               ModuleExcludeRules
 }
 type ModuleLinterRules struct {
-	DefinitionFileRule    RuleConfig
-	OSSRule               RuleConfig
-	ConversionRule        RuleConfig
-	HelmignoreRule        RuleConfig
-	LicenseRule           RuleConfig
-	RequarementsRule      RuleConfig
-	PackageYAMLRule               RuleConfig
-	ModulePackageConsistencyRule  RuleConfig
-	LegacyReleaseFileRule         RuleConfig
+	DefinitionFileRule           RuleConfig
+	OSSRule                      RuleConfig
+	ConversionRule               RuleConfig
+	HelmignoreRule               RuleConfig
+	LicenseRule                  RuleConfig
+	RequarementsRule             RuleConfig
+	PackageYAMLRule              RuleConfig
+	ModulePackageConsistencyRule RuleConfig
+	LegacyReleaseFileRule        RuleConfig
 }
 type OSSRuleSettings struct {
 	Disable bool

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -108,8 +108,9 @@ type ModuleLinterRules struct {
 	HelmignoreRule        RuleConfig `mapstructure:"helmignore"`
 	LicenseRule           RuleConfig `mapstructure:"license"`
 	RequarementsRule      RuleConfig `mapstructure:"requarements"`
-	PackageYAMLRule       RuleConfig `mapstructure:"package-yaml"`
-	LegacyReleaseFileRule RuleConfig `mapstructure:"legacy-release-file"`
+	PackageYAMLRule              RuleConfig `mapstructure:"package-yaml"`
+	ModulePackageConsistencyRule RuleConfig `mapstructure:"module-package-consistency"`
+	LegacyReleaseFileRule        RuleConfig `mapstructure:"legacy-release-file"`
 }
 
 type TemplatesLinterConfig struct {

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -102,12 +102,12 @@ type ModuleLinterConfig struct {
 }
 
 type ModuleLinterRules struct {
-	DefinitionFileRule    RuleConfig `mapstructure:"definition-file"`
-	OSSRule               RuleConfig `mapstructure:"oss"`
-	ConversionRule        RuleConfig `mapstructure:"conversion"`
-	HelmignoreRule        RuleConfig `mapstructure:"helmignore"`
-	LicenseRule           RuleConfig `mapstructure:"license"`
-	RequarementsRule      RuleConfig `mapstructure:"requarements"`
+	DefinitionFileRule           RuleConfig `mapstructure:"definition-file"`
+	OSSRule                      RuleConfig `mapstructure:"oss"`
+	ConversionRule               RuleConfig `mapstructure:"conversion"`
+	HelmignoreRule               RuleConfig `mapstructure:"helmignore"`
+	LicenseRule                  RuleConfig `mapstructure:"license"`
+	RequarementsRule             RuleConfig `mapstructure:"requarements"`
 	PackageYAMLRule              RuleConfig `mapstructure:"package-yaml"`
 	ModulePackageConsistencyRule RuleConfig `mapstructure:"module-package-consistency"`
 	LegacyReleaseFileRule        RuleConfig `mapstructure:"legacy-release-file"`

--- a/pkg/linters/module/module.go
+++ b/pkg/linters/module/module.go
@@ -56,6 +56,7 @@ func (l *Module) Run(m *module.Module) {
 		CheckFiles(m, errorList.WithMaxLevel(l.cfg.Rules.LicenseRule.GetLevel()))
 	rules.NewRequirementsRule().CheckRequirements(m.GetPath(), errorList.WithMaxLevel(l.cfg.Rules.RequarementsRule.GetLevel()))
 	rules.NewPackageYAMLRule().CheckPackageYAML(m.GetPath(), errorList.WithMaxLevel(l.cfg.Rules.PackageYAMLRule.GetLevel()))
+	rules.NewModulePackageConsistencyRule().CheckModulePackageConsistency(m.GetPath(), errorList.WithMaxLevel(l.cfg.Rules.ModulePackageConsistencyRule.GetLevel()))
 	rules.NewLegacyReleaseFileRule().CheckLegacyReleaseFile(m.GetPath(), errorList.WithMaxLevel(l.cfg.Rules.LegacyReleaseFileRule.GetLevel()))
 }
 

--- a/pkg/linters/module/rules/module_package_consistency.go
+++ b/pkg/linters/module/rules/module_package_consistency.go
@@ -131,12 +131,9 @@ func compareKubernetes(module *DeckhouseModule, packageYAML *ModulePackage, erro
 // In module.yaml dependencies are a flat map (optional ones carry the "!optional" suffix),
 // while package.yaml splits them into mandatory and conditional groups.
 func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorList *errors.LintRuleErrorsList) {
-	moduleErr := errorList.WithFilePath(ModuleConfigFilename)
-	pkgErr := errorList.WithFilePath(PackageConfigFilename)
-
 	if module.Requirements == nil || len(module.Requirements.ParentModules) == 0 {
 		if packageYAML.Requirements != nil && (len(packageYAML.Requirements.Modules.Mandatory) > 0 || len(packageYAML.Requirements.Modules.Conditional) > 0) {
-			checkPackageModulesNotInModule(module, packageYAML, pkgErr)
+			checkPackageModulesNotInModule(module, packageYAML, errorList.WithFilePath(PackageConfigFilename))
 		}
 
 		return
@@ -144,7 +141,7 @@ func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorLi
 
 	if packageYAML.Requirements == nil {
 		for name := range module.Requirements.ParentModules {
-			moduleErr.Errorf("module.yaml module %q has requirement but package.yaml has no requirements section", name)
+			errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q has requirement but package.yaml has no requirements section", name)
 		}
 
 		return
@@ -178,16 +175,16 @@ func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorLi
 		pkgConstraint, exists := pkgMandatory[name]
 		if !exists {
 			if _, isConditional := pkgConditional[name]; isConditional {
-				moduleErr.Errorf("module.yaml module %q is mandatory but package.yaml lists it as conditional", name)
+				errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q is mandatory but package.yaml lists it as conditional", name)
 			} else {
-				moduleErr.Errorf("module.yaml module %q is mandatory but not found in package.yaml requirements.modules.mandatory", name)
+				errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q is mandatory but not found in package.yaml requirements.modules.mandatory", name)
 			}
 
 			continue
 		}
 
 		if constraint != pkgConstraint {
-			moduleErr.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
+			errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
 		}
 	}
 
@@ -196,16 +193,16 @@ func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorLi
 		pkgConstraint, exists := pkgConditional[name]
 		if !exists {
 			if _, isMandatory := pkgMandatory[name]; isMandatory {
-				moduleErr.Errorf("module.yaml module %q is optional but package.yaml lists it as mandatory", name)
+				errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q is optional but package.yaml lists it as mandatory", name)
 			} else {
-				moduleErr.Errorf("module.yaml module %q is optional but not found in package.yaml requirements.modules.conditional", name)
+				errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q is optional but not found in package.yaml requirements.modules.conditional", name)
 			}
 
 			continue
 		}
 
 		if constraint != pkgConstraint {
-			moduleErr.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
+			errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
 		}
 	}
 
@@ -219,7 +216,7 @@ func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorLi
 			continue
 		}
 
-		pkgErr.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
+		errorList.WithFilePath(PackageConfigFilename).Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
 	}
 
 	// package.yaml conditional -> module.yaml
@@ -232,7 +229,7 @@ func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorLi
 			continue
 		}
 
-		pkgErr.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
+		errorList.WithFilePath(PackageConfigFilename).Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
 	}
 }
 

--- a/pkg/linters/module/rules/module_package_consistency.go
+++ b/pkg/linters/module/rules/module_package_consistency.go
@@ -25,6 +25,7 @@ import (
 
 const ModulePackageConsistencyRuleName = "module-package-consistency"
 
+// NewModulePackageConsistencyRule creates a rule for cross-validating module.yaml against package.yaml.
 func NewModulePackageConsistencyRule() *ModulePackageConsistencyRule {
 	return &ModulePackageConsistencyRule{
 		RuleMeta: pkg.RuleMeta{
@@ -33,10 +34,14 @@ func NewModulePackageConsistencyRule() *ModulePackageConsistencyRule {
 	}
 }
 
+// ModulePackageConsistencyRule checks that module.yaml and package.yaml do not diverge
+// when both files exist in the module directory.
 type ModulePackageConsistencyRule struct {
 	pkg.RuleMeta
 }
 
+// CheckModulePackageConsistency compares overlapping fields between module.yaml and package.yaml.
+// Skips modules that have only one of the two files — without both there is nothing to cross-validate.
 func (r *ModulePackageConsistencyRule) CheckModulePackageConsistency(modulePath string, errorList *errors.LintRuleErrorsList) {
 	errorList = errorList.WithRule(r.GetName()).WithFilePath(ModuleConfigFilename)
 
@@ -45,7 +50,7 @@ func (r *ModulePackageConsistencyRule) CheckModulePackageConsistency(modulePath 
 		return
 	}
 
-	// package.yaml errors are reported under its own file path
+	// load package.yaml separately so its parse errors are reported under its own file path
 	pkgErrorList := errorList.WithFilePath(PackageConfigFilename)
 
 	pkg, err := getModulePackage(modulePath, pkgErrorList)
@@ -63,6 +68,7 @@ func (r *ModulePackageConsistencyRule) CheckModulePackageConsistency(modulePath 
 	compareModules(module, pkg, errorList)
 }
 
+// compareNames ensures module.yaml name matches package.yaml name.
 func compareNames(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Name == "" {
 		return
@@ -73,6 +79,7 @@ func compareNames(module *DeckhouseModule, pkg *ModulePackage, errorList *errors
 	}
 }
 
+// compareDeckhouse ensures requirements.deckhouse in module.yaml matches requirements.deckhouse.constraint in package.yaml.
 func compareDeckhouse(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Requirements == nil || module.Requirements.Deckhouse == "" {
 		return
@@ -88,6 +95,7 @@ func compareDeckhouse(module *DeckhouseModule, pkg *ModulePackage, errorList *er
 	}
 }
 
+// compareKubernetes ensures requirements.kubernetes in module.yaml matches requirements.kubernetes.constraint in package.yaml.
 func compareKubernetes(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Requirements == nil || module.Requirements.Kubernetes == "" {
 		return
@@ -103,9 +111,11 @@ func compareKubernetes(module *DeckhouseModule, pkg *ModulePackage, errorList *e
 	}
 }
 
+// compareModules cross-validates module dependency lists between module.yaml and package.yaml.
+// In module.yaml dependencies are a flat map (optional ones carry the "!optional" suffix),
+// while package.yaml splits them into mandatory and conditional groups.
 func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Requirements == nil || len(module.Requirements.ParentModules) == 0 {
-		// If module.yaml has no module deps but package.yaml does, that's a discrepancy
 		if pkg.Requirements != nil && (len(pkg.Requirements.Modules.Mandatory) > 0 || len(pkg.Requirements.Modules.Conditional) > 0) {
 			checkPackageModulesNotInModule(module, pkg, errorList)
 		}
@@ -142,7 +152,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		pkgConditional[m.Name] = m.Constraint
 	}
 
-	// Check module.yaml mandatory → package.yaml mandatory
+	// module.yaml mandatory -> package.yaml mandatory
 	for name, constraint := range moduleMandatory {
 		pkgConstraint, exists := pkgMandatory[name]
 		if !exists {
@@ -160,7 +170,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		}
 	}
 
-	// Check module.yaml conditional → package.yaml conditional
+	// module.yaml conditional -> package.yaml conditional
 	for name, constraint := range moduleConditional {
 		pkgConstraint, exists := pkgConditional[name]
 		if !exists {
@@ -178,33 +188,34 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		}
 	}
 
-	// Check package.yaml mandatory → module.yaml
+	// package.yaml mandatory -> module.yaml
 	for name := range pkgMandatory {
 		if _, exists := moduleMandatory[name]; exists {
-			continue // already checked above
+			continue
 		}
 
 		if _, exists := moduleConditional[name]; exists {
-			continue // already reported as "optional but listed as mandatory"
+			continue
 		}
 
 		errorList.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
 	}
 
-	// Check package.yaml conditional → module.yaml
+	// package.yaml conditional -> module.yaml
 	for name := range pkgConditional {
 		if _, exists := moduleConditional[name]; exists {
-			continue // already checked above
+			continue
 		}
 
 		if _, exists := moduleMandatory[name]; exists {
-			continue // already reported as "mandatory but listed as conditional"
+			continue
 		}
 
 		errorList.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
 	}
 }
 
+// checkPackageModulesNotInModule reports package.yaml modules that are missing from module.yaml.
 func checkPackageModulesNotInModule(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	for _, m := range pkg.Requirements.Modules.Mandatory {
 		if module.Requirements == nil || module.Requirements.ParentModules == nil {

--- a/pkg/linters/module/rules/module_package_consistency.go
+++ b/pkg/linters/module/rules/module_package_consistency.go
@@ -47,6 +47,7 @@ func (r *ModulePackageConsistencyRule) CheckModulePackageConsistency(modulePath 
 
 	// package.yaml errors are reported under its own file path
 	pkgErrorList := errorList.WithFilePath(PackageConfigFilename)
+
 	pkg, err := getModulePackage(modulePath, pkgErrorList)
 	if err != nil {
 		return
@@ -108,6 +109,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		if pkg.Requirements != nil && (len(pkg.Requirements.Modules.Mandatory) > 0 || len(pkg.Requirements.Modules.Conditional) > 0) {
 			checkPackageModulesNotInModule(module, pkg, errorList)
 		}
+
 		return
 	}
 
@@ -115,6 +117,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		for name := range module.Requirements.ParentModules {
 			errorList.Errorf("module.yaml module %q has requirement but package.yaml has no requirements section", name)
 		}
+
 		return
 	}
 
@@ -148,6 +151,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 			} else {
 				errorList.Errorf("module.yaml module %q is mandatory but not found in package.yaml requirements.modules.mandatory", name)
 			}
+
 			continue
 		}
 
@@ -165,6 +169,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 			} else {
 				errorList.Errorf("module.yaml module %q is optional but not found in package.yaml requirements.modules.conditional", name)
 			}
+
 			continue
 		}
 
@@ -178,9 +183,11 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		if _, exists := moduleMandatory[name]; exists {
 			continue // already checked above
 		}
+
 		if _, exists := moduleConditional[name]; exists {
 			continue // already reported as "optional but listed as mandatory"
 		}
+
 		errorList.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
 	}
 
@@ -189,9 +196,11 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		if _, exists := moduleConditional[name]; exists {
 			continue // already checked above
 		}
+
 		if _, exists := moduleMandatory[name]; exists {
 			continue // already reported as "mandatory but listed as conditional"
 		}
+
 		errorList.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
 	}
 }
@@ -202,6 +211,7 @@ func checkPackageModulesNotInModule(module *DeckhouseModule, pkg *ModulePackage,
 			errorList.Errorf("package.yaml module %q is mandatory but module.yaml has no requirements.modules", m.Name)
 			continue
 		}
+
 		if _, exists := module.Requirements.ParentModules[m.Name]; !exists {
 			errorList.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", m.Name)
 		}
@@ -212,6 +222,7 @@ func checkPackageModulesNotInModule(module *DeckhouseModule, pkg *ModulePackage,
 			errorList.Errorf("package.yaml module %q is conditional but module.yaml has no requirements.modules", m.Name)
 			continue
 		}
+
 		if _, exists := module.Requirements.ParentModules[m.Name]; !exists {
 			errorList.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", m.Name)
 		}

--- a/pkg/linters/module/rules/module_package_consistency.go
+++ b/pkg/linters/module/rules/module_package_consistency.go
@@ -43,89 +43,108 @@ type ModulePackageConsistencyRule struct {
 // CheckModulePackageConsistency compares overlapping fields between module.yaml and package.yaml.
 // Skips modules that have only one of the two files — without both there is nothing to cross-validate.
 func (r *ModulePackageConsistencyRule) CheckModulePackageConsistency(modulePath string, errorList *errors.LintRuleErrorsList) {
-	errorList = errorList.WithRule(r.GetName()).WithFilePath(ModuleConfigFilename)
+	errorList = errorList.WithRule(r.GetName())
 
-	module, err := getDeckhouseModule(modulePath, errorList)
+	module, err := getDeckhouseModule(modulePath, errorList.WithFilePath(ModuleConfigFilename))
 	if err != nil {
 		return
 	}
 
 	// load package.yaml separately so its parse errors are reported under its own file path
-	pkgErrorList := errorList.WithFilePath(PackageConfigFilename)
-
-	pkg, err := getModulePackage(modulePath, pkgErrorList)
+	packageYAML, err := getModulePackage(modulePath, errorList.WithFilePath(PackageConfigFilename))
 	if err != nil {
 		return
 	}
 
-	if module == nil || pkg == nil {
+	if module == nil || packageYAML == nil {
 		return
 	}
 
-	compareNames(module, pkg, errorList)
-	compareDeckhouse(module, pkg, errorList)
-	compareKubernetes(module, pkg, errorList)
-	compareModules(module, pkg, errorList)
+	compareNames(module, packageYAML, errorList)
+	compareDeckhouse(module, packageYAML, errorList)
+	compareKubernetes(module, packageYAML, errorList)
+	compareModules(module, packageYAML, errorList)
 }
 
 // compareNames ensures module.yaml name matches package.yaml name.
-func compareNames(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+func compareNames(module *DeckhouseModule, packageYAML *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Name == "" {
 		return
 	}
 
-	if module.Name != pkg.Name {
-		errorList.Errorf("module.yaml name %q does not match package.yaml name %q", module.Name, pkg.Name)
+	if module.Name != packageYAML.Name {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml name %q does not match package.yaml name %q", module.Name, packageYAML.Name)
 	}
 }
 
 // compareDeckhouse ensures requirements.deckhouse in module.yaml matches requirements.deckhouse.constraint in package.yaml.
-func compareDeckhouse(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+func compareDeckhouse(module *DeckhouseModule, packageYAML *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Requirements == nil || module.Requirements.Deckhouse == "" {
 		return
 	}
 
-	if pkg.Requirements == nil || pkg.Requirements.Deckhouse.Constraint == "" {
-		errorList.Errorf("module.yaml requirements.deckhouse is %q but package.yaml requirements.deckhouse.constraint is empty", module.Requirements.Deckhouse)
+	moduleConstraint := strings.TrimSpace(module.Requirements.Deckhouse)
+
+	if packageYAML.Requirements == nil {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml requirements.deckhouse is %q but package.yaml has no requirements section", moduleConstraint)
 		return
 	}
 
-	if module.Requirements.Deckhouse != pkg.Requirements.Deckhouse.Constraint {
-		errorList.Errorf("module.yaml requirements.deckhouse %q does not match package.yaml requirements.deckhouse.constraint %q", module.Requirements.Deckhouse, pkg.Requirements.Deckhouse.Constraint)
+	pkgConstraint := strings.TrimSpace(packageYAML.Requirements.Deckhouse.Constraint)
+
+	if pkgConstraint == "" {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml requirements.deckhouse is %q but package.yaml requirements.deckhouse.constraint is empty", moduleConstraint)
+		return
+	}
+
+	if moduleConstraint != pkgConstraint {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml requirements.deckhouse %q does not match package.yaml requirements.deckhouse.constraint %q", moduleConstraint, pkgConstraint)
 	}
 }
 
 // compareKubernetes ensures requirements.kubernetes in module.yaml matches requirements.kubernetes.constraint in package.yaml.
-func compareKubernetes(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+func compareKubernetes(module *DeckhouseModule, packageYAML *ModulePackage, errorList *errors.LintRuleErrorsList) {
 	if module.Requirements == nil || module.Requirements.Kubernetes == "" {
 		return
 	}
 
-	if pkg.Requirements == nil || pkg.Requirements.Kubernetes.Constraint == "" {
-		errorList.Errorf("module.yaml requirements.kubernetes is %q but package.yaml requirements.kubernetes.constraint is empty", module.Requirements.Kubernetes)
+	moduleConstraint := strings.TrimSpace(module.Requirements.Kubernetes)
+
+	if packageYAML.Requirements == nil {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml requirements.kubernetes is %q but package.yaml has no requirements section", moduleConstraint)
 		return
 	}
 
-	if module.Requirements.Kubernetes != pkg.Requirements.Kubernetes.Constraint {
-		errorList.Errorf("module.yaml requirements.kubernetes %q does not match package.yaml requirements.kubernetes.constraint %q", module.Requirements.Kubernetes, pkg.Requirements.Kubernetes.Constraint)
+	pkgConstraint := strings.TrimSpace(packageYAML.Requirements.Kubernetes.Constraint)
+
+	if pkgConstraint == "" {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml requirements.kubernetes is %q but package.yaml requirements.kubernetes.constraint is empty", moduleConstraint)
+		return
+	}
+
+	if moduleConstraint != pkgConstraint {
+		errorList.WithFilePath(ModuleConfigFilename).Errorf("module.yaml requirements.kubernetes %q does not match package.yaml requirements.kubernetes.constraint %q", moduleConstraint, pkgConstraint)
 	}
 }
 
 // compareModules cross-validates module dependency lists between module.yaml and package.yaml.
 // In module.yaml dependencies are a flat map (optional ones carry the "!optional" suffix),
 // while package.yaml splits them into mandatory and conditional groups.
-func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+func compareModules(module *DeckhouseModule, packageYAML *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	moduleErr := errorList.WithFilePath(ModuleConfigFilename)
+	pkgErr := errorList.WithFilePath(PackageConfigFilename)
+
 	if module.Requirements == nil || len(module.Requirements.ParentModules) == 0 {
-		if pkg.Requirements != nil && (len(pkg.Requirements.Modules.Mandatory) > 0 || len(pkg.Requirements.Modules.Conditional) > 0) {
-			checkPackageModulesNotInModule(module, pkg, errorList)
+		if packageYAML.Requirements != nil && (len(packageYAML.Requirements.Modules.Mandatory) > 0 || len(packageYAML.Requirements.Modules.Conditional) > 0) {
+			checkPackageModulesNotInModule(module, packageYAML, pkgErr)
 		}
 
 		return
 	}
 
-	if pkg.Requirements == nil {
+	if packageYAML.Requirements == nil {
 		for name := range module.Requirements.ParentModules {
-			errorList.Errorf("module.yaml module %q has requirement but package.yaml has no requirements section", name)
+			moduleErr.Errorf("module.yaml module %q has requirement but package.yaml has no requirements section", name)
 		}
 
 		return
@@ -135,6 +154,8 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 	moduleConditional := make(map[string]string)
 
 	for name, constraint := range module.Requirements.ParentModules {
+		constraint = strings.TrimSpace(constraint)
+
 		if strings.Contains(constraint, "!optional") {
 			moduleConditional[name] = strings.TrimSpace(strings.ReplaceAll(constraint, "!optional", ""))
 		} else {
@@ -143,13 +164,13 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 	}
 
 	pkgMandatory := make(map[string]string)
-	for _, m := range pkg.Requirements.Modules.Mandatory {
-		pkgMandatory[m.Name] = m.Constraint
+	for _, m := range packageYAML.Requirements.Modules.Mandatory {
+		pkgMandatory[m.Name] = strings.TrimSpace(m.Constraint)
 	}
 
 	pkgConditional := make(map[string]string)
-	for _, m := range pkg.Requirements.Modules.Conditional {
-		pkgConditional[m.Name] = m.Constraint
+	for _, m := range packageYAML.Requirements.Modules.Conditional {
+		pkgConditional[m.Name] = strings.TrimSpace(m.Constraint)
 	}
 
 	// module.yaml mandatory -> package.yaml mandatory
@@ -157,16 +178,16 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		pkgConstraint, exists := pkgMandatory[name]
 		if !exists {
 			if _, isConditional := pkgConditional[name]; isConditional {
-				errorList.Errorf("module.yaml module %q is mandatory but package.yaml lists it as conditional", name)
+				moduleErr.Errorf("module.yaml module %q is mandatory but package.yaml lists it as conditional", name)
 			} else {
-				errorList.Errorf("module.yaml module %q is mandatory but not found in package.yaml requirements.modules.mandatory", name)
+				moduleErr.Errorf("module.yaml module %q is mandatory but not found in package.yaml requirements.modules.mandatory", name)
 			}
 
 			continue
 		}
 
 		if constraint != pkgConstraint {
-			errorList.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
+			moduleErr.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
 		}
 	}
 
@@ -175,16 +196,16 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 		pkgConstraint, exists := pkgConditional[name]
 		if !exists {
 			if _, isMandatory := pkgMandatory[name]; isMandatory {
-				errorList.Errorf("module.yaml module %q is optional but package.yaml lists it as mandatory", name)
+				moduleErr.Errorf("module.yaml module %q is optional but package.yaml lists it as mandatory", name)
 			} else {
-				errorList.Errorf("module.yaml module %q is optional but not found in package.yaml requirements.modules.conditional", name)
+				moduleErr.Errorf("module.yaml module %q is optional but not found in package.yaml requirements.modules.conditional", name)
 			}
 
 			continue
 		}
 
 		if constraint != pkgConstraint {
-			errorList.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
+			moduleErr.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
 		}
 	}
 
@@ -198,7 +219,7 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 			continue
 		}
 
-		errorList.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
+		pkgErr.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
 	}
 
 	// package.yaml conditional -> module.yaml
@@ -211,13 +232,13 @@ func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *erro
 			continue
 		}
 
-		errorList.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
+		pkgErr.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
 	}
 }
 
 // checkPackageModulesNotInModule reports package.yaml modules that are missing from module.yaml.
-func checkPackageModulesNotInModule(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
-	for _, m := range pkg.Requirements.Modules.Mandatory {
+func checkPackageModulesNotInModule(module *DeckhouseModule, packageYAML *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	for _, m := range packageYAML.Requirements.Modules.Mandatory {
 		if module.Requirements == nil || module.Requirements.ParentModules == nil {
 			errorList.Errorf("package.yaml module %q is mandatory but module.yaml has no requirements.modules", m.Name)
 			continue
@@ -228,7 +249,7 @@ func checkPackageModulesNotInModule(module *DeckhouseModule, pkg *ModulePackage,
 		}
 	}
 
-	for _, m := range pkg.Requirements.Modules.Conditional {
+	for _, m := range packageYAML.Requirements.Modules.Conditional {
 		if module.Requirements == nil || module.Requirements.ParentModules == nil {
 			errorList.Errorf("package.yaml module %q is conditional but module.yaml has no requirements.modules", m.Name)
 			continue

--- a/pkg/linters/module/rules/module_package_consistency.go
+++ b/pkg/linters/module/rules/module_package_consistency.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"strings"
+
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const ModulePackageConsistencyRuleName = "module-package-consistency"
+
+func NewModulePackageConsistencyRule() *ModulePackageConsistencyRule {
+	return &ModulePackageConsistencyRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: ModulePackageConsistencyRuleName,
+		},
+	}
+}
+
+type ModulePackageConsistencyRule struct {
+	pkg.RuleMeta
+}
+
+func (r *ModulePackageConsistencyRule) CheckModulePackageConsistency(modulePath string, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName()).WithFilePath(ModuleConfigFilename)
+
+	module, err := getDeckhouseModule(modulePath, errorList)
+	if err != nil {
+		return
+	}
+
+	// package.yaml errors are reported under its own file path
+	pkgErrorList := errorList.WithFilePath(PackageConfigFilename)
+	pkg, err := getModulePackage(modulePath, pkgErrorList)
+	if err != nil {
+		return
+	}
+
+	if module == nil || pkg == nil {
+		return
+	}
+
+	compareNames(module, pkg, errorList)
+	compareDeckhouse(module, pkg, errorList)
+	compareKubernetes(module, pkg, errorList)
+	compareModules(module, pkg, errorList)
+}
+
+func compareNames(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	if module.Name == "" {
+		return
+	}
+
+	if module.Name != pkg.Name {
+		errorList.Errorf("module.yaml name %q does not match package.yaml name %q", module.Name, pkg.Name)
+	}
+}
+
+func compareDeckhouse(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	if module.Requirements == nil || module.Requirements.Deckhouse == "" {
+		return
+	}
+
+	if pkg.Requirements == nil || pkg.Requirements.Deckhouse.Constraint == "" {
+		errorList.Errorf("module.yaml requirements.deckhouse is %q but package.yaml requirements.deckhouse.constraint is empty", module.Requirements.Deckhouse)
+		return
+	}
+
+	if module.Requirements.Deckhouse != pkg.Requirements.Deckhouse.Constraint {
+		errorList.Errorf("module.yaml requirements.deckhouse %q does not match package.yaml requirements.deckhouse.constraint %q", module.Requirements.Deckhouse, pkg.Requirements.Deckhouse.Constraint)
+	}
+}
+
+func compareKubernetes(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	if module.Requirements == nil || module.Requirements.Kubernetes == "" {
+		return
+	}
+
+	if pkg.Requirements == nil || pkg.Requirements.Kubernetes.Constraint == "" {
+		errorList.Errorf("module.yaml requirements.kubernetes is %q but package.yaml requirements.kubernetes.constraint is empty", module.Requirements.Kubernetes)
+		return
+	}
+
+	if module.Requirements.Kubernetes != pkg.Requirements.Kubernetes.Constraint {
+		errorList.Errorf("module.yaml requirements.kubernetes %q does not match package.yaml requirements.kubernetes.constraint %q", module.Requirements.Kubernetes, pkg.Requirements.Kubernetes.Constraint)
+	}
+}
+
+func compareModules(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	if module.Requirements == nil || len(module.Requirements.ParentModules) == 0 {
+		// If module.yaml has no module deps but package.yaml does, that's a discrepancy
+		if pkg.Requirements != nil && (len(pkg.Requirements.Modules.Mandatory) > 0 || len(pkg.Requirements.Modules.Conditional) > 0) {
+			checkPackageModulesNotInModule(module, pkg, errorList)
+		}
+		return
+	}
+
+	if pkg.Requirements == nil {
+		for name := range module.Requirements.ParentModules {
+			errorList.Errorf("module.yaml module %q has requirement but package.yaml has no requirements section", name)
+		}
+		return
+	}
+
+	moduleMandatory := make(map[string]string)
+	moduleConditional := make(map[string]string)
+
+	for name, constraint := range module.Requirements.ParentModules {
+		if strings.Contains(constraint, "!optional") {
+			moduleConditional[name] = strings.TrimSpace(strings.ReplaceAll(constraint, "!optional", ""))
+		} else {
+			moduleMandatory[name] = constraint
+		}
+	}
+
+	pkgMandatory := make(map[string]string)
+	for _, m := range pkg.Requirements.Modules.Mandatory {
+		pkgMandatory[m.Name] = m.Constraint
+	}
+
+	pkgConditional := make(map[string]string)
+	for _, m := range pkg.Requirements.Modules.Conditional {
+		pkgConditional[m.Name] = m.Constraint
+	}
+
+	// Check module.yaml mandatory → package.yaml mandatory
+	for name, constraint := range moduleMandatory {
+		pkgConstraint, exists := pkgMandatory[name]
+		if !exists {
+			if _, isConditional := pkgConditional[name]; isConditional {
+				errorList.Errorf("module.yaml module %q is mandatory but package.yaml lists it as conditional", name)
+			} else {
+				errorList.Errorf("module.yaml module %q is mandatory but not found in package.yaml requirements.modules.mandatory", name)
+			}
+			continue
+		}
+
+		if constraint != pkgConstraint {
+			errorList.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
+		}
+	}
+
+	// Check module.yaml conditional → package.yaml conditional
+	for name, constraint := range moduleConditional {
+		pkgConstraint, exists := pkgConditional[name]
+		if !exists {
+			if _, isMandatory := pkgMandatory[name]; isMandatory {
+				errorList.Errorf("module.yaml module %q is optional but package.yaml lists it as mandatory", name)
+			} else {
+				errorList.Errorf("module.yaml module %q is optional but not found in package.yaml requirements.modules.conditional", name)
+			}
+			continue
+		}
+
+		if constraint != pkgConstraint {
+			errorList.Errorf("module.yaml module %q constraint %q does not match package.yaml constraint %q", name, constraint, pkgConstraint)
+		}
+	}
+
+	// Check package.yaml mandatory → module.yaml
+	for name := range pkgMandatory {
+		if _, exists := moduleMandatory[name]; exists {
+			continue // already checked above
+		}
+		if _, exists := moduleConditional[name]; exists {
+			continue // already reported as "optional but listed as mandatory"
+		}
+		errorList.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", name)
+	}
+
+	// Check package.yaml conditional → module.yaml
+	for name := range pkgConditional {
+		if _, exists := moduleConditional[name]; exists {
+			continue // already checked above
+		}
+		if _, exists := moduleMandatory[name]; exists {
+			continue // already reported as "mandatory but listed as conditional"
+		}
+		errorList.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", name)
+	}
+}
+
+func checkPackageModulesNotInModule(module *DeckhouseModule, pkg *ModulePackage, errorList *errors.LintRuleErrorsList) {
+	for _, m := range pkg.Requirements.Modules.Mandatory {
+		if module.Requirements == nil || module.Requirements.ParentModules == nil {
+			errorList.Errorf("package.yaml module %q is mandatory but module.yaml has no requirements.modules", m.Name)
+			continue
+		}
+		if _, exists := module.Requirements.ParentModules[m.Name]; !exists {
+			errorList.Errorf("package.yaml module %q is mandatory but not found in module.yaml requirements.modules", m.Name)
+		}
+	}
+
+	for _, m := range pkg.Requirements.Modules.Conditional {
+		if module.Requirements == nil || module.Requirements.ParentModules == nil {
+			errorList.Errorf("package.yaml module %q is conditional but module.yaml has no requirements.modules", m.Name)
+			continue
+		}
+		if _, exists := module.Requirements.ParentModules[m.Name]; !exists {
+			errorList.Errorf("package.yaml module %q is conditional but not found in module.yaml requirements.modules", m.Name)
+		}
+	}
+}

--- a/pkg/linters/module/rules/module_package_consistency_test.go
+++ b/pkg/linters/module/rules/module_package_consistency_test.go
@@ -502,9 +502,8 @@ func TestConsistencyInvalidModuleYAMLIgnoresConsistency(t *testing.T) {
 	writeFile(t, modulePath, ModuleConfigFilename, `invalid: yaml: [[[`)
 	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\n")
 	errorList := runConsistencyCheck(modulePath)
-	// The parse error is reported but consistency checks are skipped
 	errs := errorList.GetErrors()
-	// The module.yaml parse error goes through errorList (getDeckhouseModule returns err)
+	// broken module.yaml -> parse error, consistency checks are skipped
 	require.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Text, `Cannot parse file "module.yaml"`)
 }

--- a/pkg/linters/module/rules/module_package_consistency_test.go
+++ b/pkg/linters/module/rules/module_package_consistency_test.go
@@ -30,6 +30,7 @@ import (
 func runConsistencyCheck(modulePath string) *errors.LintRuleErrorsList {
 	errorList := errors.NewLintRuleErrorsList()
 	NewModulePackageConsistencyRule().CheckModulePackageConsistency(modulePath, errorList)
+
 	return errorList
 }
 
@@ -38,6 +39,7 @@ func writeFile(t *testing.T, dir, name, content string) {
 	if content == "" {
 		return
 	}
+
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), DefaultFilePerm))
 }
 

--- a/pkg/linters/module/rules/module_package_consistency_test.go
+++ b/pkg/linters/module/rules/module_package_consistency_test.go
@@ -1,0 +1,507 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+func runConsistencyCheck(modulePath string) *errors.LintRuleErrorsList {
+	errorList := errors.NewLintRuleErrorsList()
+	NewModulePackageConsistencyRule().CheckModulePackageConsistency(modulePath, errorList)
+	return errorList
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if content == "" {
+		return
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), DefaultFilePerm))
+}
+
+// --- No files / single file ---
+
+func TestConsistencyNoFiles(t *testing.T) {
+	modulePath := t.TempDir()
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyOnlyModuleYAML(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyOnlyPackageYAML(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+// --- Name comparison ---
+
+func TestConsistencyNameMatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyNameMismatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: different-name\napiVersion: v2\n")
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml name "stronghold" does not match package.yaml name "different-name"`)
+	assert.Equal(t, ModuleConfigFilename, errs[0].FilePath)
+	assert.Equal(t, ModulePackageConsistencyRuleName, errs[0].RuleID)
+}
+
+func TestConsistencyNameEmptyInModule(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "namespace: test\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+// --- Deckhouse comparison ---
+
+func TestConsistencyDeckhouseMatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\nrequirements:\n  deckhouse: \">= 1.77\"\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\nrequirements:\n  deckhouse:\n    constraint: \">= 1.77\"\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyDeckhouseMismatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\nrequirements:\n  deckhouse: \">= 1.77\"\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\nrequirements:\n  deckhouse:\n    constraint: \">= 1.76\"\n")
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml requirements.deckhouse ">= 1.77" does not match package.yaml requirements.deckhouse.constraint ">= 1.76"`)
+}
+
+func TestConsistencyDeckhouseMissingInPackage(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\nrequirements:\n  deckhouse: \">= 1.77\"\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\nrequirements:\n  deckhouse:\n    constraint: \"\"\n")
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml requirements.deckhouse is ">= 1.77" but package.yaml requirements.deckhouse.constraint is empty`)
+}
+
+func TestConsistencyDeckhouseNotInModule(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\nrequirements:\n  deckhouse:\n    constraint: \">= 1.77\"\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+// --- Kubernetes comparison ---
+
+func TestConsistencyKubernetesMatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\nrequirements:\n  kubernetes: \">= 1.27\"\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\nrequirements:\n  kubernetes:\n    constraint: \">= 1.27\"\n")
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyKubernetesMismatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, "name: stronghold\nnamespace: test\nrequirements:\n  kubernetes: \">= 1.27\"\n")
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\nrequirements:\n  kubernetes:\n    constraint: \">= 1.26\"\n")
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml requirements.kubernetes ">= 1.27" does not match package.yaml requirements.kubernetes.constraint ">= 1.26"`)
+}
+
+// --- Module dependencies comparison ---
+
+func TestConsistencyModulesMandatoryMatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    mandatory:
+      - name: some-module
+        constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyModulesConditionalMatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0 !optional"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    conditional:
+      - name: some-module
+        constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyModulesMandatoryNotFoundInPackage(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    mandatory: []
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml module "some-module" is mandatory but not found in package.yaml requirements.modules.mandatory`)
+}
+
+func TestConsistencyModulesOptionalNotFoundInPackage(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0 !optional"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    conditional: []
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml module "some-module" is optional but not found in package.yaml requirements.modules.conditional`)
+}
+
+func TestConsistencyModulesMandatoryVsConditional(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    conditional:
+      - name: some-module
+        constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml module "some-module" is mandatory but package.yaml lists it as conditional`)
+}
+
+func TestConsistencyModulesOptionalVsMandatory(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0 !optional"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    mandatory:
+      - name: some-module
+        constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml module "some-module" is optional but package.yaml lists it as mandatory`)
+}
+
+func TestConsistencyModulesConstraintMismatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    mandatory:
+      - name: some-module
+        constraint: ">= 2.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml module "some-module" constraint ">= 1.0.0" does not match package.yaml constraint ">= 2.0.0"`)
+}
+
+func TestConsistencyPackageModuleMandatoryNotInModuleYAML(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    other-module: ">= 1.0.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    mandatory:
+      - name: other-module
+        constraint: ">= 1.0.0"
+      - name: extra-module
+        constraint: ">= 2.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `package.yaml module "extra-module" is mandatory but not found in module.yaml requirements.modules`)
+}
+
+func TestConsistencyPackageModuleConditionalNotInModuleYAML(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    conditional:
+      - name: extra-module
+        constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `package.yaml module "extra-module" is conditional but module.yaml has no requirements.modules`)
+}
+
+func TestConsistencyModulesNoRequirementsInPackage(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    some-module: ">= 1.0.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `module.yaml module "some-module" has requirement but package.yaml has no requirements section`)
+}
+
+func TestConsistencyModulesAnyOfIgnored(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  modules:
+    cloud-provider-gcp: ">= 1.5.0"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  modules:
+    mandatory:
+      - name: cloud-provider-gcp
+        constraint: ">= 1.5.0"
+    anyOf:
+      - description: "cloud provider"
+        modules:
+          - name: cloud-provider-aws
+            constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+// --- Integration tests ---
+
+func TestConsistencyAllMatch(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  deckhouse: ">= 1.77"
+  kubernetes: ">= 1.27"
+  modules:
+    mandatory-mod: ">= 1.0.0"
+    optional-mod: ">= 1.0.0 !optional"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: stronghold
+apiVersion: v2
+requirements:
+  deckhouse:
+    constraint: ">= 1.77"
+  kubernetes:
+    constraint: ">= 1.27"
+  modules:
+    mandatory:
+      - name: mandatory-mod
+        constraint: ">= 1.0.0"
+    conditional:
+      - name: optional-mod
+        constraint: ">= 1.0.0"
+`)
+	errorList := runConsistencyCheck(modulePath)
+	assert.False(t, errorList.ContainsErrors())
+}
+
+func TestConsistencyMultipleMismatches(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `
+name: stronghold
+namespace: test
+requirements:
+  deckhouse: ">= 1.77"
+  kubernetes: ">= 1.27"
+  modules:
+    mandatory-mod: ">= 1.0.0"
+    optional-mod: ">= 1.0.0 !optional"
+`)
+	writeFile(t, modulePath, PackageConfigFilename, `
+name: wrong-name
+apiVersion: v2
+requirements:
+  deckhouse:
+    constraint: ">= 1.76"
+  kubernetes:
+    constraint: ">= 1.26"
+  modules:
+    mandatory: []
+    conditional: []
+`)
+	errorList := runConsistencyCheck(modulePath)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 5)
+
+	texts := make([]string, len(errs))
+	for i, e := range errs {
+		texts[i] = e.Text
+		assert.Equal(t, ModulePackageConsistencyRuleName, e.RuleID)
+	}
+
+	assert.Contains(t, texts[0], `module.yaml name "stronghold" does not match package.yaml name "wrong-name"`)
+	assert.Contains(t, texts[1], `module.yaml requirements.deckhouse ">= 1.77" does not match package.yaml requirements.deckhouse.constraint ">= 1.76"`)
+	assert.Contains(t, texts[2], `module.yaml requirements.kubernetes ">= 1.27" does not match package.yaml requirements.kubernetes.constraint ">= 1.26"`)
+	assert.Contains(t, texts[3], `module.yaml module "mandatory-mod" is mandatory but not found in package.yaml requirements.modules.mandatory`)
+	assert.Contains(t, texts[4], `module.yaml module "optional-mod" is optional but not found in package.yaml requirements.modules.conditional`)
+}
+
+func TestConsistencyInvalidModuleYAMLIgnoresConsistency(t *testing.T) {
+	modulePath := t.TempDir()
+	writeFile(t, modulePath, ModuleConfigFilename, `invalid: yaml: [[[`)
+	writeFile(t, modulePath, PackageConfigFilename, "name: stronghold\napiVersion: v2\n")
+	errorList := runConsistencyCheck(modulePath)
+	// The parse error is reported but consistency checks are skipped
+	errs := errorList.GetErrors()
+	// The module.yaml parse error goes through errorList (getDeckhouseModule returns err)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, `Cannot parse file "module.yaml"`)
+}

--- a/pkg/linters/module/rules/module_package_consistency_test.go
+++ b/pkg/linters/module/rules/module_package_consistency_test.go
@@ -36,6 +36,7 @@ func runConsistencyCheck(modulePath string) *errors.LintRuleErrorsList {
 
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
+
 	if content == "" {
 		return
 	}


### PR DESCRIPTION
## Summary

Add cross-validation between module.yaml and package.yaml to ensure both files stay consistent during the migration period:

- **Cross-validate name field**: module.yaml `name` must match package.yaml `name`.
- **Cross-validate deckhouse requirement**: module.yaml `requirements.deckhouse` must match package.yaml `requirements.deckhouse.constraint`.
- **Cross-validate kubernetes requirement**: module.yaml `requirements.kubernetes` must match package.yaml `requirements.kubernetes.constraint`.
- **Cross-validate module dependencies**: module.yaml flat module map is compared against package.yaml structured mandatory/conditional lists — entries without `!optional` must be in mandatory, entries with `!optional` must be in conditional. Both directions are checked.

If developers no longer want to maintain both files, they should delete module.yaml.

## Example

Consistent files — no errors:

```yaml
# module.yaml
name: stronghold
namespace: test
requirements:
  deckhouse: ">= 1.77"
  kubernetes: ">= 1.27"
  modules:
    mandatory-mod: ">= 1.0.0"
    optional-mod: ">= 1.0.0 !optional"

# package.yaml
name: stronghold
apiVersion: v2
requirements:
  deckhouse:
    constraint: ">= 1.77"
  kubernetes:
    constraint: ">= 1.27"
  modules:
    mandatory:
      - name: mandatory-mod
        constraint: ">= 1.0.0"
    conditional:
      - name: optional-mod
        constraint: ">= 1.0.0"
```

Inconsistent files — errors reported:

```yaml
# module.yaml
name: stronghold
requirements:
  modules:
    some-module: ">= 1.0.0"         # mandatory here

# package.yaml
name: stronghold
requirements:
  modules:
    conditional:                     # but conditional here
      - name: some-module
        constraint: ">= 1.0.0"
```