### PR TITLE
[dmt] fix(helm) prevent nil pointer panic on Chart.lock with external dependencies

### DIFF
--- a/internal/helm/render.go
+++ b/internal/helm/render.go
@@ -27,6 +27,15 @@ import (
 	"github.com/werf/nelm/pkg/helm/pkg/werf/helmopts"
 )
 
+func init() {
+	// nelm's chart loader prints "Cannot automatically download chart
+	// dependencies without Chart.lock or requirements.lock." straight to stdout
+	// when a module's Chart.yaml declares dependencies but ships no lock file.
+	// dmt only lints rendered templates and never resolves remote dependencies,
+	// so this warning is noise that pollutes scan output. Suppress it.
+	loader.NoChartLockWarning = ""
+}
+
 type Renderer struct {
 	Name      string
 	Namespace string
@@ -57,6 +66,10 @@ func (r Renderer) RenderChartFromDir(chartDir string, values map[string]any) (ma
 			DefaultChartAPIVersion: "v2",
 			DefaultChartName:       r.Name,
 			DefaultChartVersion:    "0.2.0",
+			// Nelm's chart loader calls DepDownloader.SetChartPath / Build when
+			// the chart has a Chart.lock with external (non-file://) dependencies.
+			// Leave it nil and the loader panics with a nil pointer dereference.
+			DepDownloader: &lintDepDownloader{},
 		},
 	}
 
@@ -97,4 +110,25 @@ func (r Renderer) applyTemplateOverrides(chrt *chart.Chart) {
 	for _, dep := range chrt.Dependencies() {
 		r.applyTemplateOverrides(dep)
 	}
+}
+
+// lintDepDownloader is a minimal implementation of helmopts.DepDownloader used
+// during lint. Nelm's loader requires a non-nil DepDownloader when a chart has
+// a Chart.lock with external dependencies, but dmt does not fetch charts from
+// remote repositories. Returning nil lets lint continue without the external
+// dependencies instead of panicking on a nil pointer dereference.
+type lintDepDownloader struct{}
+
+func (d *lintDepDownloader) SetChartPath(path string) {}
+
+func (d *lintDepDownloader) Build(opts helmopts.HelmOptions) error {
+	return nil
+}
+
+func (d *lintDepDownloader) Update(opts helmopts.HelmOptions) error {
+	return nil
+}
+
+func (d *lintDepDownloader) UpdateRepositories() error {
+	return nil
 }

--- a/internal/helm/render_test.go
+++ b/internal/helm/render_test.go
@@ -77,4 +77,30 @@ func TestRenderChartFromDir(t *testing.T) {
 		assert.Contains(t, manifest, "name: test-configmap")
 		assert.Contains(t, manifest, "key: value")
 	})
+
+	t.Run("should not panic on chart with external dependencies", func(t *testing.T) {
+		renderer := Renderer{
+			Name:      "test-chart",
+			Namespace: "default",
+		}
+
+		dir := writeChart(t, map[string]string{
+			"Chart.yaml": "apiVersion: v2\nname: test-chart\nversion: 0.1.0\ndependencies:\n  - name: external-dep\n    version: 1.0.0\n    repository: https://example.com/charts\n",
+			"Chart.lock": "apiVersion: v2\ndependencies:\n  - name: external-dep\n    repository: https://example.com/charts\n    version: 1.0.0\ndigest: sha256:0000000000000000000000000000000000000000000000000000000000000000\ngenerated: \"2025-01-01T00:00:00.000000000Z\"\n",
+			"templates/test.yaml": "apiVersion: v1\n" +
+				"kind: ConfigMap\n" +
+				"metadata:\n" +
+				"  name: test-configmap\n" +
+				"data:\n" +
+				"  key: {{ .Values.key }}\n",
+		})
+
+		// Before the fix this panicked with a nil pointer dereference because
+		// RenderChartFromDir did not set ChartLoadOpts.DepDownloader.
+		output, err := renderer.RenderChartFromDir(dir, map[string]any{
+			"Values": map[string]any{"key": "value"},
+		})
+		require.NoError(t, err)
+		require.Contains(t, output, "test-chart/templates/test.yaml")
+	})
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `internal/helm.RenderChartFromDir` in dmt v0.1.84 passes `helmopts.HelmOptions` to nelm chart loader but leaves `ChartLoadOpts.DepDownloader` as `nil`.
- **Trigger**: the module has a `Chart.lock` with external (non-`file://`) chart dependencies that are not already vendored in `charts/`.
- **Crash site**: `github.com/werf/nelm@v1.24.3/pkg/helm/pkg/chart/loader/load_dependencies.go:428` — `buildChartDependenciesInDir` calls `opts.ChartLoadOpts.DepDownloader.SetChartPath(targetDir)` on the nil interface, causing `panic: runtime error: invalid memory address or nil pointer dereference`.
- **Fix**: added a minimal no-op `lintDepDownloader` implementation of `helmopts.DepDownloader` in `internal/helm/render.go`. It prevents the panic by satisfying nelm's loader interface and silently skips downloading remote chart dependencies during lint.
- **Warning suppression**: nelm prints `Cannot automatically download chart dependencies without Chart.lock or requirements.lock.` to stdout when a chart declares dependencies without a lock file. Since dmt only lints rendered templates and never resolves remote dependencies, this output is noise; `loader.NoChartLockWarning` is set to an empty string once at package init time.
- **Test coverage**: regression test in `internal/helm/render_test.go` creates a chart with `Chart.yaml` + `Chart.lock` referencing an external dependency and asserts that `RenderChartFromDir` renders successfully without panicking.
- **Validation**: `go test ./...`, `go test -race ./...`, `go vet ./internal/helm/...`, `golangci-lint run ./internal/helm/...` all pass.
- **No go.mod changes**: the fix avoids importing nelm's full `downloader.Manager`, so no extra transitive dependencies (docker/containerd/etc.) are pulled in.

## Context

Starting with v0.1.83 dmt uses the nelm renderer to load and render charts from disk. Nelm's loader expects a dependency downloader whenever it sees unresolved external dependencies in `Chart.lock`. Because dmt never configured one, any module with such a lock file crashed the linter process. Deckhouse modules normally do not have external chart dependencies, so the most likely cause is a stale or accidentally committed `Chart.lock`.

## Example

**Before fix**:
```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/werf/nelm/pkg/helm/pkg/chart/loader.load_dependencies.go:428
```

**After fix**:
chart renders successfully; external dependencies are ignored during lint.
