### PR TITLE
[dmt] fix helmignore missing chart dirs

### DIFF
--- a/pkg/linters/module/rules/helmignore.go
+++ b/pkg/linters/module/rules/helmignore.go
@@ -53,10 +53,8 @@ var moduleTemplateExclude = map[string]bool{
 	"values.yaml": true,
 
 	// Read by Deckhouse directly, not part of the Helm chart
-	"module.yaml": true,
-	".namespace":  true,
-	"oss.yaml":    true,
-	"rbac.yaml":   true,
+	".namespace": true,
+	"rbac.yaml":  true,
 }
 
 func NewHelmignoreRule(disable bool) *HelmignoreRule {

--- a/pkg/linters/module/rules/helmignore.go
+++ b/pkg/linters/module/rules/helmignore.go
@@ -41,16 +41,14 @@ const (
 )
 
 // moduleTemplateExclude is the set of files and directories that belong to
-// the standard Deckhouse module (Helm chart) template and therefore should
-// NOT be listed in .helmignore.
-// moduleTemplateExclude is the set of files and directories that belong to
-// the Deckhouse module template and therefore should NOT be listed in
-// .helmignore. These are either required by Helm or read by Deckhouse
-// directly from the module filesystem (not from the rendered chart).
+// the Deckhouse module and therefore should NOT be listed in .helmignore.
+// These are either required by Helm for rendering or read by Deckhouse
+// directly from the module filesystem.
 var moduleTemplateExclude = map[string]bool{
-	// Required by Helm
+	// Required by Helm for chart rendering
 	"templates":   true,
 	"charts":      true,
+	"monitoring":  true,
 	"Chart.yaml":  true,
 	"values.yaml": true,
 

--- a/pkg/linters/module/rules/helmignore.go
+++ b/pkg/linters/module/rules/helmignore.go
@@ -51,10 +51,6 @@ var moduleTemplateExclude = map[string]bool{
 	"monitoring":  true,
 	"Chart.yaml":  true,
 	"values.yaml": true,
-
-	// Read by Deckhouse directly, not part of the Helm chart
-	".namespace": true,
-	"rbac.yaml":  true,
 }
 
 func NewHelmignoreRule(disable bool) *HelmignoreRule {

--- a/pkg/linters/module/rules/helmignore_test.go
+++ b/pkg/linters/module/rules/helmignore_test.go
@@ -159,10 +159,10 @@ func TestHelmignoreRule_CheckHelmignore(t *testing.T) {
 			name:        "multiple missing directories",
 			createFile:  true,
 			fileContent: "hooks/",
-			directories: []string{"hooks", "images", "docs"},
+			directories: []string{"hooks", "images", "scripts"},
 			expectedErrors: []string{
 				"Directory 'images/' is not listed in .helmignore",
-				"Directory 'docs/' is not listed in .helmignore",
+				"Directory 'scripts/' is not listed in .helmignore",
 			},
 		},
 		{
@@ -211,10 +211,10 @@ func TestHelmignoreRule_CheckHelmignore(t *testing.T) {
 		{
 			name:        "negated pattern does not count as covered",
 			createFile:  true,
-			fileContent: "!hooks/",
-			directories: []string{"hooks"},
+			fileContent: "!images/",
+			directories: []string{"images"},
 			expectedErrors: []string{
-				"Directory 'hooks/' is not listed in .helmignore",
+				"Directory 'images/' is not listed in .helmignore",
 			},
 		},
 		{
@@ -230,6 +230,25 @@ func TestHelmignoreRule_CheckHelmignore(t *testing.T) {
 			fileContent:    "hooks/",
 			directories:    []string{"hooks", "charts"},
 			expectedErrors: []string{},
+		},
+		{
+			name:           "monitoring directory is skipped (needed in chart)",
+			createFile:     true,
+			fileContent:    ".git/",
+			directories:    []string{"monitoring"},
+			expectedErrors: []string{},
+		},
+		{
+			name:        "only helm rendering dirs are skipped",
+			createFile:  true,
+			fileContent: ".git/",
+			directories: []string{"docs", "crds", "hooks", "monitoring", "openapi", "templates", "charts"},
+			expectedErrors: []string{
+				"Directory 'docs/' is not listed in .helmignore",
+				"Directory 'crds/' is not listed in .helmignore",
+				"Directory 'hooks/' is not listed in .helmignore",
+				"Directory 'openapi/' is not listed in .helmignore",
+			},
 		},
 		{
 			name:           "empty module root only templates",

--- a/test/e2e/testdata/module/helmignore-all-covered/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-all-covered/module/.helmignore
@@ -2,3 +2,4 @@ hooks/
 openapi/
 crds/
 docs/
+module.yaml

--- a/test/e2e/testdata/module/helmignore-dir-covered-without-slash/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-dir-covered-without-slash/module/.helmignore
@@ -1,3 +1,4 @@
 hooks
 openapi
 docs
+module.yaml

--- a/test/e2e/testdata/module/helmignore-missing-dir/expected.yaml
+++ b/test/e2e/testdata/module/helmignore-missing-dir/expected.yaml
@@ -1,7 +1,6 @@
 description: >
-  .helmignore only lists hooks/ but the module also has images/ and openapi/
-  directories. module.yaml is excluded (read by Deckhouse directly).
-  The rule must report each uncovered directory.
+  .helmignore lists hooks/ and module.yaml but the module also has images/
+  and openapi/ directories. The rule must report each uncovered directory.
 module: module
 expect:
   - linter: module

--- a/test/e2e/testdata/module/helmignore-missing-dir/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-missing-dir/module/.helmignore
@@ -1,1 +1,2 @@
 hooks/
+module.yaml

--- a/test/e2e/testdata/module/helmignore-multiple-missing/expected.yaml
+++ b/test/e2e/testdata/module/helmignore-multiple-missing/expected.yaml
@@ -1,7 +1,7 @@
 description: >
-  .helmignore only lists hooks/ but the module has images/, docs/, openapi/,
-  crds/ directories. module.yaml is excluded (read by Deckhouse directly).
-  templates/ and charts/ are skipped (module-template).
+  .helmignore lists hooks/ and module.yaml but the module has images/,
+  docs/, openapi/, crds/ directories. templates/ and charts/ are skipped
+  (module-template).
 module: module
 expect:
   - linter: module

--- a/test/e2e/testdata/module/helmignore-multiple-missing/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-multiple-missing/module/.helmignore
@@ -1,1 +1,2 @@
 hooks/
+module.yaml


### PR DESCRIPTION
## Summary

- **Add `monitoring/` to `moduleTemplateExclude`**: the `monitoring/` directory contains Grafana dashboards and Prometheus rules that are rendered by Helm templates. It MUST be in the chart — listing it in `.helmignore` would break the module.
- **Clearer comments** on `moduleTemplateExclude` grouping: "required by Helm" vs "read by Deckhouse directly".
- **Updated unit tests**: added test for `monitoring/` being skipped, added test verifying that only `templates/`, `charts/`, `monitoring/` are exempt from `.helmignore` (other dirs like `docs/`, `crds/`, `hooks/`, `openapi/` correctly require `.helmignore` entries).

## Context

The `checkModuleRootCoverage` check scans the module root and warns about any file/directory not listed in `.helmignore` — except those in `moduleTemplateExclude`. The exemption list was missing `monitoring/`, causing false warnings:

```
WARN Directory 'monitoring/' is not listed in .helmignore
```

`monitoring/` is referenced by `templates/monitoring.yaml` via `helm_lib_prometheus_rules_recursion` and `helm_lib_grafana_dashboards_recursion`. Adding it to `.helmignore` breaks chart rendering.

Directories like `docs/`, `crds/`, `hooks/`, `openapi/` correctly trigger warnings — Deckhouse reads them directly from the module filesystem, not from the rendered Helm chart. They should be in `.helmignore` to keep the chart lean.

## Example

**Before** (false warning):
```
WARN Directory 'monitoring/' is not listed in .helmignore
```

**After**:
```
(monitoring/ is skipped — needed for chart rendering)
(successful lint)
```