### PR TITLE
[dmt] trdl version fix

### DIFF
--- a/scripts/ci/build_release.sh
+++ b/scripts/ci/build_release.sh
@@ -10,7 +10,16 @@ fi
 
 export CGO_ENABLED=0
 
+# Mark the checkout as a safe git directory so `git` works inside the build
+# container (trdl mounts the repo with a different owner).
+git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
+
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+VERSION_PKG="github.com/deckhouse/dmt/internal/version"
+
 go run github.com/mitchellh/gox@latest -osarch="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64" \
     -output="release-build/$VERSION/{{.OS}}-{{.Arch}}/bin/dmt" \
-    -ldflags="-s -w -X main.version=$VERSION" \
+    -ldflags="-s -w -X ${VERSION_PKG}.Version=$VERSION -X ${VERSION_PKG}.Commit=$COMMIT -X ${VERSION_PKG}.Date=$DATE" \
         github.com/deckhouse/dmt/cmd/dmt


### PR DESCRIPTION
after trdl build we have this

```
2026-06-05T11:12:02+03:00 INFO msg='DMT version' commit='none' date='unknown' version='devel'
```

now it must be correct