### PR TITLE
[dmt] add cert-manager.io/v1 to default capabilities for linter

### DIFF
--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -61,7 +61,7 @@ func applyDigests(moduleName string, digests, helmValues map[string]any) {
 func helmFormatModuleImages(m *Module, rawValues map[string]any) (chartutil.Values, error) {
 	caps := chartutil.DefaultCapabilities
 	vers := []string(caps.APIVersions)
-	vers = append(vers, "autoscaling.k8s.io/v1/VerticalPodAutoscaler")
+	vers = append(vers, "autoscaling.k8s.io/v1/VerticalPodAutoscaler", "cert-manager.io/v1")
 	caps.APIVersions = vers
 
 	digests := map[string]any{


### PR DESCRIPTION
## Summary

- Adds `cert-manager.io/v1` to the default Helm capabilities in the linter's rendering context
- Ensures templates using `.Capabilities.APIVersions.Has "cert-manager.io/v1"` render correctly during `dmt lint`

## Context

The `.Values.global.enabledModules` mechanism is being deprecated in favor of `.Capabilities.APIVersions.Has`. The new `enabled-modules` linter rule suggests migrating to API version checks. However, the linter's default capabilities only included built-in Kubernetes APIs and `autoscaling.k8s.io/v1/VerticalPodAutoscaler`. Templates checking for `cert-manager.io/v1` would evaluate the condition as `false`, rendering a different template branch and often producing invalid YAML.

With this fix, `.Capabilities.APIVersions.Has "cert-manager.io/v1"` correctly returns `true` in the linter, matching real cluster behavior.

## Example

```yaml
{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
apiVersion: cert-manager.io/v1
kind: Certificate
...
{{- end }}
```

**Before**: `dmt lint` fails with `yaml: line X: could not find expected ':'` because the condition evaluates to `false`.

**After**: `dmt lint` correctly renders the `cert-manager.io/v1` resource.