### PR TITLE
[dmt] add modules-template to dmt-lint-verify CI

### DIFF
--- a/.github/scripts/dmt-lint-modules-template.sh
+++ b/.github/scripts/dmt-lint-modules-template.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lints the modules-template repository with a locally built dmt binary.
+# This verifies that changes in this repository do not break (or unexpectedly
+# change) linting of the reference module template.
+#
+# Required environment variables:
+#   SRC_DIR  - directory where modules-template is (or will be) checked out
+# Optional:
+#   DMT_BIN  - dmt binary to use (default: "dmt" from PATH)
+
+set -euo pipefail
+
+DMT_BIN="${DMT_BIN:-dmt}"
+SRC_DIR="${SRC_DIR:?SRC_DIR (directory for modules-template checkout) is required}"
+
+echo "Linting with: ${DMT_BIN}"
+"${DMT_BIN}" --version || true
+
+echo "Running: ${DMT_BIN} lint -l INFO ${SRC_DIR}"
+"${DMT_BIN}" lint -l INFO "${SRC_DIR}"

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -70,7 +70,7 @@ jobs:
   lint-deckhouse:
     needs: resolve-skip
     if: needs.resolve-skip.outputs.skip != 'true'
-    name: lint-deckhouse
+    name: DMT verify deckhouse
     runs-on: ubuntu-latest
     steps:
       - name: Checkout dmt
@@ -105,7 +105,7 @@ jobs:
   lint-modules-template:
     needs: resolve-skip
     if: needs.resolve-skip.outputs.skip != 'true'
-    name: lint-modules-template
+    name: DMT verify modules-template
     runs-on: ubuntu-latest
     steps:
       - name: Checkout dmt

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -50,50 +50,48 @@ env:
   TEMPLATE_REF: ${{ inputs.template_branch || 'main' }}
 
 jobs:
-  resolve-skip:
-    name: resolve-skip
+  lint-deckhouse:
+    name: DMT verify deckhouse
     runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.ctx.outputs.skip }}
     steps:
-      - name: Resolve skip label
-        id: ctx
+      - name: Check skip label
+        id: skip
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]] \
             && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
+            echo "::warning::'${SKIP_LABEL}' label present — skipping deckhouse lint."
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::'${SKIP_LABEL}' label present — dmt lint verification will be skipped."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-  lint-deckhouse:
-    needs: resolve-skip
-    if: needs.resolve-skip.outputs.skip != 'true'
-    name: DMT verify deckhouse
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout dmt
+        if: steps.skip.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Setup Go
+        if: steps.skip.outputs.skip != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Build dmt
+        if: steps.skip.outputs.skip != 'true'
         run: make build
 
       - name: Clone deckhouse (${{ env.DECKHOUSE_REF }})
+        if: steps.skip.outputs.skip != 'true'
         run: |
           git clone --depth 1 --branch "${DECKHOUSE_REF}" "${DECKHOUSE_REPO}" "${RUNNER_TEMP}/deckhouse-src"
 
       - name: Prepare /deckhouse
+        if: steps.skip.outputs.skip != 'true'
         run: |
           sudo mkdir -p /deckhouse
           sudo chown "$(id -u):$(id -g)" /deckhouse
 
       - name: Lint deckhouse with built dmt
+        if: steps.skip.outputs.skip != 'true'
         env:
           DMT_BIN: ${{ github.workspace }}/dmt
           SRC_DIR: ${{ runner.temp }}/deckhouse-src
@@ -103,27 +101,41 @@ jobs:
         run: bash .github/scripts/dmt-lint-deckhouse.sh
 
   lint-modules-template:
-    needs: resolve-skip
-    if: needs.resolve-skip.outputs.skip != 'true'
     name: DMT verify modules-template
     runs-on: ubuntu-latest
     steps:
+      - name: Check skip label
+        id: skip
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
+            echo "::warning::'${SKIP_LABEL}' label present — skipping modules-template lint."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout dmt
+        if: steps.skip.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Setup Go
+        if: steps.skip.outputs.skip != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Build dmt
+        if: steps.skip.outputs.skip != 'true'
         run: make build
 
       - name: Clone modules-template (${{ env.TEMPLATE_REF }})
+        if: steps.skip.outputs.skip != 'true'
         run: |
           git clone --depth 1 --branch "${TEMPLATE_REF}" "${TEMPLATE_REPO}" "${RUNNER_TEMP}/modules-template"
 
       - name: Lint modules-template with built dmt
+        if: steps.skip.outputs.skip != 'true'
         env:
           DMT_BIN: ${{ github.workspace }}/dmt
           SRC_DIR: ${{ runner.temp }}/modules-template

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -1,7 +1,7 @@
 name: DMT Lint Verify
 
 # Verifies that the dmt build from this branch lints the real deckhouse codebase
