### PR TITLE
[dmt] validate duplicate yaml keys

### DIFF
--- a/pkg/linters/module/rules/module_yaml.go
+++ b/pkg/linters/module/rules/module_yaml.go
@@ -81,19 +81,20 @@ const (
 )
 
 type DeckhouseModule struct {
-	Name          string               `json:"name"`
-	Critical      bool                 `json:"critical,omitempty"`
-	Namespace     string               `json:"namespace"`
-	Weight        uint32               `json:"weight,omitempty"`
-	Tags          []string             `json:"tags"`
-	Subsystems    []string             `json:"subsystems,omitempty"`
-	Stage         string               `json:"stage"`
-	Description   string               `json:"description,omitempty"`
-	Descriptions  ModuleDescriptions   `json:"descriptions,omitempty"`
-	Requirements  *ModuleRequirements  `json:"requirements,omitempty"`
-	Accessibility *ModuleAccessibility `json:"accessibility,omitempty"`
-	Update        *ModuleUpdate        `json:"update,omitempty"`
-	Disable       *ModuleDisable       `json:"disable,omitempty"`
+	Name           string               `json:"name"`
+	Critical       bool                 `json:"critical,omitempty"`
+	Namespace      string               `json:"namespace"`
+	Weight         uint32               `json:"weight,omitempty"`
+	Tags           []string             `json:"tags"`
+	Subsystems     []string             `json:"subsystems,omitempty"`
+	Stage          string               `json:"stage"`
+	Description    string               `json:"description,omitempty"`
+	ExclusiveGroup string               `json:"exclusiveGroup,omitempty"`
+	Descriptions   ModuleDescriptions   `json:"descriptions,omitempty"`
+	Requirements   *ModuleRequirements  `json:"requirements,omitempty"`
+	Accessibility  *ModuleAccessibility `json:"accessibility,omitempty"`
+	Update         *ModuleUpdate        `json:"update,omitempty"`
+	Disable        *ModuleDisable       `json:"disable,omitempty"`
 }
 
 type ModuleDescriptions struct {
@@ -233,7 +234,7 @@ func (r *DefinitionFileRule) CheckDefinitionFile(modulePath string, errorList *e
 
 	var yml DeckhouseModule
 
-	err = yaml.Unmarshal(yamlFile, &yml)
+	err = yaml.UnmarshalStrict(yamlFile, &yml)
 	if err != nil {
 		errorList.Errorf("Cannot parse file %q: %s", ModuleConfigFilename, err)
 

--- a/pkg/linters/module/rules/module_yaml_test.go
+++ b/pkg/linters/module/rules/module_yaml_test.go
@@ -600,6 +600,32 @@ disable:
 	assert.True(t, containsText(errorList, "'disable.message' must be removed on Deckhouse >= v1.77"), "expected disable.message removal error")
 }
 
+func TestCheckDefinitionFile_DuplicateKeys(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)
+
+	// Test duplicate keys in module.yaml (simulates the real bug:
+	// descriptions.en defined twice)
+	err := os.WriteFile(moduleFilePath, []byte(`
+name: state-snapshotter
+stage: Preview
+descriptions:
+  en: "State snapshotter module"
+  en: "Модуль State snapshotter"
+requirements:
+  deckhouse: ">= 1.72"
+namespace: d8-state-snapshotter
+`), 0600)
+	require.NoError(t, err)
+
+	rule := NewDefinitionFileRule(false)
+	errorList := errors.NewLintRuleErrorsList()
+
+	rule.CheckDefinitionFile(tempDir, errorList)
+	assert.True(t, errorList.ContainsErrors(), "Expected errors for duplicate keys in module.yaml")
+	assert.Contains(t, errorList.GetErrors()[0].Text, "Cannot parse file")
+}
+
 func TestCheckDefinitionFile_FileErrors(t *testing.T) {
 	tempDir := t.TempDir()
 	moduleFilePath := filepath.Join(tempDir, ModuleConfigFilename)

--- a/test/e2e/testdata/module/duplicate-keys/expected.yaml
+++ b/test/e2e/testdata/module/duplicate-keys/expected.yaml
@@ -1,0 +1,9 @@
+description: >
+  A module with duplicate keys in module.yaml (descriptions.en defined twice)
+  must be flagged by the definition-file linter.
+module: module
+expect:
+  - linter: module
+    rule: definition-file
+    level: error
+    textContains: "Cannot parse file"

--- a/test/e2e/testdata/module/duplicate-keys/module/module.yaml
+++ b/test/e2e/testdata/module/duplicate-keys/module/module.yaml
@@ -1,0 +1,8 @@
+name: state-snapshotter
+stage: Preview
+descriptions:
+  en: "State snapshotter module"
+  en: "Модуль State snapshotter"
+requirements:
+  deckhouse: ">= 1.72"
+namespace: d8-state-snapshotter

--- a/test/e2e/testdata/module/duplicate-keys/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/module/duplicate-keys/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/module/duplicate-keys/module/openapi/values.yaml
+++ b/test/e2e/testdata/module/duplicate-keys/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/module/exclusive-group/expected.yaml
+++ b/test/e2e/testdata/module/exclusive-group/expected.yaml
@@ -1,0 +1,7 @@
+description: >
+  A valid module with exclusiveGroup field must not produce definition-file parse errors.
+module: module
+expectAbsent:
+  - linter: module
+    rule: definition-file
+    textContains: "Cannot parse file"

--- a/test/e2e/testdata/module/exclusive-group/module/module.yaml
+++ b/test/e2e/testdata/module/exclusive-group/module/module.yaml
@@ -1,0 +1,9 @@
+name: cni-cilium
+stage: General Availability
+descriptions:
+  en: "Cilium CNI"
+  ru: "Cilium CNI"
+exclusiveGroup: cni
+requirements:
+  deckhouse: ">= 1.72"
+namespace: d8-cni-cilium

--- a/test/e2e/testdata/module/exclusive-group/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/module/exclusive-group/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/module/exclusive-group/module/openapi/values.yaml
+++ b/test/e2e/testdata/module/exclusive-group/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}


### PR DESCRIPTION
## Summary

- **Use `yaml.UnmarshalStrict` for `module.yaml` and `Chart.yaml` parsing**: replaces `yaml.Unmarshal` with `yaml.UnmarshalStrict` in `CheckDefinitionFile` (linter rule), `ParseModuleConfigFile`, and `ParseChartFile`.
- **Add test for duplicate YAML keys**: new `TestCheckDefinitionFile_DuplicateKeys` reproduces the real bug where `descriptions.en` was defined twice.
- **Affected files**: `pkg/linters/module/rules/module_yaml.go`, `internal/module/module.go`, `pkg/linters/module/rules/module_yaml_test.go`

## Context

`module.yaml` with duplicate keys (e.g. `en:` defined twice under `descriptions:`) silently passed DMT validation because `yaml.Unmarshal` drops duplicates by taking the last value. However, the Deckhouse controller uses strict parsing and crashes at runtime:

```json
{"level":"error","msg":"run","error":"start deckhouse controller: ... parse module definition ... yaml: unmarshal errors:\n  line 5: mapping key \"en\" already defined at line 4"}
```

`sigs.k8s.io/yaml` `UnmarshalStrict` was already used elsewhere in the codebase (controller rendering, openapi parsing, values, oss.yaml) but not for `module.yaml`. This aligns the parsing to strict everywhere.

## Example

**Before** (duplicate keys silently accepted):
```yaml
name: state-snapshotter
stage: "Preview"
descriptions:
  en: "State snapshotter module"
  en: "Модуль State snapshotter"
```
→ dmt lint passes ✗

**After** (duplicate keys caught):
```
Error: definition-file: Cannot parse file "module.yaml": ...
```
→ dmt lint fails ✓