### PR TITLE
[dmt] add cse to valid editions

### DIFF
--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -65,6 +65,7 @@ The `accessibility` section controls which editions and bundles include the modu
 - `se` - Standard Edition
 - `se-plus` - Standard Edition Plus
 - `be` - Business Edition
+- `cse` - Certified Security Edition
 - `_default` - Default behavior override
 
 **Valid Bundles:**

--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -49,6 +49,7 @@ var ValidEditions = []string{
 	"se",
 	"se-plus",
 	"be",
+	"cse",
 	"_default",
 }
 


### PR DESCRIPTION
Adds `cse` to the `ValidEditions` list in the module linter (`pkg/linters/module/rules/module_yaml.go`). CSE is a Deckhouse edition but was missing from the enum, so a module declaring `accessibility.editions.cse` in its `module.yaml` was flagged as an invalid edition; this makes the linter accept it.
