### PR TITLE
[dmt] werf images underscore chech must check only files in ./image folder

### DIFF
--- a/internal/werf/images.go
+++ b/internal/werf/images.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package werf
+
+import (
+	"cmp"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/template"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+)
+
+const (
+	imagesDirName   = "images"
+	werfIncFileName = "werf.inc.yaml"
+)
+
+// ModuleImageWerfFile holds a rendered werf.inc.yaml file together with its
+// path relative to the module directory (e.g. "images/<name>/werf.inc.yaml").
+type ModuleImageWerfFile struct {
+	// RelPath is the module-relative path of the source werf.inc.yaml file.
+	RelPath string
+	// Content is the rendered werf.inc.yaml content.
+	Content string
+}
+
+// GetModuleImagesWerfFiles renders every "images/*/werf.inc.yaml" file found in
+// the module directory and returns them keyed by their module-relative path.
+//
+// Unlike GetWerfConfig, it does not walk up to the repository root werf.yaml and
+// does not aggregate stages/base images from outside the module. Only the
+// module's own images are considered. Files that cannot be rendered in isolation
+// (e.g. they rely on build context that is only available to the full werf
+// pipeline) are skipped rather than reported as errors.
+func GetModuleImagesWerfFiles(moduleDir string) ([]ModuleImageWerfFile, error) {
+	imagesDir := filepath.Join(moduleDir, imagesDirName)
+	if !fsutils.IsDir(imagesDir) {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []ModuleImageWerfFile
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		incPath := filepath.Join(imagesDir, entry.Name(), werfIncFileName)
+		if !fsutils.IsFile(incPath) {
+			continue
+		}
+
+		content, err := os.ReadFile(incPath)
+		if err != nil {
+			return nil, err
+		}
+
+		rendered, err := renderWerfIncFile(moduleDir, entry.Name(), string(content))
+		if err != nil {
+			// Best-effort: the inc file may rely on build context that is only
+			// available to the full werf pipeline. Skip it instead of producing
+			// a false positive.
+			log.Debug("skipping werf.inc.yaml that cannot be rendered in isolation",
+				slog.String("path", incPath),
+				slog.String("error", err.Error()),
+			)
+
+			continue
+		}
+
+		result = append(result, ModuleImageWerfFile{
+			RelPath: filepath.ToSlash(filepath.Join(imagesDirName, entry.Name(), werfIncFileName)),
+			Content: rendered,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool { return result[i].RelPath < result[j].RelPath })
+
+	return result, nil
+}
+
+// renderWerfIncFile renders a single images/<name>/werf.inc.yaml file the same
+// way the module's ".werf/images.yaml" would: the content is treated as a
+// template and executed with a per-image context.
+func renderWerfIncFile(moduleDir, imageName, content string) (string, error) {
+	tmpl := template.New(werfIncFileName)
+	tmpl.Funcs(funcMap(tmpl))
+
+	if err := parseWerfConfigTemplatesDir(moduleDir, tmpl); err != nil {
+		return "", err
+	}
+
+	tmpl, err := tmpl.Parse(content)
+	if err != nil {
+		return "", err
+	}
+
+	root := map[string]any{
+		"Files": NewFiles(filepath.Join(moduleDir, werfFileName), moduleDir),
+		"Env":   cmp.Or(os.Getenv("WERF_ENV"), "EE"),
+	}
+
+	ctx := map[string]any{
+		"Root":             root,
+		"ImageName":        imageName,
+		"ImagePath":        filepath.ToSlash(filepath.Join("/", imagesDirName, imageName)),
+		"ModuleNamePrefix": "",
+		"ModuleDir":        "/",
+		"GOPROXY":          cmp.Or(os.Getenv("GOPROXY"), "https://proxy.golang.org,direct"),
+	}
+
+	return executeTemplate(tmpl, werfIncFileName, ctx)
+}

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -1512,15 +1512,15 @@ Module names are converted to camelCase for values:
 
 ### werf
 
-**Purpose:** Validates that image names defined in `werf.yaml` do not contain underscores. Underscores in image names break OCI/Docker image reference rules and can cause push/pull failures in some registries and tooling.
+**Purpose:** Validates that image names defined in the module's `images/*/werf.inc.yaml` files do not contain underscores. Underscores in image names break OCI/Docker image reference rules and can cause push/pull failures in some registries and tooling.
 
 **Description:**
 
-Splits the module's `werf.yaml` into individual documents and, for every document that defines an `image`, checks that the image name does not contain an underscore (`_`).
+Scans only the module's `images/` directory. Each `images/<name>/werf.inc.yaml` file is rendered the same way the module's `.werf/images.yaml` would render it, split into individual documents, and for every document that defines an `image`, the rule checks that the image name does not contain an underscore (`_`). The repository-root `werf.yaml` and stages/base images defined outside the module are no longer scanned.
 
 **What it checks:**
 
-1. Every document in `werf.yaml` that has an `image` field
+1. Every document in each `images/<name>/werf.inc.yaml` that has an `image` field
 2. The `image` name does not contain the `_` character
 
 **Why it matters:**
@@ -1536,7 +1536,7 @@ Underscores in image names:
 ❌ **Incorrect** - Image name with underscore:
 
 ```yaml
-# werf.yaml
+# images/app/werf.inc.yaml
 image: my_module/app
 git:
   - add: /src
@@ -1545,13 +1545,13 @@ git:
 
 **Error:**
 ```
-Error: Image name "my_module/app" in werf.yaml (document 1) must not contain underscores
+Error: Image name "my_module/app" in images/app/werf.inc.yaml (document 1) must not contain underscores
 ```
 
 ✅ **Correct** - Image name without underscores:
 
 ```yaml
-# werf.yaml
+# images/app/werf.inc.yaml
 image: my-module/app
 git:
   - add: /src
@@ -1561,7 +1561,7 @@ git:
 ✅ **Correct** - Multiple images:
 
 ```yaml
-# werf.yaml
+# images/app/werf.inc.yaml
 ---
 image: my-module/app
 git:

--- a/pkg/linters/templates/rules/werf.go
+++ b/pkg/linters/templates/rules/werf.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/internal/werf"
 	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
@@ -44,17 +45,27 @@ type WerfRule struct {
 }
 
 func (r *WerfRule) ValidateWerfTemplates(m pkg.Module, errorList *errors.LintRuleErrorsList) {
-	errorList = errorList.WithFilePath(m.GetPath()).WithRule(r.GetName())
+	errorList = errorList.WithRule(r.GetName())
 
-	manifests := fsutils.SplitManifests(m.GetWerfFile())
-	checkUnderscoredImages(manifests, errorList)
+	imageFiles, err := werf.GetModuleImagesWerfFiles(m.GetPath())
+	if err != nil {
+		errorList.Errorf("Failed to read images werf files: %s", err)
+		return
+	}
+
+	for _, imageFile := range imageFiles {
+		fileErrorList := errorList.WithFilePath(imageFile.RelPath)
+
+		manifests := fsutils.SplitManifests(imageFile.Content)
+		checkUnderscoredImages(imageFile.RelPath, manifests, fileErrorList)
+	}
 }
 
-func checkUnderscoredImages(manifests []string, errorList *errors.LintRuleErrorsList) {
+func checkUnderscoredImages(filePath string, manifests []string, errorList *errors.LintRuleErrorsList) {
 	for i, manifest := range manifests {
 		jsonData, err := yaml.YAMLToJSON([]byte(manifest))
 		if err != nil {
-			errorList.Errorf("Failed to parse werf.yaml document %d: %s", i+1, err)
+			errorList.Errorf("Failed to parse %s document %d: %s", filePath, i+1, err)
 			continue
 		}
 
@@ -64,7 +75,7 @@ func checkUnderscoredImages(manifests []string, errorList *errors.LintRuleErrors
 		}
 
 		if strings.Contains(imageName, "_") {
-			errorList.Errorf("Image name %q in werf.yaml (document %d) must not contain underscores", imageName, i+1)
+			errorList.Errorf("Image name %q in %s (document %d) must not contain underscores", imageName, filePath, i+1)
 		}
 	}
 }

--- a/pkg/linters/templates/rules/werf_test.go
+++ b/pkg/linters/templates/rules/werf_test.go
@@ -12,48 +12,58 @@ import (
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
-func TestValidateWerfTemplates(t *testing.T) {
-	dir := t.TempDir()
+// writeImageWerfFile writes content to <moduleDir>/images/<image>/werf.inc.yaml.
+func writeImageWerfFile(t *testing.T, moduleDir, image, content string) {
+	t.Helper()
 
-	filePath := filepath.Join(dir, "test-image")
-	if err := os.WriteFile(filePath, []byte(`image: {{ include "helm_lib_module_image" . "mock-module/test-image" }}`), 0644); err != nil {
+	dir := filepath.Join(moduleDir, "images", image)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
+	if err := os.WriteFile(filepath.Join(dir, "werf.inc.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateWerfTemplates(t *testing.T) {
+	mc := minimock.NewController(t)
+
+	// Module with a valid werf.inc.yaml (no underscores in image name).
+	validDir := t.TempDir()
+	writeImageWerfFile(t, validDir, "test-image", `
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}
+git:
+- add: /src
+  to: /src
+`)
 
 	rule := NewWerfRule()
 	errorList := errors.NewLintRuleErrorsList()
 
-	// Mock module with valid Werf file
-	mc := minimock.NewController(t)
+	validModule := mocks.NewModuleMock(mc)
+	validModule.GetPathMock.Return(validDir)
 
-	mock := mocks.NewModuleMock(mc)
-	mock.GetPathMock.Return("/mock/path")
-	mock.GetWerfFileMock.Return(`
-image: mock-module/test-image
-git:
-- add: /deckhouse/modules/910-test-module/images/test-image
-  to: /src
-  stageDependencies:
-    install:
-    - '**/*.sh'
-`)
-
-	rule.ValidateWerfTemplates(mock, errorList)
+	rule.ValidateWerfTemplates(validModule, errorList)
 	assert.False(t, errorList.ContainsErrors(), "Expected no errors for valid Werf file")
 
-	errorList = errors.NewLintRuleErrorsList()
-	// Mock module with invalid Werf file (image name contains an underscore)
-	mockModuleWerfInvalid := mocks.NewModuleMock(mc)
-	mockModuleWerfInvalid.GetPathMock.Return("/mock/path")
-	mockModuleWerfInvalid.GetWerfFileMock.Return(`
-image: mock-module/test_image
-git:
-- add: /deckhouse/modules/910-test-module/images/test-image
-  to: /src
+	// Module with an invalid werf.inc.yaml (image name contains an underscore).
+	invalidDir := t.TempDir()
+	writeImageWerfFile(t, invalidDir, "test-image", `
+image: {{ .ModuleNamePrefix }}_{{ .ImageName }}_
+fromImage: scratch
 `)
-	rule.ValidateWerfTemplates(mockModuleWerfInvalid, errorList)
+
+	errorList = errors.NewLintRuleErrorsList()
+
+	invalidModule := mocks.NewModuleMock(mc)
+	invalidModule.GetPathMock.Return(invalidDir)
+
+	rule.ValidateWerfTemplates(invalidModule, errorList)
 	assert.True(t, errorList.ContainsErrors(), "Expected errors for invalid Werf file")
 	assert.Contains(t, errorList.GetErrors()[0].Text, "must not contain underscores")
+	assert.Equal(t, filepath.ToSlash(filepath.Join("images", "test-image", "werf.inc.yaml")),
+		errorList.GetErrors()[0].FilePath, "Expected a relative file path that includes the werf file name")
 }
 
 func TestCheckUnderscoredImages(t *testing.T) {
@@ -72,7 +82,7 @@ git:
 `,
 	}
 
-	checkUnderscoredImages(validManifests, errorList)
+	checkUnderscoredImages("images/test-image/werf.inc.yaml", validManifests, errorList)
 	assert.False(t, errorList.ContainsErrors(), "Expected no errors for valid manifest")
 
 	// Invalid manifest
@@ -88,7 +98,7 @@ git:
 `,
 	}
 
-	checkUnderscoredImages(invalidManifests, errorList)
+	checkUnderscoredImages("images/test-image/werf.inc.yaml", invalidManifests, errorList)
 	assert.True(t, errorList.ContainsErrors(), "Expected errors for invalid manifest")
 	assert.Contains(t, errorList.GetErrors()[0].Text, "must not contain underscores")
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -108,6 +108,10 @@ type CaseSpec struct {
 	ExpectClean bool `yaml:"expectClean"`
 	// Expect lists the findings that must be present.
 	Expect []Finding `yaml:"expect"`
+	// ExpectAbsent lists findings that must NOT be present. Each entry uses the
+	// same matching semantics as Expect (linter required; rule/level/textContains
+	// optional); the case fails if any produced finding matches.
+	ExpectAbsent []Finding `yaml:"expectAbsent"`
 	// Exhaustive, when true, asserts that there are no findings beyond those
 	// listed in Expect (every produced finding must be matched by some Finding).
 	Exhaustive bool `yaml:"exhaustive"`
@@ -322,6 +326,15 @@ func Match(spec *CaseSpec, findings []pkg.LinterError) MatchResult {
 		case exp.Count == 0 && hits == 0:
 			res.Failures = append(res.Failures,
 				fmt.Sprintf("expected at least one finding for [%s], got none", exp))
+		}
+	}
+
+	for _, absent := range spec.ExpectAbsent {
+		for i := range findings {
+			if findingMatches(absent, findings[i]) {
+				res.Failures = append(res.Failures,
+					fmt.Sprintf("expected no finding for [%s], but got: %s", absent, formatFinding(findings[i])))
+			}
 		}
 	}
 

--- a/test/e2e/testdata/templates/underscored-werf-template/expected.yaml
+++ b/test/e2e/testdata/templates/underscored-werf-template/expected.yaml
@@ -1,8 +1,14 @@
 description: >
-  A werf.yaml file that contains an image with underscores should be flagged by the werf test rule.
+  An images/<name>/werf.inc.yaml that renders to an image name with underscores
+  should be flagged by the werf rule, and the message must reference the image's
+  relative werf file path.
 module: module
 expect:
   - linter: templates
     rule: werf
     level: error
     textContains: "must not contain underscores"
+  - linter: templates
+    rule: werf
+    level: error
+    textContains: "images/test/werf.inc.yaml"

--- a/test/e2e/testdata/templates/werf-image-clean/expected.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/expected.yaml
@@ -1,0 +1,7 @@
+description: >
+  A module whose images/*/werf.inc.yaml render to image names without
+  underscores must not trigger the werf rule.
+module: module
+expectAbsent:
+  - linter: templates
+    rule: werf

--- a/test/e2e/testdata/templates/werf-image-clean/module/.werf/images.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/module/.werf/images.yaml
@@ -1,0 +1,26 @@
+{{- $Root := . }}
+
+{{- $ImagesBuildFiles := .Files.Glob "images/*/{Dockerfile,werf.inc.yaml}" }}
+
+{{- range $path, $content := $ImagesBuildFiles  }}
+  {{- $imageName := base (dir $path) }}
+  {{- $ctx := dict }}
+  {{- $_ := set $ctx "Root" $ }}
+  {{- $_ := set $ctx "ImageName" $imageName }}
+  {{- $_ := set $ctx "ImagePath" (printf "/images/%s" $imageName) }}
+  {{- $_ := set $ctx "ModuleNamePrefix" "" }}
+  {{- $_ := set $ctx "ModuleDir" "/" }}
+  {{- $_ := set $ctx "GOPROXY" (env "GOPROXY" "https://proxy.golang.org,direct") }}
+---
+  {{- /* For Dockerfile just render it from the folder. */ -}}
+  {{- if not (regexMatch "/werf.inc.yaml$" $path) }}
+image: images/{{ $ctx.ImageName }}
+context: images/{{ $ctx.ImageName }}
+dockerfile: Dockerfile
+
+  {{- /* For werf.inc.yaml render content by providing the ImageName param. */ -}}
+  {{- else }}
+{{ tpl $content $ctx }}
+
+  {{- end }}
+{{- end }}

--- a/test/e2e/testdata/templates/werf-image-clean/module/images/test/werf.inc.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/module/images/test/werf.inc.yaml
@@ -1,0 +1,15 @@
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+final: false
+fromImage: nginx:latest
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}
+fromImage: scratch
+import:
+- image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+  add: /index.html
+  to: /index.html
+  before: setup
+imageSpec:
+  config:
+    entrypoint: ["/bin/sh"]

