### PR TITLE
[dmt] collect mount files

### DIFF
--- a/pkg/linters/container/rules/mount_points.go
+++ b/pkg/linters/container/rules/mount_points.go
@@ -35,7 +35,8 @@ const (
 )
 
 type mountPointsFile struct {
-	Dirs []string `yaml:"dirs"`
+	Dirs  []string `yaml:"dirs"`
+	Files []string `yaml:"files"`
 }
 
 func NewMountPointsRule(excludeRules []pkg.StringRuleExclude, modulePath string) *MountPointsRule {
@@ -131,6 +132,10 @@ func collectMountPointsDirs(modulePath string) map[string]bool {
 
 		for _, dir := range mpf.Dirs {
 			dirs[strings.TrimRight(dir, "/")] = true
+		}
+
+		for _, file := range mpf.Files {
+			dirs[strings.TrimRight(file, "/")] = true
 		}
 
 		return nil

--- a/pkg/linters/container/rules/mount_points_test.go
+++ b/pkg/linters/container/rules/mount_points_test.go
@@ -227,6 +227,32 @@ func TestMountPointsContainerRule_TrailingSlash(t *testing.T) {
 	assert.Len(t, errorList.GetErrors(), 0)
 }
 
+func TestMountPointsContainerRule_FilesDeclared(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "mpcr-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writeMountPointsFile(t, tmpDir, `dirs:
+  - /etc/app
+files:
+  - /etc/app/config.yaml
+  - /var/run/app.sock
+`)
+
+	obj := objectWithMounts("Deployment", "app", "/etc/app", "/etc/app/config.yaml", "/var/run/app.sock")
+
+	containers, err := obj.GetAllContainers()
+	assert.NoError(t, err)
+
+	errorList := errors.NewLintRuleErrorsList()
+	rule := NewMountPointsRule(nil, tmpDir)
+	rule.CheckMountPaths(obj, containers, errorList)
+
+	assert.Len(t, errorList.GetErrors(), 0)
+}
+
 func TestMountPointsContainerRule_DaemonSetAndStatefulSet(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "mpcr-test")
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Parse `files` section in mount-points.yaml**: the `mount-points` container rule only collected `dirs`, ignoring `files` entries.
- **Fix**: added `Files []string` field to `mountPointsFile` struct and iterate over `mpf.Files` alongside `mpf.Dirs` in `collectMountPointsDirs`.
- **Test**: added `TestMountPointsContainerRule_FilesDeclared` covering `files` section.
- **Affected files**: `pkg/linters/container/rules/mount_points.go`, `pkg/linters/container/rules/mount_points_test.go`

## Context

The `mount-points` rule requires every `volumeMount.mountPath` in Deployment/DaemonSet/StatefulSet to be declared in a `mount-points.yaml`. However, `mount-points.yaml` supports both `dirs` and `files` sections, but the linter only read `dirs`. This caused false positives for mount paths declared as files (e.g., `/etc/app/config.yaml`, `/run/xtables.lock`) — the linter warned they were "not declared" even though they were present in `files`.

## Example

**Before** (false positive):
```
Container "main" mountPath "/run/xtables.lock" is not declared in any mount-points.yaml
```
Even though `mount-points.yaml` contains:
```yaml
files:
  - /run/xtables.lock
```

**After**: no warning — file mount paths are recognized.