### PR TITLE
[dmt] add rendered template feature

### DIFF
--- a/cmd/dmt/root.go
+++ b/cmd/dmt/root.go
@@ -34,6 +34,7 @@ import (
 	"github.com/deckhouse/dmt/internal/bootstrap"
 	"github.com/deckhouse/dmt/internal/flags"
 	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/internal/render"
 	"github.com/deckhouse/dmt/internal/test"
 	"github.com/deckhouse/dmt/internal/version"
 	"github.com/deckhouse/dmt/pkg/config"
@@ -199,9 +200,40 @@ committed 'expected.yaml' snapshot. Use --update to (re)generate snapshots.`,
 	testCmd.AddCommand(conversionsCmd)
 	testCmd.AddCommand(templatesCmd)
 
+	var renderOutput string
+
+	renderCmd := &cobra.Command{
+		Use:   "render [module-path]",
+		Short: "Render Deckhouse module templates",
+		Long: `Finds all modules under the given path (including subdirectories) and renders
+each module's templates from its 'templates' directory using values generated
+from the module's openapi schemas ('openapi/config-values.yaml' and
+'openapi/values.yaml', if present).
+
+By default the output is written into a 'rendered' directory at each module
+root. When --output is set, the output is instead written into
+'<output>/rendered/<module-name>/<edition>/', where the module name is taken
+from the module's 'module.yaml' and editions follow the
+'openapi/values_<edition>.yaml' convention (with 'default' for
+'openapi/values.yaml').`,
+		Args:         cobra.RangeArgs(0, 1),
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			var dir = "."
+			if len(args) > 0 {
+				dir = args[0]
+			}
+
+			return render.Render(dir, renderOutput)
+		},
+	}
+	renderCmd.Flags().StringVarP(&renderOutput, "output", "o", "",
+		"directory to write the rendered output into (created if absent; a 'rendered' subdirectory is created inside it)")
+
 	rootCmd.AddCommand(lintCmd)
 	rootCmd.AddCommand(bootstrapCmd)
 	rootCmd.AddCommand(testCmd)
+	rootCmd.AddCommand(renderCmd)
 	rootCmd.Flags().AddFlagSet(flags.InitDefaultFlagSet())
 
 	err := rootCmd.Execute()

--- a/internal/module/openapi.go
+++ b/internal/module/openapi.go
@@ -104,11 +104,18 @@ func helmFormatModuleImages(m *Module, rawValues map[string]any) (chartutil.Valu
 }
 
 func ComposeValuesFromSchemas(m *Module, globalSchema *spec.Schema) (chartutil.Values, error) {
+	return ComposeValuesFromSchemasForValuesFile(m, globalSchema, "values.yaml")
+}
+
+// ComposeValuesFromSchemasForValuesFile is like ComposeValuesFromSchemas but
+// generates the module values from the given openapi values schema file name
+// (e.g. "values_ce.yaml") instead of the default "values.yaml".
+func ComposeValuesFromSchemasForValuesFile(m *Module, globalSchema *spec.Schema, valuesFile string) (chartutil.Values, error) {
 	if globalSchema == nil {
 		globalSchema = &spec.Schema{}
 	}
 
-	moduleValues, err := values.GetModuleValues(m.GetPath())
+	moduleValues, err := values.GetModuleValuesForValuesFile(m.GetPath(), valuesFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find openapi values schema for module %q: %w", m.GetName(), err)
 	}

--- a/internal/module/render_templates.go
+++ b/internal/module/render_templates.go
@@ -19,6 +19,8 @@ package module
 import (
 	"fmt"
 
+	"github.com/go-openapi/spec"
+
 	"github.com/deckhouse/dmt/internal/helm"
 )
 
@@ -60,6 +62,46 @@ func RenderModuleWithValues(modulePath string, userValues map[string]any) (map[s
 		Name:             mod.GetName(),
 		Namespace:        mod.GetNamespace(),
 		LintMode:         false,
+		HelmLibOverrides: helmLibOverrides(),
+	}
+
+	files, err := renderer.RenderChartFromDir(mod.GetPath(), renderValues)
+	if err != nil {
+		return nil, fmt.Errorf("render module: %w", err)
+	}
+
+	return files, nil
+}
+
+// RenderModule renders the module located at modulePath using values
+// auto-generated from the module's openapi schemas (the optional
+// 'openapi/config-values.yaml' and 'openapi/values.yaml' files) combined with
+// the supplied global schema, mirroring the value generation dmt uses while
+// linting. It returns the rendered manifests keyed by chart-relative source
+// file path.
+func RenderModule(modulePath string, globalSchema *spec.Schema) (map[string]string, error) {
+	return RenderModuleForValuesFile(modulePath, globalSchema, "values.yaml")
+}
+
+// RenderModuleForValuesFile is like RenderModule but generates the module values
+// from the given openapi values schema file name (e.g. "values_ce.yaml")
+// instead of the default "values.yaml". It is used to render edition-specific
+// variants of a module.
+func RenderModuleForValuesFile(modulePath string, globalSchema *spec.Schema, valuesFile string) (map[string]string, error) {
+	mod, err := newModuleFromPath(modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	renderValues, err := ComposeValuesFromSchemasForValuesFile(mod, globalSchema, valuesFile)
+	if err != nil {
+		return nil, fmt.Errorf("compose values: %w", err)
+	}
+
+	renderer := helm.Renderer{
+		Name:             mod.GetName(),
+		Namespace:        mod.GetNamespace(),
+		LintMode:         true,
 		HelmLibOverrides: helmLibOverrides(),
 	}
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package render implements the "render" command. It discovers every module
+// under a directory and renders each module's templates into a 'rendered'
+// directory at the module root, using values generated from the module's
+// openapi schemas (the same way dmt generates values while linting).
+package render
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-openapi/spec"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/internal/moduleloader"
+	"github.com/deckhouse/dmt/internal/values"
+)
+
+const (
+	// RenderedDirName is the per-module directory that receives the rendered output.
+	RenderedDirName = "rendered"
+	// openAPIDirName is the per-module directory holding the values schemas.
+	openAPIDirName = "openapi"
+	// defaultValuesFile is the base openapi values schema file.
+	defaultValuesFile = "values.yaml"
+	// defaultEditionName is the directory name used for the base (non-edition)
+	// render when edition-specific values files are present.
+	defaultEditionName = "default"
+	// editionValuesPrefix / editionValuesSuffix bound the edition name in an
+	// edition-specific values schema file (e.g. "values_ce.yaml" -> "ce").
+	editionValuesPrefix = "values_"
+	editionValuesSuffix = ".yaml"
+)
+
+// Render discovers all modules under dir (including subdirectories) and renders
+// each module's templates.
+//
+// When outputDir is empty, every module is rendered into a 'rendered' directory
+// at its own root. When outputDir is set, all modules are rendered into a shared
+// '<outputDir>/rendered/<module-name>/<edition>/' tree instead; outputDir must
+// be an existing directory.
+func Render(dir, outputDir string) error {
+	expandedDir, err := fsutils.ExpandDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to expand directory: %w", err)
+	}
+
+	baseRenderedDir, err := prepareOutputDir(outputDir)
+	if err != nil {
+		return err
+	}
+
+	paths, err := moduleloader.GetModulePaths(expandedDir)
+	if err != nil {
+		return fmt.Errorf("failed to get module paths: %w", err)
+	}
+
+	if len(paths) == 0 {
+		fmt.Fprintf(os.Stderr, "⚠️ No modules found\n")
+		return nil
+	}
+
+	globalValues, err := values.GetGlobalValues(getRootDirectory(expandedDir))
+	if err != nil {
+		return fmt.Errorf("failed to get global values: %w", err)
+	}
+
+	var hasErrors bool
+
+	for _, modulePath := range paths {
+		moduleName := moduleName(modulePath)
+
+		log.Info("Rendering module", slog.String("module", moduleName), slog.String("path", modulePath))
+
+		var renderErr error
+		if baseRenderedDir != "" {
+			renderErr = renderModuleToOutput(modulePath, globalValues, moduleName, baseRenderedDir)
+		} else {
+			renderErr = renderModule(modulePath, globalValues)
+		}
+
+		if renderErr != nil {
+			log.Error("Failed to render module", slog.String("module", moduleName), log.Err(renderErr))
+
+			hasErrors = true
+
+			continue
+		}
+	}
+
+	if hasErrors {
+		return fmt.Errorf("failed to render some modules")
+	}
+
+	return nil
+}
+
+// prepareOutputDir validates the user-supplied output directory and returns the
+// path of the 'rendered' directory to create inside it. It returns an empty
+// string when outputDir is empty (per-module output mode).
+func prepareOutputDir(outputDir string) (string, error) {
+	if outputDir == "" {
+		return "", nil
+	}
+
+	expandedOut, err := fsutils.ExpandDir(outputDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand output directory: %w", err)
+	}
+
+	info, err := os.Stat(expandedOut)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat output directory %q: %w", expandedOut, err)
+		}
+		// Directory does not exist — create it.
+		if mkErr := os.MkdirAll(expandedOut, 0o755); mkErr != nil {
+			return "", fmt.Errorf("create output directory %q: %w", expandedOut, mkErr)
+		}
+	} else if !info.IsDir() {
+		return "", fmt.Errorf("output path %q is not a directory", expandedOut)
+	}
+
+	baseRenderedDir := filepath.Join(expandedOut, RenderedDirName)
+	if err := os.MkdirAll(baseRenderedDir, 0o755); err != nil {
+		return "", fmt.Errorf("create rendered directory: %w", err)
+	}
+
+	return baseRenderedDir, nil
+}
+
+// renderModule renders a single module into its 'rendered' directory, which is
+// recreated on every run.
+//
+// When the module ships edition-specific values schemas
+// ('openapi/values_<edition>.yaml'), the output is split per edition:
+//
+//	rendered/default        rendered from openapi/values.yaml
+//	rendered/<edition>       rendered from openapi/values_<edition>.yaml
+//
+// Otherwise the manifests are written directly under 'rendered'.
+func renderModule(modulePath string, globalSchema *spec.Schema) error {
+	editions, err := discoverEditions(modulePath)
+	if err != nil {
+		return err
+	}
+
+	outputDir := filepath.Join(modulePath, RenderedDirName)
+
+	if err := os.RemoveAll(outputDir); err != nil {
+		return fmt.Errorf("clean rendered directory: %w", err)
+	}
+
+	if len(editions) == 0 {
+		return renderEdition(modulePath, globalSchema, defaultValuesFile, outputDir)
+	}
+
+	if err := renderEdition(modulePath, globalSchema, defaultValuesFile, filepath.Join(outputDir, defaultEditionName)); err != nil {
+		return fmt.Errorf("edition %q: %w", defaultEditionName, err)
+	}
+
+	for edition, valuesFile := range editions {
+		if err := renderEdition(modulePath, globalSchema, valuesFile, filepath.Join(outputDir, edition)); err != nil {
+			return fmt.Errorf("edition %q: %w", edition, err)
+		}
+	}
+
+	return nil
+}
+
+// renderModuleToOutput renders a single module into the shared output tree at
+// '<baseRenderedDir>/<moduleName>/<edition>/'. The 'default' edition (from
+// openapi/values.yaml) is always rendered; any 'openapi/values_<edition>.yaml'
+// files add further editions. The module's subtree is recreated on every run.
+func renderModuleToOutput(modulePath string, globalSchema *spec.Schema, moduleName, baseRenderedDir string) error {
+	editions, err := discoverEditions(modulePath)
+	if err != nil {
+		return err
+	}
+
+	moduleOut := filepath.Join(baseRenderedDir, moduleName)
+
+	if err := os.RemoveAll(moduleOut); err != nil {
+		return fmt.Errorf("clean module output directory: %w", err)
+	}
+
+	if err := renderEdition(modulePath, globalSchema, defaultValuesFile, filepath.Join(moduleOut, defaultEditionName)); err != nil {
+		return fmt.Errorf("edition %q: %w", defaultEditionName, err)
+	}
+
+	for edition, valuesFile := range editions {
+		if err := renderEdition(modulePath, globalSchema, valuesFile, filepath.Join(moduleOut, edition)); err != nil {
+			return fmt.Errorf("edition %q: %w", edition, err)
+		}
+	}
+
+	return nil
+}
+
+// renderEdition renders the module using the given openapi values schema file
+// and writes the manifests into targetDir, preserving each manifest's
+// chart-relative path (e.g. 'templates/foo.yaml').
+func renderEdition(modulePath string, globalSchema *spec.Schema, valuesFile, targetDir string) error {
+	files, err := module.RenderModuleForValuesFile(modulePath, globalSchema, valuesFile)
+	if err != nil {
+		return err
+	}
+
+	for path, content := range files {
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+
+		relPath := stripChartName(path)
+
+		target := filepath.Join(targetDir, relPath)
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create directory for %q: %w", relPath, err)
+		}
+
+		if err := os.WriteFile(target, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write rendered file %q: %w", relPath, err)
+		}
+	}
+
+	return nil
+}
+
+// discoverEditions returns the edition-specific values schema files found in the
+// module's openapi directory, keyed by edition name (e.g. "ce" ->
+// "values_ce.yaml").
+func discoverEditions(modulePath string) (map[string]string, error) {
+	entries, err := os.ReadDir(filepath.Join(modulePath, openAPIDirName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("read openapi directory: %w", err)
+	}
+
+	editions := make(map[string]string)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasPrefix(name, editionValuesPrefix) || !strings.HasSuffix(name, editionValuesSuffix) {
+			continue
+		}
+
+		edition := strings.TrimSuffix(strings.TrimPrefix(name, editionValuesPrefix), editionValuesSuffix)
+		if edition == "" {
+			continue
+		}
+
+		editions[edition] = name
+	}
+
+	return editions, nil
+}
+
+// moduleName returns the module's name taken from its 'module.yaml' (falling
+// back to 'Chart.yaml' and finally to the directory name).
+func moduleName(modulePath string) string {
+	moduleYaml, err := module.ParseModuleConfigFile(modulePath)
+	if err != nil {
+		moduleYaml = nil
+	}
+
+	chartYaml, err := module.ParseChartFile(modulePath)
+	if err != nil {
+		chartYaml = nil
+	}
+
+	if name := module.GetModuleName(moduleYaml, chartYaml); name != "" {
+		return name
+	}
+
+	return filepath.Base(modulePath)
+}
+
+// stripChartName drops the leading chart-name component from a rendered manifest
+// path (e.g. "module/templates/foo.yaml" -> "templates/foo.yaml").
+func stripChartName(path string) string {
+	elements := strings.Split(path, "/")
+	if len(elements) > 1 {
+		return filepath.Join(elements[1:]...)
+	}
+
+	return path
+}
+
+// getRootDirectory walks up from dir looking for a deckhouse repository root
+// (one that ships global-hooks/openapi values). When found, those global values
+// are used; otherwise the embedded defaults are used.
+func getRootDirectory(dir string) string {
+	for {
+		if fsutils.IsDir(filepath.Join(dir, "global-hooks", "openapi")) &&
+			fsutils.IsDir(filepath.Join(dir, "modules")) &&
+			fsutils.IsFile(filepath.Join(dir, "global-hooks", "openapi", "config-values.yaml")) &&
+			fsutils.IsFile(filepath.Join(dir, "global-hooks", "openapi", "values.yaml")) {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if dir == parent || parent == "" {
+			break
+		}
+
+		dir = parent
+	}
+
+	return ""
+}

--- a/internal/values/values.go
+++ b/internal/values/values.go
@@ -22,27 +22,6 @@ const (
 	configValuesFileName = "config-values.yaml"
 )
 
-// readOpenAPIFiles reads config-values.yaml and values.yaml from the specified directory.
-// Mirrors the helper previously imported from github.com/flant/addon-operator/pkg/utils.
-//
-// Module schemas:
-//
-//	/modules/XXX-module-name/openapi/config-values.yaml
-//	/modules/XXX-module-name/openapi/values.yaml
-func readOpenAPIFiles(openAPIDir string) ([]byte, []byte, error) {
-	configValuesBytes, err := readOpenAPIFile(openAPIDir, configValuesFileName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	valuesBytes, err := readOpenAPIFile(openAPIDir, valuesFileName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return configValuesBytes, valuesBytes, nil
-}
-
 // readOpenAPIFile reads a single file from the openapi directory, returning nil
 // (and no error) when the directory or the file does not exist.
 func readOpenAPIFile(openAPIDir, fileName string) ([]byte, error) {

--- a/internal/values/values.go
+++ b/internal/values/values.go
@@ -30,39 +30,41 @@ const (
 //	/modules/XXX-module-name/openapi/config-values.yaml
 //	/modules/XXX-module-name/openapi/values.yaml
 func readOpenAPIFiles(openAPIDir string) ([]byte, []byte, error) {
-	if openAPIDir == "" {
-		return nil, nil, nil
+	configValuesBytes, err := readOpenAPIFile(openAPIDir, configValuesFileName)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	if _, err := os.Stat(openAPIDir); os.IsNotExist(err) {
-		return nil, nil, nil
-	}
-
-	var configValuesBytes []byte
-
-	configPath := filepath.Join(openAPIDir, configValuesFileName)
-	if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
-		var err error
-
-		configValuesBytes, err = os.ReadFile(configPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("read file %q: %w", configPath, err)
-		}
-	}
-
-	var valuesBytes []byte
-
-	valuesPath := filepath.Join(openAPIDir, valuesFileName)
-	if _, statErr := os.Stat(valuesPath); !os.IsNotExist(statErr) {
-		var err error
-
-		valuesBytes, err = os.ReadFile(valuesPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("read file %q: %w", valuesPath, err)
-		}
+	valuesBytes, err := readOpenAPIFile(openAPIDir, valuesFileName)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return configValuesBytes, valuesBytes, nil
+}
+
+// readOpenAPIFile reads a single file from the openapi directory, returning nil
+// (and no error) when the directory or the file does not exist.
+func readOpenAPIFile(openAPIDir, fileName string) ([]byte, error) {
+	if openAPIDir == "" {
+		return nil, nil
+	}
+
+	if _, err := os.Stat(openAPIDir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	path := filepath.Join(openAPIDir, fileName)
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", path, err)
+	}
+
+	return data, nil
 }
 
 type SchemaType string
@@ -181,9 +183,22 @@ func readConfigFiles(rootDir string) ([]byte, []byte, error) {
 }
 
 func GetModuleValues(modulePath string) (*spec.Schema, error) {
+	return GetModuleValuesForValuesFile(modulePath, valuesFileName)
+}
+
+// GetModuleValuesForValuesFile is like GetModuleValues but loads the module
+// values schema from the given file name inside the module's openapi directory
+// (e.g. "values_ce.yaml") instead of the default "values.yaml". The
+// "config-values.yaml" schema, when present, is always used as the base.
+func GetModuleValuesForValuesFile(modulePath, valuesFile string) (*spec.Schema, error) {
 	openAPIPath := filepath.Join(modulePath, "openapi")
 
-	configBytes, valuesBytes, err := readOpenAPIFiles(openAPIPath)
+	configBytes, err := readOpenAPIFile(openAPIPath, configValuesFileName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read openAPI schemas: %w", err)
+	}
+
+	valuesBytes, err := readOpenAPIFile(openAPIPath, valuesFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read openAPI schemas: %w", err)
 	}


### PR DESCRIPTION
Introduces a new top-level `dmt render [module-path]` command that discovers every Deckhouse module under a given directory and renders its Helm templates using values auto-generated from the module's OpenAPI schemas — the same value-generation path dmt uses during linting.

### What changed

**New `dmt render` command** (`cmd/dmt/root.go`)
- Accepts an optional positional argument for the module search root (defaults to `.`)
- `--output / -o` flag: when set, all rendered output lands in `<output>/rendered/<module-name>/<edition>/`; without the flag each module writes to its own `rendered/` directory

**New `internal/render` package** (`internal/render/render.go`)
- Discovers modules via `moduleloader.GetModulePaths`
- Auto-detects edition-specific values schemas (`openapi/values_<edition>.yaml`) and renders a separate `<edition>/` subtree for each, plus a `default/` subtree from `openapi/values.yaml`
- Walks up the directory tree to find a Deckhouse root and use its real global-hooks values; falls back to embedded defaults otherwise
- Skips empty manifests and preserves chart-relative paths in output

**Edition-aware value composition** (`internal/module/openapi.go`, `internal/module/render_templates.go`)
- `ComposeValuesFromSchemasForValuesFile` — like `ComposeValuesFromSchemas` but accepts an arbitrary openapi values filename
- `RenderModule` / `RenderModuleForValuesFile` — new helpers that produce rendered manifests keyed by chart-relative path; used by the render command and available to other callers

**Values refactor** (`internal/values/values.go`)
- Split the monolithic `readOpenAPIFiles` into a reusable single-file `readOpenAPIFile` helper (removes the now-unused wrapper)
- Added `GetModuleValuesForValuesFile` so callers can request any `values_*.yaml` variant without duplicating schema-loading logic

### Usage

```sh
# Render all modules in the current directory (output goes to <module>/rendered/)
dmt render

# Render a specific module directory
dmt render ./modules/my-module

# Collect all rendered output under /tmp/out/rendered/<module>/<edition>/
dmt render ./modules --output /tmp/out
```