### PR TITLE
[dmt] add enabled-modules linter rule to detect deprecated .Values.global.enabledModules usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ Thumbs.db
 *.log
 logs/
 *.tmp
+
+.docs
+.kilo
+.claude
+openspec
+opencode

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -341,6 +341,7 @@ func mapTemplatesRules(linterSettings *pkg.LintersSettings, configSettings *conf
 	rules.ServicePortRule.SetLevel(globalRules.ServicePortRule.Impact, fallbackImpact)
 	rules.ClusterDomainRule.SetLevel(globalRules.ClusterDomainRule.Impact, fallbackImpact)
 	rules.RegistryRule.SetLevel(globalRules.RegistryRule.Impact, fallbackImpact)
+	rules.EnabledModulesRule.SetLevel(globalRules.EnabledModulesRule.Impact, fallbackImpact)
 }
 
 // mapOpenAPIRules configures OpenAPI linter rules

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -138,8 +138,9 @@ type TemplatesLinterRules struct {
 	GrafanaRule       RuleConfig
 	KubeRBACProxyRule RuleConfig
 	ServicePortRule   RuleConfig
-	ClusterDomainRule RuleConfig
-	RegistryRule      RuleConfig
+	ClusterDomainRule   RuleConfig
+	RegistryRule        RuleConfig
+	EnabledModulesRule  RuleConfig
 }
 
 type PrometheusRuleSettings struct {

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -136,8 +136,9 @@ type TemplatesLinterRules struct {
 	GrafanaRule       RuleConfig `mapstructure:"grafana-dashboards"`
 	KubeRBACProxyRule RuleConfig `mapstructure:"kube-rbac-proxy"`
 	ServicePortRule   RuleConfig `mapstructure:"service-port"`
-	ClusterDomainRule RuleConfig `mapstructure:"cluster-domain"`
-	RegistryRule      RuleConfig `mapstructure:"registry"`
+	ClusterDomainRule   RuleConfig `mapstructure:"cluster-domain"`
+	RegistryRule        RuleConfig `mapstructure:"registry"`
+	EnabledModulesRule  RuleConfig `mapstructure:"enabled-modules"`
 }
 
 func (c LinterConfig) IsWarn() bool {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -202,8 +202,9 @@ type TemplatesLinterRules struct {
 	GrafanaRule       RuleConfig `mapstructure:"grafana-dashboards"`
 	KubeRBACProxyRule RuleConfig `mapstructure:"kube-rbac-proxy"`
 	ServicePortRule   RuleConfig `mapstructure:"service-port"`
-	ClusterDomainRule RuleConfig `mapstructure:"cluster-domain"`
-	RegistryRule      RuleConfig `mapstructure:"registry"`
+	ClusterDomainRule   RuleConfig `mapstructure:"cluster-domain"`
+	RegistryRule        RuleConfig `mapstructure:"registry"`
+	EnabledModulesRule  RuleConfig `mapstructure:"enabled-modules"`
 }
 
 type TemplatesExcludeRules struct {

--- a/pkg/linters/templates/rules/enabled_modules.go
+++ b/pkg/linters/templates/rules/enabled_modules.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	EnabledModulesRuleName = "enabled-modules"
+)
+
+var enabledModulesRe = regexp.MustCompile(`\.Values\.global\.enabledModules\s*\|\s*has\s+"([^"]*)"`)
+
+type EnabledModulesRule struct {
+	pkg.RuleMeta
+}
+
+func NewEnabledModulesRule() *EnabledModulesRule {
+	return &EnabledModulesRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: EnabledModulesRuleName,
+		},
+	}
+}
+
+func (r *EnabledModulesRule) CheckEnabledModules(m pkg.Module, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithFilePath(m.GetPath()).WithRule(r.GetName())
+
+	templatesPath := filepath.Join(m.GetPath(), "templates")
+
+	// Check if templates directory exists
+	if _, err := os.Stat(templatesPath); os.IsNotExist(err) {
+		return
+	}
+
+	// Get all files in templates directory
+	files := fsutils.GetFiles(templatesPath, true, fsutils.FilterFileByExtensions(".yaml", ".yml", ".tpl", ".tpl.yaml", ".tpl.yml"))
+
+	for _, filePath := range files {
+		// Get relative path for error reporting
+		relPath, err := filepath.Rel(m.GetPath(), filePath)
+		if err != nil {
+			errorList.Errorf("Failed to get relative path for file %s: %v", filePath, err)
+			continue
+		}
+
+		// Read file content
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			errorList.Errorf("Failed to read file %s: %v", relPath, err)
+			continue
+		}
+
+		// Find all matches of the pattern
+		matches := enabledModulesRe.FindAllStringSubmatchIndex(string(content), -1)
+		for _, match := range matches {
+			// match[0]: start of full match, match[1]: end of full match
+			// match[2]: start of capture group 1 (module name), match[3]: end of capture group 1
+			matchStart := match[0]
+			moduleName := string(content[match[2]:match[3]])
+
+			line := strings.Count(string(content[:matchStart]), "\n") + 1
+
+			errorList.WithRule(r.GetName()).
+				WithFilePath(relPath).
+				WithLineNumber(line).
+				Errorf("Found usage of .Values.global.enabledModules | has \"%s\".\nConsider using (.Capabilities.APIVersions.Has \"crd-domain/crd-version/crd-name\") instead.", moduleName)
+		}
+	}
+}