-# without regressions. Runs on PRs and on main.
+# and the modules-template reference module without regressions. Runs on PRs and on main.
 #
 # Bypass: if the lint fails but the PR carries the "dmtlint-verify-skip" label,
 # the check passes (the failure is acknowledged and merge is allowed). Without
@@ -17,6 +17,11 @@ on:
     inputs:
       deckhouse_branch:
         description: 'Deckhouse branch or tag to run dmt lint on'
+        required: false
+        default: 'main'
+        type: string
+      template_branch:
+        description: 'modules-template branch or tag to run dmt lint on'
         required: false
         default: 'main'
         type: string
@@ -43,6 +48,8 @@ env:
   SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
   DECKHOUSE_REF: ${{ inputs.deckhouse_branch || 'main' }}
+  TEMPLATE_REPO: https://github.com/deckhouse/modules-template.git
+  TEMPLATE_REF: ${{ inputs.template_branch || 'main' }}
 
 jobs:
   dmt-lint-verify:
@@ -104,6 +111,20 @@ jobs:
           DMT_MATRIX_LIMIT: ${{ inputs.matrix_limit }}
         run: bash .github/scripts/dmt-lint-deckhouse.sh
 
+      - name: Clone modules-template (${{ env.TEMPLATE_REF }})
+        if: steps.ctx.outputs.skip != 'true'
+        run: |
+          git clone --depth 1 --branch "${TEMPLATE_REF}" "${TEMPLATE_REPO}" "${RUNNER_TEMP}/modules-template"
+
+      - name: Lint modules-template with built dmt
+        id: lint-template
+        if: steps.ctx.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          DMT_BIN: ${{ github.workspace }}/dmt
+          SRC_DIR: ${{ runner.temp }}/modules-template
+        run: bash .github/scripts/dmt-lint-modules-template.sh
+
       - name: Evaluate result
         run: |
           if [[ "${{ steps.ctx.outputs.skip }}" == "true" ]]; then
@@ -111,10 +132,19 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ steps.lint.outcome }}" == "success" ]]; then
-            echo "dmt lint passed on the deckhouse codebase."
-            exit 0
+          FAILED=""
+
+          if [[ "${{ steps.lint.outcome }}" != "success" ]]; then
+            FAILED="${FAILED}  - deckhouse (review the 'Lint deckhouse with built dmt' step logs)\n"
           fi
 
-          echo "::error::dmt lint failed on the deckhouse codebase. Review the 'Lint deckhouse with built dmt' step logs. To acknowledge and allow merge anyway, add the '${SKIP_LABEL}' label to this PR."
-          exit 1
+          if [[ "${{ steps.lint-template.outcome }}" != "success" ]]; then
+            FAILED="${FAILED}  - modules-template (review the 'Lint modules-template with built dmt' step logs)\n"
+          fi
+
+          if [[ -n "${FAILED}" ]]; then
+            echo "::error::dmt lint failed on:\n${FAILED}To acknowledge and allow merge anyway, add the '${SKIP_LABEL}' label to this PR."
+            exit 1
+          fi
+
+          echo "dmt lint passed on deckhouse and modules-template."

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -43,8 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SKIP_DECKHOUSE_LABEL: dmtlint-verify-skip-deckhouse
-  SKIP_TEMPLATE_LABEL: dmtlint-verify-skip-modules-template
+  SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
   DECKHOUSE_REF: ${{ inputs.deckhouse_branch || 'main' }}
   TEMPLATE_REPO: https://github.com/deckhouse/modules-template.git
@@ -59,8 +58,8 @@ jobs:
         id: skip
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DECKHOUSE_LABEL) }}" == "true" ]]; then
-            echo "::warning::'${SKIP_DECKHOUSE_LABEL}' label present — skipping deckhouse lint."
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
+            echo "::warning::'${SKIP_LABEL}' label present — skipping deckhouse lint."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -109,8 +108,8 @@ jobs:
         id: skip
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_TEMPLATE_LABEL) }}" == "true" ]]; then
-            echo "::warning::'${SKIP_TEMPLATE_LABEL}' label present — skipping modules-template lint."
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
+            echo "::warning::'${SKIP_LABEL}' label present — skipping modules-template lint."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -2,15 +2,11 @@ name: DMT Lint Verify
 
 # Verifies that the dmt build from this branch lints the real deckhouse codebase
 # and the modules-template reference module without regressions. Runs on PRs and on main.
-#
-# Bypass: if the lint fails but the PR carries the "dmtlint-verify-skip" label,
-# the check passes (the failure is acknowledged and merge is allowed). Without
-# the label a lint failure blocks the merge.
 on:
   push:
     branches: [ main ]
   pull_request:
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
     inputs:
       deckhouse_branch:
