### PR TITLE
[dmt] add input for deckhouse branch in CI workflow

### DIFF
--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -17,7 +17,7 @@ on:
     inputs:
       deckhouse_branch:
         description: 'Deckhouse branch or tag to run dmt lint on'
-        required: false
+        required: true
         default: 'main'
         type: string
 

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -14,6 +14,12 @@ on:
     # the skip label is added or removed, without pushing a new commit.
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
+    inputs:
+      deckhouse_branch:
+        description: 'Deckhouse branch or tag to run dmt lint on'
+        required: false
+        default: 'main'
+        type: string
 
 permissions:
   contents: read
@@ -26,7 +32,7 @@ concurrency:
 env:
   SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
-  DECKHOUSE_REF: main
+  DECKHOUSE_REF: ${{ inputs.deckhouse_branch }}
 
 jobs:
   dmt-lint-verify:

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -17,7 +17,7 @@ on:
     inputs:
       deckhouse_branch:
         description: 'Deckhouse branch or tag to run dmt lint on'
-        required: true
+        required: false
         default: 'main'
         type: string
 

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -32,7 +32,7 @@ concurrency:
 env:
   SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
-  DECKHOUSE_REF: ${{ inputs.deckhouse_branch }}
+  DECKHOUSE_REF: ${{ inputs.deckhouse_branch:-main }}
 
 jobs:
   dmt-lint-verify:

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -32,7 +32,7 @@ concurrency:
 env:
   SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
-  DECKHOUSE_REF: ${{ inputs.deckhouse_branch:-main }}
+  DECKHOUSE_REF: ${{ inputs.deckhouse_branch || 'main' }}
 
 jobs:
   dmt-lint-verify:


### PR DESCRIPTION
Add additional field to manual run of dmt lint verify on deckhouse 
<img width="302" height="327" alt="image" src="https://github.com/user-attachments/assets/b17efd2e-605f-485b-9918-ef9085d46b2c" />
