### PR TITLE
[dmt] add exclusion support for priority-class rule

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -396,6 +396,7 @@ func mapContainerExclusions(linterSettings *pkg.LintersSettings, configSettings 
 
 	excludes.ControllerSecurityContext = configExcludes.ControllerSecurityContext.Get()
 	excludes.DNSPolicy = configExcludes.DNSPolicy.Get()
+	excludes.PriorityClass = configExcludes.PriorityClass.Get()
 	excludes.HostNetworkPorts = configExcludes.HostNetworkPorts.Get()
 	excludes.Ports = configExcludes.Ports.Get()
 	excludes.ReadOnlyRootFilesystem = configExcludes.ReadOnlyRootFilesystem.Get()

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -346,6 +346,7 @@ type ContainerLinterRules struct {
 type ContainerExcludeRules struct {
 	ControllerSecurityContext KindRuleExcludeList
 	DNSPolicy                 KindRuleExcludeList
+	PriorityClass             KindRuleExcludeList
 
 	HostNetworkPorts       ContainerRuleExcludeList
 	Ports                  ContainerRuleExcludeList

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -58,6 +58,7 @@ type ContainerSettings struct {
 type ContainerExcludeRules struct {
 	ControllerSecurityContext KindRuleExcludeList `mapstructure:"controller-security-context"`
 	DNSPolicy                 KindRuleExcludeList `mapstructure:"dns-policy"`
+	PriorityClass             KindRuleExcludeList `mapstructure:"priority-class"`
 
 	HostNetworkPorts       ContainerRuleExcludeList `mapstructure:"host-network-ports"`
 	Ports                  ContainerRuleExcludeList `mapstructure:"ports"`

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -30,7 +30,7 @@ func (l *Container) applyContainerRules(object storage.StoreObject, storageMap m
 	rules.NewRecommendedLabelsRule().ObjectRecommendedLabels(object, errorList.WithMaxLevel(l.cfg.Rules.RecommendedLabelsRule.GetLevel()))
 	rules.NewNamespaceLabelsRule().ObjectNamespaceLabels(object, storageMap, errorList.WithMaxLevel(l.cfg.Rules.NamespaceLabelsRule.GetLevel()))
 	rules.NewAPIVersionRule().ObjectAPIVersion(object, errorList.WithMaxLevel(l.cfg.Rules.APIVersionRule.GetLevel()))
-	rules.NewPriorityClassRule().ObjectPriorityClass(object, errorList.WithMaxLevel(l.cfg.Rules.PriorityClassRule.GetLevel()))
+	rules.NewPriorityClassRule(l.cfg.ExcludeRules.PriorityClass.Get()).ObjectPriorityClass(object, errorList.WithMaxLevel(l.cfg.Rules.PriorityClassRule.GetLevel()))
 	rules.NewDNSPolicyRule(l.cfg.ExcludeRules.DNSPolicy.Get()).
 		ObjectDNSPolicy(object, errorList.WithMaxLevel(l.cfg.Rules.DNSPolicyRule.GetLevel()))
 	rules.NewControllerSecurityContextRule(l.cfg.ExcludeRules.ControllerSecurityContext.Get()).

--- a/pkg/linters/container/rules/priority_class.go
+++ b/pkg/linters/container/rules/priority_class.go
@@ -29,22 +29,30 @@ const (
 	PriorityClassRuleName = "object-priority-class"
 )
 
-func NewPriorityClassRule() *PriorityClassRule {
+func NewPriorityClassRule(excludeRules []pkg.KindRuleExclude) *PriorityClassRule {
 	return &PriorityClassRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: PriorityClassRuleName,
+		},
+		KindRule: pkg.KindRule{
+			ExcludeRules: excludeRules,
 		},
 	}
 }
 
 type PriorityClassRule struct {
 	pkg.RuleMeta
+	pkg.KindRule
 }
 
 func (r *PriorityClassRule) ObjectPriorityClass(object storage.StoreObject, errorList *errors.LintRuleErrorsList) {
 	errorList = errorList.WithRule(r.GetName())
 
 	if !isPriorityClassSupportedKind(object.Unstructured.GetKind()) {
+		return
+	}
+
+	if !r.Enabled(object.Unstructured.GetKind(), object.Unstructured.GetName()) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

- **PriorityClass validation rule (`priority_class.go`)**: validates that Deployments, DaemonSets, and StatefulSets have a PriorityClass set. One-way check: **object → allowed list**.
- **Exclusion mechanism**: added `KindRuleExcludeList` support via `pkg.KindRule` embedding, consistent with existing rules (`DNSPolicyRule`, `ControllerSecurityContextRule`). Matches by `kind` + `name`.
- **Config wiring**: added `PriorityClass KindRuleExcludeList` with tag `mapstructure:"priority-class"` to `ContainerExcludeRules` in both runtime config (`pkg/config.go`) and settings (`pkg/config/linters_settings.go`).
- **Mapping**: `excludes.PriorityClass = configExcludes.PriorityClass.Get()` added to `mapContainerExclusions()` (`internal/module/module.go`).
- **Rule registration**: `NewPriorityClassRule()` now accepts `[]pkg.KindRuleExclude` and passes `l.cfg.ExcludeRules.PriorityClass.Get()` from `applyContainerRules()` (`rules.go`).

## Context

An operator chart deploys both inside and outside DKP. Outside DKP the required PriorityClass does not exist, so the deployment is created without it — PriorityClass is injected via Helm values hooks only for DKP environments. Without exclusion support, the DMT linter blocks these modules in CI pipelines, requiring developers to either disable the entire linter or add fake PriorityClass values.

## Example

**Excluding a specific Deployment:**

```yaml
container:
  exclude-rules:
    priority-class:
      - kind: Deployment
        name: my-operator
```

**Result**: the `my-operator` Deployment is skipped by PriorityClass validation. Other Deployments in the module are still checked.

## Excluding objects

Per-object exclude via `kind` + `name` match. Works for Deployment, DaemonSet, and StatefulSet.

```yaml
container:
  exclude-rules:
    priority-class:
      - kind: Deployment
        name: operator-deploy
      - kind: StatefulSet
        name: kafka-broker
```