--- a/pkg/linters/templates/rules/enabled_modules_test.go
+++ b/pkg/linters/templates/rules/enabled_modules_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+
+	"github.com/deckhouse/dmt/internal/mocks"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+func TestEnabledModulesRule_CheckEnabledModules(t *testing.T) {
+	tests := []struct {
+		name           string
+		templateFiles  map[string]string
+		expectedErrors []string
+		expectedLines  []int
+	}{
+		{
+			name: "should detect single enabledModules usage in template file",
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        image: test:latest
+{{- if .Values.global.enabledModules | has "cni-cilium" }}
+        env:
+        - name: CILIUM_ENABLED
+          value: "true"
+{{- end }}
+`,
+			},
+			expectedErrors: []string{
+				`Found usage of .Values.global.enabledModules | has "cni-cilium"`,
+			},
+			expectedLines: []int{12},
+		},
+		{
+			name: "should detect multiple enabledModules usages in one file",
+			templateFiles: map[string]string{
+				"templates/configmap.yaml": `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key1: "value1"
+{{ if .Values.global.enabledModules | has "module-a" }}
+  module-a: "enabled"
+{{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: another-config
+data:
+{{- if .Values.global.enabledModules | has "module-b" }}
+  module-b: "enabled"
+{{- end }}
+`,
+			},
+			expectedErrors: []string{
+				`Found usage of .Values.global.enabledModules | has "module-a"`,
+				`Found usage of .Values.global.enabledModules | has "module-b"`,
+			},
+			expectedLines: []int{8, 17},
+		},
+		{
+			name: "should handle template with parentheses and whitespace trimming",
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  template:
+    spec:
+{{- if ( .Values.global.enabledModules | has "some-module" ) }}
+      containers:
+      - name: test
+        image: test:latest
+{{- end }}
+`,
+			},
+			expectedErrors: []string{
+				`Found usage of .Values.global.enabledModules | has "some-module"`,
+			},
+			expectedLines: []int{9},
+		},
+		{
+			name: "should not report error when pattern is not present",
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        image: test:latest
+{{- if .Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/ModuleConfig" }}
+        env:
+        - name: MODULE_ENABLED
+          value: "true"
+{{- end }}
+`,
+			},
+			expectedErrors: []string{},
+			expectedLines:  []int{},
+		},
+		{
+			name: "should detect with extra whitespace in has expression",
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+{{- if .Values.global.enabledModules|has "my-module" }}
+  replicas: 3
+{{- end }}
+`,
+			},
+			expectedErrors: []string{
+				`Found usage of .Values.global.enabledModules | has "my-module"`,
+			},
+			expectedLines: []int{7},
+		},
+		{
+			name: "should match in .tpl files",
+			templateFiles: map[string]string{
+				"templates/_helpers.tpl": `
+{{- define "check-module" -}}
+{{- if .Values.global.enabledModules | has "my-module" -}}
+  enabled
+{{- else -}}
+  disabled
+{{- end -}}
+{{- end -}}
+`,
+			},
+			expectedErrors: []string{
+				`Found usage of .Values.global.enabledModules | has "my-module"`,
+			},
+			expectedLines: []int{3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tempDir, err := os.MkdirTemp("", "enabled-modules-test")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Create module structure
+			modulePath := filepath.Join(tempDir, "module")
+			if err := os.MkdirAll(modulePath, 0755); err != nil {
+				t.Fatalf("Failed to create module dir: %v", err)
+			}
+
+			// Create template files
+			for filePath, content := range tt.templateFiles {
+				fullPath := filepath.Join(modulePath, filePath)
+				if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+					t.Fatalf("Failed to create template dir: %v", err)
+				}
+
+				if err := os.WriteFile(fullPath, []byte(content), 0600); err != nil {
+					t.Fatalf("Failed to write template file: %v", err)
+				}
+			}
+
+			// Create mock module
+			mc := minimock.NewController(t)
+
+			mockModule := mocks.NewModuleMock(mc)
+			mockModule.GetPathMock.Return(modulePath)
+
+			// Create error list
+			errorList := errors.NewLintRuleErrorsList()
+
+			// Create rule
+			rule := NewEnabledModulesRule()
+
+			// Run validation
+			rule.CheckEnabledModules(mockModule, errorList)
+
+			// Check results
+			errs := errorList.GetErrors()
+			if len(errs) != len(tt.expectedErrors) {
+				t.Errorf("Expected %d errors, got %d", len(tt.expectedErrors), len(errs))
+			}
+
+			for i, expectedError := range tt.expectedErrors {
+				if i >= len(errs) {
+					t.Errorf("Expected error at index %d: %s", i, expectedError)
+					continue
+				}
+
+				if !containsStr(errs[i].Text, expectedError) {
+					t.Errorf("Expected error to contain '%s', got: %s", expectedError, errs[i].Text)
+				}
+			}
+
+			for i, expectedLine := range tt.expectedLines {
+				if i >= len(errs) {
+					t.Errorf("Expected line at index %d: %d", i, expectedLine)
+					continue
+				}
+
+				if errs[i].LineNumber != expectedLine {
+					t.Errorf("Expected line %d, got %d for error: %s", expectedLine, errs[i].LineNumber, errs[i].Text)
+				}
+			}
+		})
+	}
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -92,6 +92,9 @@ func (l *Templates) Run(m *module.Module) {
 	// rules.NewWerfRule().ValidateWerfTemplates(m, errorList.WithMaxLevel(l.cfg.Rules.WerfRule.GetLevel()))
 
 	rules.NewRegistryRule().CheckRegistrySecret(m, errorList.WithMaxLevel(l.cfg.Rules.RegistryRule.GetLevel()))
+
+	// EnabledModules rule
+	rules.NewEnabledModulesRule().CheckEnabledModules(m, errorList.WithMaxLevel(l.cfg.Rules.EnabledModulesRule.GetLevel()))
 }
 
 func (l *Templates) Name() string {


### PR DESCRIPTION
## Summary

- **Lint rule (`enabled_modules.go`)**: scans Helm template files for `.Values.global.enabledModules | has "..."` patterns and suggests migrating to `.Capabilities.APIVersions.Has` instead
- **Config wiring**: adds `EnabledModulesRule` field across three `TemplatesLinterRules` structs (runtime in `pkg/config.go`, global in `pkg/config/global/global.go`, per-module in `pkg/config/linters_settings.go`) and maps it in `mapTemplatesRules` in `internal/module/module.go`
- **Tests**: 6 test cases covering single/multiple matches, whitespace trimming variants (`{{- if`, `{{ if`, `{{- if (`), parentheses, extra whitespace in has expression, `.tpl` files, and negative (no-match) scenario — all with line number verification

## Context

The `.Values.global.enabledModules` mechanism is being deprecated in favor of Kubernetes native `.Capabilities.APIVersions.Has`. Modules should detect CRD presence via API version checks rather than relying on Helm values that depend on deckhouse-controller state. This rule helps module authors identify and migrate existing usages.

## Example

Module with `.Values.global.enabledModules | has "cni-cilium"` in templates:

```yaml
# templates/deployment.yaml
{{- if .Values.global.enabledModules | has "cni-cilium" }}
  env:
  - name: CILIUM_ENABLED
    value: "true"
{{- end }}
```

**Before**: `dmt lint templates` passes silently.

**After**: `dmt lint templates` warns:
```
Found usage of .Values.global.enabledModules | has "cni-cilium".
Consider using (.Capabilities.APIVersions.Has "crd-domain/crd-version/crd-name") instead.
```