### PR TITLE
[dmt] add CI deckhouse repo verify

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,3 @@
+- name: dmtlint-verify-skip
+  color: "fbca04"
+  description: "Skip the dmt-lint-verify CI check and allow merging despite lint failures on the deckhouse codebase."

--- a/.github/scripts/dmt-lint-deckhouse.sh
+++ b/.github/scripts/dmt-lint-deckhouse.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lints the deckhouse repository the same way deckhouse/tools/dmt-lint.sh does,
+# but with a locally built dmt binary instead of a released one. This verifies
+# that changes in this repository do not break (or unexpectedly change) linting
+# of the real deckhouse codebase.
+#
+# Required environment variables:
+#   SRC_DIR  - path to a checkout of the deckhouse repository
+# Optional:
+#   DMT_BIN  - dmt binary to use (default: "dmt" from PATH)
+#   WORK_DIR - scratch directory for the prepared structure (default: ${SRC_DIR}-prepared)
+
+set -euo pipefail
+
+DMT_BIN="${DMT_BIN:-dmt}"
+SRC_DIR="${SRC_DIR:?SRC_DIR (path to a deckhouse checkout) is required}"
+WORK_DIR="${WORK_DIR:-${SRC_DIR}-prepared}"
+
+# structure_prepare mirrors deckhouse/tools/dmt-lint.sh: it folds the per-edition
+# module trees (ee, be, fe, se, se-plus) into a single modules/ directory and
+# extracts cloud providers into candi/cloud-providers, so the linter sees the
+# same layout deckhouse lints in its own CI.
+structure_prepare() {
+  local modules_dir=("ee/modules" "ee/be/modules" "ee/fe/modules" "ee/se/modules" "ee/se-plus/modules")
+  local cloud_providers_glob="030-cloud-provider-*"
+
+  rm -rf "${WORK_DIR}"
+  cp -R "${SRC_DIR}" "${WORK_DIR}"
+  mkdir -p "${WORK_DIR}/candi/cloud-providers"
+  mkdir -p "${WORK_DIR}/modules"
+
+  local dir
+  for dir in "${modules_dir[@]}"; do
+    if [ -d "${WORK_DIR}/${dir}" ]; then
+      cp -R "${WORK_DIR}/${dir}"/* "${WORK_DIR}/modules/" 2>/dev/null || true
+    fi
+
+    shopt -s nullglob
+    local cloud_provider_dir
+    for cloud_provider_dir in "${WORK_DIR}/${dir}/"${cloud_providers_glob}; do
+      local cloud_provider_name
+      cloud_provider_name=$(echo "${cloud_provider_dir}" | grep -oP '(?<=030-cloud-provider-)[^[:space:]]+')
+      cp -R "${cloud_provider_dir}" "${WORK_DIR}/candi/cloud-providers/${cloud_provider_name}"
+    done
+    shopt -u nullglob
+  done
+}
+
+echo "Preparing deckhouse module structure in ${WORK_DIR}"
+structure_prepare
+
+echo "Linting with: ${DMT_BIN}"
+"${DMT_BIN}" --version || true
+
+echo "Running: ${DMT_BIN} lint -l INFO ${WORK_DIR}/modules"
+"${DMT_BIN}" lint -l INFO "${WORK_DIR}/modules"

--- a/.github/scripts/dmt-lint-deckhouse.sh
+++ b/.github/scripts/dmt-lint-deckhouse.sh
@@ -23,13 +23,20 @@
 #   SRC_DIR  - path to a checkout of the deckhouse repository
 # Optional:
 #   DMT_BIN  - dmt binary to use (default: "dmt" from PATH)
-#   WORK_DIR - scratch directory for the prepared structure (default: ${SRC_DIR}-prepared)
+#   WORK_DIR - directory for the prepared structure (default: /deckhouse)
+#
+# NOTE: WORK_DIR defaults to the absolute path /deckhouse on purpose. Deckhouse
+# OpenAPI schemas contain absolute $ref paths like
+# /deckhouse/candi/openapi/cluster_configuration.yaml, so the prepared tree must
+# live at /deckhouse for them to resolve — exactly as in deckhouse's own CI
+# (tools/dmt-lint.sh copies the sources to /deckhouse). WORK_DIR must already
+# exist and be writable by the current user (the workflow creates it).
 
 set -euo pipefail
 
 DMT_BIN="${DMT_BIN:-dmt}"
 SRC_DIR="${SRC_DIR:?SRC_DIR (path to a deckhouse checkout) is required}"
-WORK_DIR="${WORK_DIR:-${SRC_DIR}-prepared}"
+WORK_DIR="${WORK_DIR:-/deckhouse}"
 
 # structure_prepare mirrors deckhouse/tools/dmt-lint.sh: it folds the per-edition
 # module trees (ee, be, fe, se, se-plus) into a single modules/ directory and
@@ -39,8 +46,11 @@ structure_prepare() {
   local modules_dir=("ee/modules" "ee/be/modules" "ee/fe/modules" "ee/se/modules" "ee/se-plus/modules")
   local cloud_providers_glob="030-cloud-provider-*"
 
-  rm -rf "${WORK_DIR}"
-  cp -R "${SRC_DIR}" "${WORK_DIR}"
+  # Clean WORK_DIR contents but keep the directory itself: recreating a directory
+  # directly under / would require root, while WORK_DIR is pre-created for us.
+  mkdir -p "${WORK_DIR}"
+  find "${WORK_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+  cp -aT "${SRC_DIR}" "${WORK_DIR}"
   mkdir -p "${WORK_DIR}/candi/cloud-providers"
   mkdir -p "${WORK_DIR}/modules"
 

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -1,0 +1,89 @@
+name: DMT Lint Verify
+
+# Verifies that the dmt build from this branch lints the real deckhouse codebase
+# without regressions. Runs on PRs and on main.
+#
+# Bypass: if the lint fails but the PR carries the "dmtlint-verify-skip" label,
+# the check passes (the failure is acknowledged and merge is allowed). Without
+# the label a lint failure blocks the merge.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # `labeled`/`unlabeled` let the check re-evaluate (and turn green) as soon as
+    # the skip label is added or removed, without pushing a new commit.
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dmt-lint-verify-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  SKIP_LABEL: dmtlint-verify-skip
+  DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
+  DECKHOUSE_REF: main
+
+jobs:
+  dmt-lint-verify:
+    name: dmt-lint-verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve skip label
+        id: ctx
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::'${SKIP_LABEL}' label present — dmt lint verification will be skipped."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout dmt
+        if: steps.ctx.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        if: steps.ctx.outputs.skip != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build dmt
+        if: steps.ctx.outputs.skip != 'true'
+        run: make build
+
+      - name: Clone deckhouse (${{ env.DECKHOUSE_REF }})
+        if: steps.ctx.outputs.skip != 'true'
+        run: |
+          git clone --depth 1 --branch "${DECKHOUSE_REF}" "${DECKHOUSE_REPO}" "${RUNNER_TEMP}/deckhouse-src"
+
+      - name: Lint deckhouse with built dmt
+        id: lint
+        if: steps.ctx.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          DMT_BIN: ${{ github.workspace }}/dmt
+          SRC_DIR: ${{ runner.temp }}/deckhouse-src
+          WORK_DIR: ${{ runner.temp }}/deckhouse-prepared
+        run: bash .github/scripts/dmt-lint-deckhouse.sh
+
+      - name: Evaluate result
+        run: |
+          if [[ "${{ steps.ctx.outputs.skip }}" == "true" ]]; then
+            echo "::warning::dmt lint verification skipped because the '${SKIP_LABEL}' label is set on this PR."
+            exit 0
+          fi
+
+          if [[ "${{ steps.lint.outcome }}" == "success" ]]; then
+            echo "dmt lint passed on the deckhouse codebase."
+            exit 0
+          fi
+
+          echo "::error::dmt lint failed on the deckhouse codebase. Review the 'Lint deckhouse with built dmt' step logs. To acknowledge and allow merge anyway, add the '${SKIP_LABEL}' label to this PR."
+          exit 1

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -63,6 +63,15 @@ jobs:
         run: |
           git clone --depth 1 --branch "${DECKHOUSE_REF}" "${DECKHOUSE_REPO}" "${RUNNER_TEMP}/deckhouse-src"
 
+      # Deckhouse OpenAPI schemas use absolute $ref paths under /deckhouse, so the
+      # prepared tree must live there. Creating a dir under / needs root; hand it
+      # to the runner user so the lint step can populate it without sudo.
+      - name: Prepare /deckhouse
+        if: steps.ctx.outputs.skip != 'true'
+        run: |
+          sudo mkdir -p /deckhouse
+          sudo chown "$(id -u):$(id -g)" /deckhouse
+
       - name: Lint deckhouse with built dmt
         id: lint
         if: steps.ctx.outputs.skip != 'true'
@@ -70,7 +79,7 @@ jobs:
         env:
           DMT_BIN: ${{ github.workspace }}/dmt
           SRC_DIR: ${{ runner.temp }}/deckhouse-src
-          WORK_DIR: ${{ runner.temp }}/deckhouse-prepared
+          WORK_DIR: /deckhouse
         run: bash .github/scripts/dmt-lint-deckhouse.sh
 
       - name: Evaluate result

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -19,7 +19,7 @@ Proper template validation prevents runtime issues, ensures applications are pro
 | [grafana-dashboards](#grafana-dashboards) | Validates Grafana dashboard templates | ✅ | enabled |
 | [cluster-domain](#cluster-domain) | Validates cluster domain configuration is dynamic | ❌ | enabled |
 | [registry](#registry) | Validates registry secret configuration | ❌ | enabled |
-| [werf](#werf) | Validates werf.yaml templates for git stage dependencies | ❌ | enabled |
+| [werf](#werf) | Validates image names in `werf.yaml` do not contain underscores | ❌ | enabled |
 | [enabled-modules](#enabled-modules) | Detects usage of `.Values.global.enabledModules` in templates | ✅ | enabled |
 
 ## Rule Details
@@ -868,8 +868,10 @@ linters-settings:
   templates:
     exclude-rules:
       service-port:
-        - d8-control-plane-apiserver  # Exclude specific service
-        - legacy-service
+        - name: web-service       # Exclude a specific service port
+          port: http
+        - name: legacy-service
+          port: metrics
 ```
 
 ---
@@ -998,7 +1000,7 @@ spec:
 linters-settings:
   templates:
     exclude-rules:
-      ingress-rules:
+      ingress:
         - kind: Ingress
           name: dashboard  # Exclude specific Ingress
         - kind: Ingress
@@ -1510,44 +1512,43 @@ Module names are converted to camelCase for values:
 
 ### werf
 
-**Purpose:** Validates werf.yaml templates to ensure proper git stage dependencies are configured. This ensures consistent and reproducible image builds.
+**Purpose:** Validates that image names defined in `werf.yaml` do not contain underscores. Underscores in image names break OCI/Docker image reference rules and can cause push/pull failures in some registries and tooling.
 
 **Description:**
 
-Scans the werf.yaml file for image definitions that belong to the module and validates that git sections have proper `stageDependencies` configured.
+Splits the module's `werf.yaml` into individual documents and, for every document that defines an `image`, checks that the image name does not contain an underscore (`_`).
 
 **What it checks:**
 
-1. Image definitions in werf.yaml that match the module name
-2. Git sections have `stageDependencies` configured
+1. Every document in `werf.yaml` that has an `image` field
+2. The `image` name does not contain the `_` character
 
 **Why it matters:**
 
-Missing stage dependencies:
-- Can cause inconsistent builds
-- May skip rebuilds when source files change
-- Lead to stale images being used
-- Create debugging difficulties
+Underscores in image names:
+- Are not valid in many container registry naming conventions
+- Cause inconsistent behavior between registries and build tools
+- Can lead to failed image pushes or pulls
+- Make image references harder to predict and reuse
 
 **Examples:**
 
-❌ **Incorrect** - Missing stageDependencies:
+❌ **Incorrect** - Image name with underscore:
 
 ```yaml
 # werf.yaml
-image: my-module/app
+image: my_module/app
 git:
   - add: /src
     to: /app
-    # ❌ Missing stageDependencies
 ```
 
 **Error:**
 ```
-Error: parsing Werf file, document 1 (image: my-module/app) failed: 'git.stageDependencies' is required
+Error: Image name "my_module/app" in werf.yaml (document 1) must not contain underscores
 ```
 
-✅ **Correct** - With stageDependencies:
+✅ **Correct** - Image name without underscores:
 
 ```yaml
 # werf.yaml
@@ -1555,30 +1556,22 @@ image: my-module/app
 git:
   - add: /src
     to: /app
-    stageDependencies:
-      install:
-        - "**/*"
-      beforeSetup:
-        - "go.mod"
-        - "go.sum"
 ```
 
-✅ **Correct** - Multiple git sources:
+✅ **Correct** - Multiple images:
 
 ```yaml
 # werf.yaml
+---
 image: my-module/app
 git:
   - add: /src
     to: /app/src
-    stageDependencies:
-      install:
-        - "**/*.go"
-  - add: /config
-    to: /app/config
-    stageDependencies:
-      beforeSetup:
-        - "**/*.yaml"
+---
+image: my-module/exporter
+git:
+  - add: /exporter
+    to: /app/exporter
 ```
 
 ---

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -36,13 +36,13 @@ Validates that every pod controller has a VPA targeting it, and that the VPA's c
 
 1. Every Deployment, DaemonSet, and StatefulSet has a corresponding VPA
 2. VPA `targetRef` correctly references the controller (kind, name, namespace)
-3. VPA `updateMode` cannot be "Auto"
+3. VPA `updateMode` must be one of `Off`, `Initial`, `Recreate`, or `InPlaceOrRecreate` (the legacy `Auto` mode is deprecated and reported as an error)
 4. VPA has `resourcePolicy.containerPolicies` for all containers (except when `updateMode: "Off"`)
 5. Each container policy specifies:
    - `minAllowed.cpu` and `minAllowed.memory`
    - `maxAllowed.cpu` and `maxAllowed.memory`
 6. Min values are less than max values
-7. Container names in VPA match container names in the controller
+7. Container names match in both directions: every controller container has a VPA policy, and every VPA policy references an existing controller container
 
 **Why it matters:**
 
@@ -1278,7 +1278,7 @@ monitoring/
 # .dmt.yaml
 linters-settings:
   templates:
-    grafana:
+    grafana-dashboards:
       disable: true  # Disable rule completely
 ```
 
@@ -1290,7 +1290,7 @@ linters-settings:
 
 **Description:**
 
-Scans all template files (`.yaml`, `.yml`, `.tpl`) for hardcoded `cluster.local` strings and recommends using the dynamic `.Values.global.clusterConfiguration.clusterDomain` value instead.
+Scans all template files (`.yaml`, `.yml`, `.tpl`, `.tpl.yaml`, `.tpl.yml`) for hardcoded `cluster.local` strings and recommends using the dynamic `.Values.global.clusterConfiguration.clusterDomain` value instead.
 
 **What it checks:**
 
@@ -1665,6 +1665,37 @@ linters-settings:
       disable: true
 ```
 
+### Per-Rule Impact Levels
+
+Each rule can override the overall impact level individually via the `rules` block:
+
+```yaml
+# .dmt.yaml
+linters-settings:
+  templates:
+    rules:
+      vpa:
+        impact: warning
+      pdb:
+        impact: error
+      ingress:
+        impact: warning
+      prometheus-rules:
+        impact: info
+      grafana-dashboards:
+        impact: info
+      kube-rbac-proxy:
+        impact: error
+      service-port:
+        impact: warning
+      cluster-domain:
+        impact: warning
+      registry:
+        impact: error
+      enabled-modules:
+        impact: warning
+```
+
 ### Rule-Level Exclusions
 
 Configure exclusions for specific rules:
@@ -1689,16 +1720,18 @@ linters-settings:
           name: test-database
       
       # Ingress exclusions (by kind and name)
-      ingress-rules:
+      ingress:
         - kind: Ingress
           name: dashboard
         - kind: Ingress
           name: legacy-api
       
-      # Service port exclusions (by service name)
+      # Service port exclusions (by service name and port name)
       service-port:
-        - d8-control-plane-apiserver
-        - legacy-service
+        - name: d8-control-plane-apiserver
+          port: https
+        - name: legacy-service
+          port: http
       
       # kube-rbac-proxy exclusions (by namespace)
       kube-rbac-proxy:
@@ -1741,13 +1774,15 @@ linters-settings:
         - kind: Deployment
           name: single-pod-app
       
-      ingress-rules:
+      ingress:
         - kind: Ingress
           name: internal-dashboard
       
       service-port:
-        - apiserver
-        - webhook-service
+        - name: apiserver
+          port: https
+        - name: webhook-service
+          port: webhook
       
       kube-rbac-proxy:
         - d8-development
@@ -2033,7 +2068,7 @@ Error: Ingress annotation "nginx.ingress.kubernetes.io/configuration-snippet" do
    linters-settings:
      templates:
        exclude-rules:
-         ingress-rules:
+         ingress:
            - kind: Ingress
              name: dashboard
    ```

--- a/pkg/linters/templates/rules/werf_test.go
+++ b/pkg/linters/templates/rules/werf_test.go
@@ -28,7 +28,6 @@ func TestValidateWerfTemplates(t *testing.T) {
 
 	mock := mocks.NewModuleMock(mc)
 	mock.GetPathMock.Return("/mock/path")
-	mock.GetNameMock.Return("mock-module")
 	mock.GetWerfFileMock.Return(`
 image: mock-module/test-image
 git:
@@ -43,21 +42,18 @@ git:
 	assert.False(t, errorList.ContainsErrors(), "Expected no errors for valid Werf file")
 
 	errorList = errors.NewLintRuleErrorsList()
-	// Mock module with invalid Werf file
+	// Mock module with invalid Werf file (image name contains an underscore)
 	mockModuleWerfInvalid := mocks.NewModuleMock(mc)
 	mockModuleWerfInvalid.GetPathMock.Return("/mock/path")
-	mockModuleWerfInvalid.GetNameMock.Return("mock-module")
 	mockModuleWerfInvalid.GetWerfFileMock.Return(`
-image: mock-module/test-image
+image: mock-module/test_image
 git:
 - add: /deckhouse/modules/910-test-module/images/test-image
   to: /src
-# Missing stageDependencies
-
 `)
 	rule.ValidateWerfTemplates(mockModuleWerfInvalid, errorList)
 	assert.True(t, errorList.ContainsErrors(), "Expected errors for invalid Werf file")
-	assert.Contains(t, errorList.GetErrors()[0].Text, "is missing required 'git.stageDependencies' field")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "must not contain underscores")
 }
 
 func TestCheckUnderscoredImages(t *testing.T) {


### PR DESCRIPTION
### Summary

**`dmt-lint-verify` CI workflow**

Adds a new GitHub Actions workflow (`.github/workflows/dmt-lint.yml`) that verifies every PR and `main` push does not regress linting of the real `deckhouse/deckhouse` codebase.

- Builds `dmt` from the branch under test (instead of a released binary), clones `deckhouse` `main` at depth 1, prepares the module structure at `/deckhouse` (required for absolute `$ref` resolution in deckhouse's OpenAPI schemas), and runs `dmt lint -l INFO /deckhouse/modules` — identical to deckhouse's own CI (`tools/dmt-lint.sh`).
- Logic is extracted into a standalone shell script (`.github/scripts/dmt-lint-deckhouse.sh`) that can be run locally.
- If the lint fails but a `dmtlint-verify-skip` label is present on the PR, the check passes (the failure is acknowledged). Without the label a lint failure blocks merge.
- Added `.github/labels.yml` declaring the `dmtlint-verify-skip` label.