--- a/test/e2e/testdata/templates/werf-image-clean/module/module.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/module/module.yaml
@@ -1,0 +1,2 @@
+name: e2e-werf-image-clean
+namespace: e2e-werf-image-clean

--- a/test/e2e/testdata/templates/werf-image-clean/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/werf-image-clean/module/openapi/values.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/werf-image-clean/module/werf.yaml
+++ b/test/e2e/testdata/templates/werf-image-clean/module/werf.yaml
@@ -1,0 +1,4 @@
+project: e2e-werf-image-clean
+configVersion: 1
+---
+{{ tpl (.Files.Get ".werf/images.yaml") $ }}

--- a/test/e2e/testdata/templates/werf-multiple-images/expected.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/expected.yaml
@@ -1,0 +1,16 @@
+description: >
+  With two images, only the one whose werf.inc.yaml renders to an image name
+  with underscores is flagged. The rule scans each images/<name>/werf.inc.yaml
+  independently, so exactly one werf finding is produced, pointing at the
+  offending file.
+module: module
+expect:
+  - linter: templates
+    rule: werf
+    level: error
+    textContains: "images/broken/werf.inc.yaml"
+    count: 1
+expectAbsent:
+  - linter: templates
+    rule: werf
+    textContains: "images/good/werf.inc.yaml"

