### PR TITLE
[dmt] mute symlink logs

### DIFF
--- a/internal/helm/render.go
+++ b/internal/helm/render.go
@@ -18,6 +18,8 @@ package helm
 
 import (
 	"fmt"
+	"io"
+	stdlog "log"
 	"path"
 
 	"github.com/werf/nelm/pkg/helm/pkg/chart"
@@ -73,7 +75,19 @@ func (r Renderer) RenderChartFromDir(chartDir string, values map[string]any) (ma
 		},
 	}
 
+	// nelm's chart loader calls sympath.Walk which indiscriminately logs
+	// "found symbolic link in path: %s resolves to %s" via the standard
+	// log package. Deckhouse modules use symlinks for helm_lib and other
+	// shared resources; those messages are expected noise. Mute std log
+	// during the load call and restore it afterwards.
+	stdlogWriter := stdlog.Writer()
+
+	stdlog.SetOutput(io.Discard)
+
 	chrt, err := loader.LoadDir(chartDir, opts)
+
+	stdlog.SetOutput(stdlogWriter)
+
 	if err != nil {
 		return nil, fmt.Errorf("load chart: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Suppress noisy symlink log output**: nelm (via `github.com/werf/nelm`) chart loader calls `sympath.Walk()` which uses Go standard `log.Printf` to emit `"found symbolic link in path: %s resolves to %s. Contents of linked file included and used"` for every symlink encountered.
- **Where it hurts**: deckhouse modules use symlinks extensively for `helm_lib` and other shared resources (e.g., `modules/002-deckhouse/charts/helm_lib` → `helm_lib/charts/deckhouse_lib_helm`). Every lint scan output is polluted by dozens of these messages.
- **Fix**: mute Go standard log output (`stdlog.SetOutput(io.Discard)`) before calling `loader.LoadDir()`, restore immediately after. This is in the same spirit as the existing `loader.NoChartLockWarning = ""` suppression.
- **Affected file**: `internal/helm/render.go` — `RenderChartFromDir` method.

## Context

dmt already has a fork of Helm's `sympath/walk.go` (`internal/module/sympath.go`) with the log line removed, but the nelm render path (`helm.Renderer.RenderChartFromDir`) goes through `github.com/werf/nelm/pkg/helm/pkg/chart/loader.LoadDir`, which uses nelm's own sympath fork that still contains the noisy log. Since nelm's sympath is internal and not configurable, temporarily redirecting the standard logger is the cleanest fix.

## Example

**Before** (dozens of irrelevant log lines in scan output):
```
2026/06/29 15:27:48 found symbolic link in path: /deckhouse/modules/002-deckhouse/charts/helm_lib resolves to /deckhouse/helm_lib/charts/deckhouse_lib_helm. Contents of linked file included and used
2026/06/29 15:27:48 found symbolic link in path: /deckhouse/modules/015-admission-policy-engine/charts/helm_lib resolves to /deckhouse/helm_lib/charts/deckhouse_lib_helm. Contents of linked file included and used
...
```

**After**: clean output, no symlink noise.