### PR TITLE
[dmt] fix directory exclude rule prefix matching

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -428,7 +428,7 @@ func mapNoCyrillicExclusions(linterSettings *pkg.LintersSettings, configSettings
 	configExcludes := &configSettings.NoCyrillic.NoCyrillicExcludeRules
 
 	excludes.Files = pkg.StringRuleExcludeList(configExcludes.Files)
-	excludes.Directories = pkg.PrefixRuleExcludeList(configExcludes.Directories)
+	excludes.Directories = pkg.DirectoryRuleExcludeList(configExcludes.Directories)
 }
 
 // mapOpenAPIExclusions maps OpenAPI linter exclusion rules
@@ -453,7 +453,7 @@ func mapTemplatesExclusionsAndSettings(linterSettings *pkg.LintersSettings, conf
 	excludes.KubeRBACProxy = pkg.StringRuleExcludeList(configExcludes.KubeRBACProxy)
 	excludes.Ingress = configExcludes.Ingress.Get()
 	excludes.EnabledModules.Files = pkg.StringRuleExcludeList(configExcludes.EnabledModules.Files)
-	excludes.EnabledModules.Directories = pkg.PrefixRuleExcludeList(configExcludes.EnabledModules.Directories)
+	excludes.EnabledModules.Directories = pkg.DirectoryRuleExcludeList(configExcludes.EnabledModules.Directories)
 
 	// Additional settings
 	linterSettings.Templates.PrometheusRuleSettings.Disable = configSettings.Templates.PrometheusRules.Disable
@@ -481,7 +481,7 @@ func mapModuleExclusionsAndSettings(linterSettings *pkg.LintersSettings, configS
 	excludes := &linterSettings.Module.ExcludeRules
 	configExcludes := &configSettings.Module.ExcludeRules
 	excludes.License.Files = pkg.StringRuleExcludeList(configExcludes.License.Files)
-	excludes.License.Directories = pkg.PrefixRuleExcludeList(configExcludes.License.Directories)
+	excludes.License.Directories = pkg.DirectoryRuleExcludeList(configExcludes.License.Directories)
 	excludes.OSS.VersionNotSemver = configExcludes.OSS.VersionNotSemver.Get()
 
 	// Additional settings

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -100,7 +100,7 @@ type NoCyrillicLinterRules struct {
 
 type NoCyrillicExcludeRules struct {
 	Files       StringRuleExcludeList
-	Directories PrefixRuleExcludeList
+	Directories DirectoryRuleExcludeList
 }
 
 type OpenAPILinterConfig struct {
@@ -161,7 +161,7 @@ type TemplatesExcludeRules struct {
 
 type EnabledModulesExcludeRule struct {
 	Files       StringRuleExcludeList
-	Directories PrefixRuleExcludeList
+	Directories DirectoryRuleExcludeList
 }
 
 type ServicePortExcludeList []ServicePortExclude
@@ -255,8 +255,8 @@ type OSSExcludeRules struct {
 }
 
 type LicenseExcludeRule struct {
-	Files       StringRuleExcludeList `mapstructure:"files"`
-	Directories PrefixRuleExcludeList `mapstructure:"directories"`
+	Files       StringRuleExcludeList   `mapstructure:"files"`
+	Directories DirectoryRuleExcludeList `mapstructure:"directories"`
 }
 
 type ContainerLinterConfig struct {
@@ -300,6 +300,18 @@ func (l PrefixRuleExcludeList) Get() []PrefixRuleExclude {
 
 	for idx := range l {
 		result = append(result, PrefixRuleExclude(l[idx]))
+	}
+
+	return result
+}
+
+type DirectoryRuleExcludeList []string
+
+func (l DirectoryRuleExcludeList) Get() []DirectoryRuleExclude {
+	result := make([]DirectoryRuleExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, DirectoryRuleExclude(l[idx]))
 	}
 
 	return result

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -255,7 +255,7 @@ type OSSExcludeRules struct {
 }
 
 type LicenseExcludeRule struct {
-	Files       StringRuleExcludeList   `mapstructure:"files"`
+	Files       StringRuleExcludeList    `mapstructure:"files"`
 	Directories DirectoryRuleExcludeList `mapstructure:"directories"`
 }
 

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -167,8 +167,8 @@ type WerfRuleSettings struct {
 }
 
 type LicenseExcludeRule struct {
-	Files       StringRuleExcludeList `mapstructure:"files"`
-	Directories PrefixRuleExcludeList `mapstructure:"directories"`
+	Files       StringRuleExcludeList    `mapstructure:"files"`
+	Directories DirectoryRuleExcludeList `mapstructure:"directories"`
 }
 
 type NoCyrillicSettings struct {
@@ -178,8 +178,8 @@ type NoCyrillicSettings struct {
 }
 
 type NoCyrillicExcludeRules struct {
-	Files       StringRuleExcludeList `mapstructure:"files"`
-	Directories PrefixRuleExcludeList `mapstructure:"directories"`
+	Files       StringRuleExcludeList    `mapstructure:"files"`
+	Directories DirectoryRuleExcludeList `mapstructure:"directories"`
 }
 
 type OpenAPISettings struct {
@@ -239,8 +239,8 @@ type TemplatesExcludeRules struct {
 }
 
 type EnabledModulesExcludeRule struct {
-	Files       StringRuleExcludeList `mapstructure:"files"`
-	Directories PrefixRuleExcludeList `mapstructure:"directories"`
+	Files       StringRuleExcludeList    `mapstructure:"files"`
+	Directories DirectoryRuleExcludeList `mapstructure:"directories"`
 }
 
 type GrafanaDashboardsExcludeList struct {
@@ -282,6 +282,18 @@ func (l PrefixRuleExcludeList) Get() []pkg.PrefixRuleExclude {
 
 	for idx := range l {
 		result = append(result, pkg.PrefixRuleExclude(l[idx]))
+	}
+
+	return result
+}
+
+type DirectoryRuleExcludeList []string
+
+func (l DirectoryRuleExcludeList) Get() []pkg.DirectoryRuleExclude {
+	result := make([]pkg.DirectoryRuleExclude, 0, len(l))
+
+	for idx := range l {
+		result = append(result, pkg.DirectoryRuleExclude(l[idx]))
 	}
 
 	return result

--- a/pkg/linters/module/rules/license.go
+++ b/pkg/linters/module/rules/license.go
@@ -45,14 +45,14 @@ var fileToSkipRe = regexp.MustCompile(
 )
 
 func NewLicenseRule(excludeFilesRules []pkg.StringRuleExclude,
-	excludeDirectoryRules []pkg.PrefixRuleExclude) *LicenseRule {
+	excludeDirectoryRules []pkg.DirectoryRuleExclude) *LicenseRule {
 	return &LicenseRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: LicenseRuleName,
 		},
 		PathRule: pkg.PathRule{
-			ExcludeStringRules: excludeFilesRules,
-			ExcludePrefixRules: excludeDirectoryRules,
+			ExcludeStringRules:    excludeFilesRules,
+			ExcludeDirectoryRules: excludeDirectoryRules,
 		},
 	}
 }

--- a/pkg/linters/no-cyrillic/rules/files.go
+++ b/pkg/linters/no-cyrillic/rules/files.go
@@ -37,14 +37,14 @@ var (
 )
 
 func NewFilesRule(excludeFileRules []pkg.StringRuleExclude,
-	excludeDirectoryRules []pkg.PrefixRuleExclude) *FilesRule {
+	excludeDirectoryRules []pkg.DirectoryRuleExclude) *FilesRule {
 	return &FilesRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: FilesRuleName,
 		},
 		PathRule: pkg.PathRule{
-			ExcludeStringRules: excludeFileRules,
-			ExcludePrefixRules: excludeDirectoryRules,
+			ExcludeStringRules:    excludeFileRules,
+			ExcludeDirectoryRules: excludeDirectoryRules,
 		},
 		skipDocRe:  regexp.MustCompile(skipDocRe),
 		skipI18NRe: regexp.MustCompile(skipSelfRe),

--- a/pkg/linters/no-cyrillic/rules/files_test.go
+++ b/pkg/linters/no-cyrillic/rules/files_test.go
@@ -174,8 +174,8 @@ func TestFilesRule_CheckFile_ExcludeDirectories(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	excludeDirs := []pkg.PrefixRuleExclude{
-		pkg.PrefixRuleExclude("vendor"),
+	excludeDirs := []pkg.DirectoryRuleExclude{
+		pkg.DirectoryRuleExclude("vendor"),
 	}
 	rule := NewFilesRule(nil, excludeDirs)
 	errorList := &errors.LintRuleErrorsList{}
@@ -319,5 +319,112 @@ func TestFilesRule_CheckFile_WithExcludeRules(t *testing.T) {
 	errs := errorList.GetErrors()
 	if len(errs) > 0 {
 		t.Errorf("Expected file to be excluded, but got %d errors", len(errs))
+	}
+}
+
+// TestFilesRule_CheckFile_DirectoryExcludeNotPrefix verified that directory excludes
+// do not incorrectly match similarly-named sibling directories via prefix matching.
+func TestFilesRule_CheckFile_DirectoryExcludeNotPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		relPath     string
+		wantSkipped bool
+	}{
+		{
+			name:        "exact dir match",
+			relPath:     "images/stronghold/config.yaml",
+			wantSkipped: true,
+		},
+		{
+			name:        "subdirectory match",
+			relPath:     "images/stronghold/subdir/config.yaml",
+			wantSkipped: true,
+		},
+		{
+			name:        "sibling dir with dash suffix not matched",
+			relPath:     "images/stronghold-automatic/config.yaml",
+			wantSkipped: false,
+		},
+		{
+			name:        "sibling dir with suffix not matched",
+			relPath:     "images/stronghold-for-dmt-abuse/config.yaml",
+			wantSkipped: false,
+		},
+		{
+			name:        "parent dir not matched",
+			relPath:     "images/config.yaml",
+			wantSkipped: false,
+		},
+		{
+			name:        "unrelated dir not matched",
+			relPath:     "hooks/config.yaml",
+			wantSkipped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := minimock.NewController(t)
+			mockModule := mocks.NewModuleMock(mc)
+
+			tempDir := t.TempDir()
+			mockModule.GetPathMock.Return(tempDir)
+
+			testFile := filepath.Join(tempDir, filepath.FromSlash(tt.relPath))
+			if err := os.MkdirAll(filepath.Dir(testFile), 0700); err != nil {
+				t.Fatalf("failed to create dir: %v", err)
+			}
+
+			if err := os.WriteFile(testFile, []byte(cyrillicYAML), 0600); err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			excludeDirs := []pkg.DirectoryRuleExclude{
+				pkg.DirectoryRuleExclude("images/stronghold"),
+			}
+			rule := NewFilesRule(nil, excludeDirs)
+			errorList := &errors.LintRuleErrorsList{}
+
+			rule.CheckFile(mockModule, testFile, errorList)
+
+			errs := errorList.GetErrors()
+			if tt.wantSkipped && len(errs) > 0 {
+				t.Errorf("expected %q to be skipped, but got %d error(s)", tt.relPath, len(errs))
+			}
+			if !tt.wantSkipped && len(errs) == 0 {
+				t.Errorf("expected %q to be reported, but got no errors", tt.relPath)
+			}
+		})
+	}
+}
+
+// TestFilesRule_CheckFile_directory_exclude_trailing_slash verifies that
+// a trailing slash in the exclude directory name is handled correctly
+// (same behavior as without trailing slash).
+func TestFilesRule_CheckFile_directory_exclude_trailing_slash(t *testing.T) {
+	mc := minimock.NewController(t)
+	mockModule := mocks.NewModuleMock(mc)
+
+	tempDir := t.TempDir()
+	mockModule.GetPathMock.Return(tempDir)
+
+	testFile := filepath.Join(tempDir, "vendor", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(testFile), 0700); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(testFile, []byte(cyrillicYAML), 0600); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	excludeDirs := []pkg.DirectoryRuleExclude{
+		pkg.DirectoryRuleExclude("vendor/"),
+	}
+	rule := NewFilesRule(nil, excludeDirs)
+	errorList := &errors.LintRuleErrorsList{}
+
+	rule.CheckFile(mockModule, testFile, errorList)
+
+	if errs := errorList.GetErrors(); len(errs) > 0 {
+		t.Errorf("expected file under excluded directory (with trailing slash) to be skipped, got %d errors", len(errs))
 	}
 }

--- a/pkg/linters/no-cyrillic/rules/files_test.go
+++ b/pkg/linters/no-cyrillic/rules/files_test.go
@@ -391,6 +391,7 @@ func TestFilesRule_CheckFile_DirectoryExcludeNotPrefix(t *testing.T) {
 			if tt.wantSkipped && len(errs) > 0 {
 				t.Errorf("expected %q to be skipped, but got %d error(s)", tt.relPath, len(errs))
 			}
+
 			if !tt.wantSkipped && len(errs) == 0 {
 				t.Errorf("expected %q to be reported, but got no errors", tt.relPath)
 			}
@@ -412,6 +413,7 @@ func TestFilesRule_CheckFile_directory_exclude_trailing_slash(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(testFile), 0700); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
+
 	if err := os.WriteFile(testFile, []byte(cyrillicYAML), 0600); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}

--- a/pkg/linters/templates/rules/enabled_modules.go
+++ b/pkg/linters/templates/rules/enabled_modules.go
@@ -39,14 +39,14 @@ type EnabledModulesRule struct {
 }
 
 func NewEnabledModulesRule(excludeFileRules []pkg.StringRuleExclude,
-	excludeDirectoryRules []pkg.PrefixRuleExclude) *EnabledModulesRule {
+	excludeDirectoryRules []pkg.DirectoryRuleExclude) *EnabledModulesRule {
 	return &EnabledModulesRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: EnabledModulesRuleName,
 		},
 		PathRule: pkg.PathRule{
-			ExcludeStringRules: excludeFileRules,
-			ExcludePrefixRules: excludeDirectoryRules,
+			ExcludeStringRules:    excludeFileRules,
+			ExcludeDirectoryRules: excludeDirectoryRules,
 		},
 	}
 }

--- a/pkg/rule.go
+++ b/pkg/rule.go
@@ -68,6 +68,20 @@ func (r *PrefixRule) Enabled(str string) bool {
 	return true
 }
 
+type DirectoryRule struct {
+	ExcludeRules []DirectoryRuleExclude
+}
+
+func (r *DirectoryRule) Enabled(str string) bool {
+	for _, rule := range r.ExcludeRules {
+		if !rule.Enabled(str) {
+			return false
+		}
+	}
+
+	return true
+}
+
 type KindRule struct {
 	ExcludeRules []KindRuleExclude
 }
@@ -106,6 +120,16 @@ type PrefixRuleExclude string
 
 func (e PrefixRuleExclude) Enabled(str string) bool {
 	return !strings.HasPrefix(str, string(e))
+}
+
+type DirectoryRuleExclude string
+
+func (e DirectoryRuleExclude) Enabled(str string) bool {
+	dir := strings.TrimSuffix(string(e), "/")
+	if str == dir {
+		return false
+	}
+	return !strings.HasPrefix(str, dir+"/")
 }
 
 type ServicePortRule struct {
@@ -167,8 +191,9 @@ func (e *ContainerRuleExclude) Enabled(object storage.StoreObject, container *co
 }
 
 type PathRule struct {
-	ExcludeStringRules []StringRuleExclude
-	ExcludePrefixRules []PrefixRuleExclude
+	ExcludeStringRules    []StringRuleExclude
+	ExcludePrefixRules    []PrefixRuleExclude
+	ExcludeDirectoryRules []DirectoryRuleExclude
 }
 
 func (r *PathRule) Enabled(name string) bool {
@@ -179,6 +204,12 @@ func (r *PathRule) Enabled(name string) bool {
 	}
 
 	for _, rule := range r.ExcludePrefixRules {
+		if !rule.Enabled(name) {
+			return false
+		}
+	}
+
+	for _, rule := range r.ExcludeDirectoryRules {
 		if !rule.Enabled(name) {
 			return false
 		}

--- a/pkg/rule.go
+++ b/pkg/rule.go
@@ -129,6 +129,7 @@ func (e DirectoryRuleExclude) Enabled(str string) bool {
 	if str == dir {
 		return false
 	}
+
 	return !strings.HasPrefix(str, dir+"/")
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: `directories` exclude field in `no-cyrillic`, `license`, and `enabled-modules` linters used `PrefixRuleExcludeList` which does plain string prefix matching via `strings.HasPrefix`. This caused `"images/stronghold"` to incorrectly match `"images/stronghold-automatic"` and `"images/stronghold-for-dmt-abuse"` — any path starting with the same substring was excluded.
- **Fix**: Introduced `DirectoryRuleExclude` type that enforces directory-boundary semantics: a path is excluded only if it either **equals** the directory name or **starts with** `dirname/`. This ensures sibling directories with dash/hyphen suffixes are not incorrectly excluded.
- **Type separation**: Kept `PrefixRuleExcludeList` unchanged for genuine prefix-matching use cases (`SkipImageFilePathPrefix`, `SkipDistrolessFilePathPrefix`). Added new `DirectoryRuleExcludeList` alongside it, used exclusively for `directories` fields.
- **Updated constructors**: `NewFilesRule`, `NewEnabledModulesRule`, `NewLicenseRule` now accept `[]pkg.DirectoryRuleExclude` and assign to `PathRule.ExcludeDirectoryRules`.
- **Trailing slash tolerance**: `DirectoryRuleExclude.Enabled()` trims trailing slashes automatically — both `"vendor"` and `"vendor/"` behave identically.

## Context

Config fields named `directories` should match **directories**, not arbitrary string prefixes. A user excluding `"images/stronghold"` expects only files under `images/stronghold/` to be skipped, not files under `images/stronghold-automatic/` — the latter is a completely different directory.

## Migration

**Breaking change** for users who relied on the prefix-match behavior to exclude multiple similarly-named directories with one entry. That was incorrect behavior (bug), not a documented feature. Users should list each directory separately.

## Example

**Before (buggy)**:
```yaml
no-cyrillic:
  exclude-rules:
    directories:
      - "images/stronghold"        # matches images/stronghold, images/stronghold-automatic, images/stronghold-for-dmt-abuse
```

**After (fixed)**:
```yaml
no-cyrillic:
  exclude-rules:
    directories:
      - "images/stronghold"        # only matches images/stronghold/ and its subdirectories
      - "images/stronghold-automatic"
      - "images/stronghold-for-dmt-abuse"
```

## Tests

- **Regression test**: `TestFilesRule_CheckFile_DirectoryExcludeNotPrefix` — 6 cases verifying exact dir match, subdirectory match, sibling dirs with suffix are NOT matched, parent dir is NOT matched, unrelated dir is NOT matched.
- **Trailing slash test**: `TestFilesRule_CheckFile_directory_exclude_trailing_slash` — verifies `"vendor/"` works identically to `"vendor"`.
- All existing tests pass unchanged.