--- a/test/e2e/testdata/templates/werf-multiple-images/module/.werf/images.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/.werf/images.yaml
@@ -1,0 +1,26 @@
+{{- $Root := . }}
+
+{{- $ImagesBuildFiles := .Files.Glob "images/*/{Dockerfile,werf.inc.yaml}" }}
+
+{{- range $path, $content := $ImagesBuildFiles  }}
+  {{- $imageName := base (dir $path) }}
+  {{- $ctx := dict }}
+  {{- $_ := set $ctx "Root" $ }}
+  {{- $_ := set $ctx "ImageName" $imageName }}
+  {{- $_ := set $ctx "ImagePath" (printf "/images/%s" $imageName) }}
+  {{- $_ := set $ctx "ModuleNamePrefix" "" }}
+  {{- $_ := set $ctx "ModuleDir" "/" }}
+  {{- $_ := set $ctx "GOPROXY" (env "GOPROXY" "https://proxy.golang.org,direct") }}
+---
+  {{- /* For Dockerfile just render it from the folder. */ -}}
+  {{- if not (regexMatch "/werf.inc.yaml$" $path) }}
+image: images/{{ $ctx.ImageName }}
+context: images/{{ $ctx.ImageName }}
+dockerfile: Dockerfile
+
+  {{- /* For werf.inc.yaml render content by providing the ImageName param. */ -}}
+  {{- else }}
+{{ tpl $content $ctx }}
+
+  {{- end }}
+{{- end }}