@@ -43,33 +39,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
   DECKHOUSE_REF: ${{ inputs.deckhouse_branch || 'main' }}
   TEMPLATE_REPO: https://github.com/deckhouse/modules-template.git
   TEMPLATE_REF: ${{ inputs.template_branch || 'main' }}
 
 jobs:
-  resolve-skip:
-    name: resolve-skip
-    runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.ctx.outputs.skip }}
-    steps:
-      - name: Resolve skip label
-        id: ctx
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::'${SKIP_LABEL}' label present — dmt lint verification will be skipped."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   lint-deckhouse:
-    needs: resolve-skip
-    if: needs.resolve-skip.outputs.skip != 'true'
     name: DMT verify deckhouse
     runs-on: ubuntu-latest
     steps:
@@ -103,8 +79,6 @@ jobs:
         run: bash .github/scripts/dmt-lint-deckhouse.sh
 
   lint-modules-template:
-    needs: resolve-skip
-    if: needs.resolve-skip.outputs.skip != 'true'
     name: DMT verify modules-template
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -10,8 +10,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    # `labeled`/`unlabeled` let the check re-evaluate (and turn green) as soon as
-    # the skip label is added or removed, without pushing a new commit.
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
     inputs:
@@ -52,9 +50,11 @@ env:
   TEMPLATE_REF: ${{ inputs.template_branch || 'main' }}
 
 jobs:
-  dmt-lint-verify:
-    name: dmt-lint-verify
+  resolve-skip:
+    name: resolve-skip
     runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.ctx.outputs.skip }}
     steps:
       - name: Resolve skip label
         id: ctx
@@ -67,84 +67,64 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+  lint-deckhouse:
+    needs: resolve-skip
+    if: needs.resolve-skip.outputs.skip != 'true'
+    name: lint-deckhouse
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout dmt
-        if: steps.ctx.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Setup Go
-        if: steps.ctx.outputs.skip != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Build dmt
-        if: steps.ctx.outputs.skip != 'true'
         run: make build
 
       - name: Clone deckhouse (${{ env.DECKHOUSE_REF }})
-        if: steps.ctx.outputs.skip != 'true'
         run: |
           git clone --depth 1 --branch "${DECKHOUSE_REF}" "${DECKHOUSE_REPO}" "${RUNNER_TEMP}/deckhouse-src"
 
-      # Deckhouse OpenAPI schemas use absolute $ref paths under /deckhouse, so the
-      # prepared tree must live there. Creating a dir under / needs root; hand it
-      # to the runner user so the lint step can populate it without sudo.
       - name: Prepare /deckhouse
-        if: steps.ctx.outputs.skip != 'true'
         run: |
           sudo mkdir -p /deckhouse
           sudo chown "$(id -u):$(id -g)" /deckhouse
 
       - name: Lint deckhouse with built dmt
-        id: lint
-        if: steps.ctx.outputs.skip != 'true'
-        continue-on-error: true
         env:
           DMT_BIN: ${{ github.workspace }}/dmt
           SRC_DIR: ${{ runner.temp }}/deckhouse-src
           WORK_DIR: /deckhouse
-          # Render and lint every template variant (all openapi value
-          # combinations) so conditionally-rendered resources are verified too.
-          # Off by default; enabled only via the "matrix" input checkbox on a
-          # manual (workflow_dispatch) run.
           DMT_MATRIX: ${{ inputs.matrix && 'true' || 'false' }}
           DMT_MATRIX_LIMIT: ${{ inputs.matrix_limit }}
         run: bash .github/scripts/dmt-lint-deckhouse.sh
 
+  lint-modules-template:
+    needs: resolve-skip
+    if: needs.resolve-skip.outputs.skip != 'true'
+    name: lint-modules-template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dmt
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build dmt
+        run: make build
+
       - name: Clone modules-template (${{ env.TEMPLATE_REF }})
-        if: steps.ctx.outputs.skip != 'true'
         run: |
           git clone --depth 1 --branch "${TEMPLATE_REF}" "${TEMPLATE_REPO}" "${RUNNER_TEMP}/modules-template"
 
       - name: Lint modules-template with built dmt
-        id: lint-template
-        if: steps.ctx.outputs.skip != 'true'
-        continue-on-error: true
         env:
           DMT_BIN: ${{ github.workspace }}/dmt
           SRC_DIR: ${{ runner.temp }}/modules-template
         run: bash .github/scripts/dmt-lint-modules-template.sh
