### PR TITLE
Remove CheckGitSection and related logic from werf.go

### DIFF
--- a/pkg/linters/templates/rules/werf.go
+++ b/pkg/linters/templates/rules/werf.go
@@ -47,32 +47,7 @@ func (r *WerfRule) ValidateWerfTemplates(m pkg.Module, errorList *errors.LintRul
 	errorList = errorList.WithFilePath(m.GetPath()).WithRule(r.GetName())
 
 	manifests := fsutils.SplitManifests(m.GetWerfFile())
-	checkGitSection(m.GetName(), manifests, errorList)
 	checkUnderscoredImages(manifests, errorList)
-}
-
-func checkGitSection(moduleName string, manifests []string, errorList *errors.LintRuleErrorsList) {
-	for i, manifest := range manifests {
-		jsonData, err := yaml.YAMLToJSON([]byte(manifest))
-		if err != nil {
-			errorList.Errorf("Failed to parse werf.yaml document %d: %s", i+1, err)
-			continue
-		}
-
-		imageName := gjson.GetBytes(jsonData, "image").String()
-		if !strings.Contains(imageName, moduleName+"/") {
-			continue
-		}
-
-		gjson.GetBytes(jsonData, "git").ForEach(func(_, value gjson.Result) bool {
-			if !value.Get("stageDependencies").Exists() {
-				errorList.Errorf("Image %q in werf.yaml (document %d) is missing required 'git.stageDependencies' field", imageName, i+1)
-				return false
-			}
-
-			return true
-		})
-	}
 }
 
 func checkUnderscoredImages(manifests []string, errorList *errors.LintRuleErrorsList) {

--- a/pkg/linters/templates/rules/werf_test.go
+++ b/pkg/linters/templates/rules/werf_test.go
@@ -60,54 +60,6 @@ git:
 	assert.Contains(t, errorList.GetErrors()[0].Text, "is missing required 'git.stageDependencies' field")
 }
 
-func TestCheckGitSection(t *testing.T) {
-	errorList := errors.NewLintRuleErrorsList()
-
-	// Valid manifest
-	validManifests := []string{
-		`
-image: mock-module/test-image
-git:
-- add: /deckhouse/modules/910-test-module/images/test-image
-  to: /src
-  stageDependencies:
-    install:
-    - '**/*.sh'
-`,
-	}
-
-	checkGitSection("mock-module", validManifests, errorList)
-	assert.False(t, errorList.ContainsErrors(), "Expected no errors for valid manifest")
-
-	// Invalid manifest
-	invalidManifests := []string{
-		`
-image: mock-module/test-image
-git:
-- add: /deckhouse/modules/910-test-module/images/test-image
-  to: /src
-  # Missing stageDependencies
-`,
-	}
-
-	checkGitSection("mock-module", invalidManifests, errorList)
-	assert.True(t, errorList.ContainsErrors(), "Expected errors for invalid manifest")
-	assert.Contains(t, errorList.GetErrors()[0].Text, "is missing required 'git.stageDependencies' field")
-
-	// Malformed YAML
-	malformedManifests := []string{
-		`
-image: mock-module/test-image
-git:
-  - stageDependencies: [build: "file1", "file2"]
-`,
-	}
-
-	checkGitSection("mock-module", malformedManifests, errorList)
-	assert.True(t, errorList.ContainsErrors(), "Expected errors for malformed YAML")
-	assert.Contains(t, errorList.GetErrors()[0].Text, "mock-module/test-image")
-}
-
 func TestCheckUnderscoredImages(t *testing.T) {
 	errorList := errors.NewLintRuleErrorsList()
 


### PR DESCRIPTION
Remove unneeded linter, that turns pipelines of deckhouse to red.

Checklist:
- [x] I've tested this changes on deckhouse and no errors appeared.