--- a/test/e2e/testdata/templates/werf-multiple-images/module/images/broken/werf.inc.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/images/broken/werf.inc.yaml
@@ -1,0 +1,7 @@
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+final: false
+fromImage: nginx:latest
+---
+image: {{ .ModuleNamePrefix }}_{{ .ImageName }}_
+fromImage: scratch

--- a/test/e2e/testdata/templates/werf-multiple-images/module/images/good/werf.inc.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/images/good/werf.inc.yaml
@@ -1,0 +1,7 @@
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+final: false
+fromImage: nginx:latest
+---
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}
+fromImage: scratch

--- a/test/e2e/testdata/templates/werf-multiple-images/module/module.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/module.yaml
@@ -1,0 +1,2 @@
+name: e2e-werf-multiple-images
+namespace: e2e-werf-multiple-images

--- a/test/e2e/testdata/templates/werf-multiple-images/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/werf-multiple-images/module/openapi/values.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/werf-multiple-images/module/werf.yaml
+++ b/test/e2e/testdata/templates/werf-multiple-images/module/werf.yaml
@@ -1,0 +1,4 @@
+project: e2e-werf-multiple-images
+configVersion: 1
+---
+{{ tpl (.Files.Get ".werf/images.yaml") $ }}

--- a/test/e2e/testdata/templates/werf-underscore-outside-images/expected.yaml
+++ b/test/e2e/testdata/templates/werf-underscore-outside-images/expected.yaml
@@ -1,0 +1,9 @@
+description: >
+  An image name with underscores declared directly in the root werf.yaml (not
+  under images/) must NOT be flagged: the werf rule scans only the module's
+  images/*/werf.inc.yaml files. This guards against the previous false positives
+  from aggregated stages/base images.
+module: module
+expectAbsent:
+  - linter: templates
+    rule: werf

--- a/test/e2e/testdata/templates/werf-underscore-outside-images/module/module.yaml
+++ b/test/e2e/testdata/templates/werf-underscore-outside-images/module/module.yaml
@@ -1,0 +1,2 @@
+name: e2e-werf-underscore-outside-images
+namespace: e2e-werf-underscore-outside-images

--- a/test/e2e/testdata/templates/werf-underscore-outside-images/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/templates/werf-underscore-outside-images/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/werf-underscore-outside-images/module/openapi/values.yaml
+++ b/test/e2e/testdata/templates/werf-underscore-outside-images/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/werf-underscore-outside-images/module/werf.yaml
+++ b/test/e2e/testdata/templates/werf-underscore-outside-images/module/werf.yaml
@@ -1,0 +1,8 @@
+project: e2e-werf-underscore-outside-images
+configVersion: 1
+---
+# This image name has an underscore but is declared directly in the root
+# werf.yaml (not under images/). The werf rule scans only images/*/werf.inc.yaml,
+# so it must NOT be flagged here.
+image: bad_image/app
+fromImage: scratch