-
-      - name: Evaluate result
-        run: |
-          if [[ "${{ steps.ctx.outputs.skip }}" == "true" ]]; then
-            echo "::warning::dmt lint verification skipped because the '${SKIP_LABEL}' label is set on this PR."
-            exit 0
-          fi
-
-          FAILED=""
-
-          if [[ "${{ steps.lint.outcome }}" != "success" ]]; then
-            FAILED="${FAILED}  - deckhouse (review the 'Lint deckhouse with built dmt' step logs)\n"
-          fi
-
-          if [[ "${{ steps.lint-template.outcome }}" != "success" ]]; then
-            FAILED="${FAILED}  - modules-template (review the 'Lint modules-template with built dmt' step logs)\n"
-          fi
-
-          if [[ -n "${FAILED}" ]]; then
-            echo "::error::dmt lint failed on:\n${FAILED}To acknowledge and allow merge anyway, add the '${SKIP_LABEL}' label to this PR."
-            exit 1
-          fi
-
-          echo "dmt lint passed on deckhouse and modules-template."

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -2,11 +2,15 @@ name: DMT Lint Verify
 
 # Verifies that the dmt build from this branch lints the real deckhouse codebase
 # and the modules-template reference module without regressions. Runs on PRs and on main.
+#
+# Bypass: if the lint fails but the PR carries the "dmtlint-verify-skip" label,
+# the check passes (the failure is acknowledged and merge is allowed). Without
+# the label a lint failure blocks the merge.
 on:
   push:
     branches: [ main ]
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
     inputs:
       deckhouse_branch:
@@ -39,13 +43,33 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  SKIP_LABEL: dmtlint-verify-skip
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
   DECKHOUSE_REF: ${{ inputs.deckhouse_branch || 'main' }}
   TEMPLATE_REPO: https://github.com/deckhouse/modules-template.git
   TEMPLATE_REF: ${{ inputs.template_branch || 'main' }}
 
 jobs:
+  resolve-skip:
+    name: resolve-skip
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.ctx.outputs.skip }}
+    steps:
+      - name: Resolve skip label
+        id: ctx
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::'${SKIP_LABEL}' label present — dmt lint verification will be skipped."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint-deckhouse:
+    needs: resolve-skip
+    if: needs.resolve-skip.outputs.skip != 'true'
     name: DMT verify deckhouse
     runs-on: ubuntu-latest
     steps:
@@ -79,6 +103,8 @@ jobs:
         run: bash .github/scripts/dmt-lint-deckhouse.sh
 
   lint-modules-template:
+    needs: resolve-skip
+    if: needs.resolve-skip.outputs.skip != 'true'
     name: DMT verify modules-template
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dmt-lint.yml
+++ b/.github/workflows/dmt-lint.yml
@@ -43,7 +43,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SKIP_LABEL: dmtlint-verify-skip
+  SKIP_DECKHOUSE_LABEL: dmtlint-verify-skip-deckhouse
+  SKIP_TEMPLATE_LABEL: dmtlint-verify-skip-modules-template
   DECKHOUSE_REPO: https://github.com/deckhouse/deckhouse.git
   DECKHOUSE_REF: ${{ inputs.deckhouse_branch || 'main' }}
   TEMPLATE_REPO: https://github.com/deckhouse/modules-template.git
@@ -58,8 +59,8 @@ jobs:
         id: skip
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
-            echo "::warning::'${SKIP_LABEL}' label present — skipping deckhouse lint."
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_DECKHOUSE_LABEL) }}" == "true" ]]; then
+            echo "::warning::'${SKIP_DECKHOUSE_LABEL}' label present — skipping deckhouse lint."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -108,8 +109,8 @@ jobs:
         id: skip
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]] \
-            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_LABEL) }}" == "true" ]]; then
-            echo "::warning::'${SKIP_LABEL}' label present — skipping modules-template lint."
+            && [[ "${{ contains(github.event.pull_request.labels.*.name, env.SKIP_TEMPLATE_LABEL) }}" == "true" ]]; then
+            echo "::warning::'${SKIP_TEMPLATE_LABEL}' label present — skipping modules-template lint."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Currently `dmt-lint-verify` only lints the deckhouse codebase. When a new DMT rule is added or changed, there is no automated check against `modules-template` — the reference module template from which all new modules are forked. This means regressions in the template module can go unnoticed until users report them.

## Solution

Add `modules-template` as a second lint target in the `dmt-lint-verify` workflow, alongside deckhouse.

### Changes

- **New script** `.github/scripts/dmt-lint-modules-template.sh` — clones and lints the modules-template repo (simpler than deckhouse: no `structure_prepare` needed since it is a single module directory)
- **Updated workflow** `.github/workflows/dmt-lint.yml`:
  - Clones `modules-template` and runs `dmt lint` on it with the built binary
  - Reports failures from either repo (deckhouse or modules-template) together
  - Added `template_branch` input to `workflow_dispatch` for manual runs against a custom branch
  - Both lint steps use `continue-on-error: true`; the final `Evaluate result` step aggregates failures

### How it works

```
dmt PR opened
  → build dmt
  → lint deckhouse
  → lint modules-template
  → if either fails: CI blocked (unless skip label is set)
```