### PR DESCRIPTION
## Summary

The `werf` linter rule that detects underscores in image names was previously reading the module's root `werf.yaml` directly. This was fragile because:

- The root `werf.yaml` aggregates all modules and stages, making it hard to attribute errors to a specific module file.
- It relied on `GetWerfFile()` returning pre-fetched content rather than scanning the actual per-image sources.

## Changes

- **`internal/werf/images.go`** (new): introduces `GetModuleImagesWerfFiles`, which scans `images/*/werf.inc.yaml` files within a module directory, renders each one the same way `.werf/images.yaml` would (applying Go template functions and per-image context), and returns the results. Files that cannot be rendered in isolation (e.g. depend on pipeline-only build context) are skipped rather than treated as errors.

- **`pkg/linters/templates/rules/werf.go`**: rewires `ValidateWerfTemplates` to use `GetModuleImagesWerfFiles` instead of `GetWerfFile`. Error paths now include the relative `images/<name>/werf.inc.yaml` path for clearer diagnostics. The `GetWerfFile` mock dependency is removed.

- **`pkg/linters/templates/rules/werf_test.go`**: tests rewritten to create real `images/<name>/werf.inc.yaml` files on disk and verify that error messages include the correct relative file path.

- **`pkg/linters/templates/README.md`**: documentation updated to reflect the new scanning target.

- **`test/e2e/testdata/templates/`**: three new e2e fixture modules added (`werf-image-clean`, `werf-multiple-images`, `werf-underscore-outside-images`) covering clean, multi-image, and underscore-outside-`images/` scenarios.

## Why

Scoping the check to `images/*/werf.inc.yaml` matches how modules actually declare their images, produces file-precise error messages, and avoids false positives from base images or stages defined outside the module boundary.