### PR TITLE
Actualize nelm engine: extract NelmEngine with DI, add helm-render rule

### DIFF
--- a/internal/helm/engine.go
+++ b/internal/helm/engine.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"fmt"
+	"io"
+	stdlog "log"
+
+	"github.com/werf/nelm/pkg/helm/pkg/chart"
+	"github.com/werf/nelm/pkg/helm/pkg/chart/loader"
+	"github.com/werf/nelm/pkg/helm/pkg/chartutil"
+	"github.com/werf/nelm/pkg/helm/pkg/engine"
+	"github.com/werf/nelm/pkg/helm/pkg/werf/helmopts"
+)
+
+// EngineOption is a functional option for configuring NelmEngine.
+type EngineOption func(*NelmEngine)
+
+// NelmEngine is a reusable wrapper around werf/nelm for rendering Helm charts.
+// Unlike the old Renderer, it does not own chart name / namespace / lint mode —
+// those are passed per-render call. Engine-level concerns (log suppression,
+// default options, DepDownloader) are injected via functional options.
+type NelmEngine struct {
+	chartLoadOpts helmopts.ChartLoadOptions
+}
+
+// NewEngine creates a NelmEngine with optional overrides.
+func NewEngine(opts ...EngineOption) *NelmEngine {
+	e := &NelmEngine{
+		chartLoadOpts: helmopts.ChartLoadOptions{
+			DefaultChartAPIVersion: "v2",
+			DefaultChartVersion:    "0.2.0",
+			DepDownloader:          &lintDepDownloader{},
+		},
+	}
+	for _, o := range opts {
+		o(e)
+	}
+	return e
+}
+
+// WithDepDownloader overrides the default lintDepDownloader.
+func WithDepDownloader(d helmopts.DepDownloader) EngineOption {
+	return func(e *NelmEngine) {
+		e.chartLoadOpts.DepDownloader = d
+	}
+}
+
+// WithChartLoadOption sets a ChartLoadOptions field directly.
+func WithChartLoadOption(fn func(*helmopts.ChartLoadOptions)) EngineOption {
+	return func(e *NelmEngine) {
+		fn(&e.chartLoadOpts)
+	}
+}
+
+// LoadChart loads the chart at chartDir using nelm's loader with the engine's
+// default options. name is used as DefaultChartName when the chart lacks a
+// Chart.yaml. Returns the loaded chart or an error.
+func (e *NelmEngine) LoadChart(chartDir, name string) (*chart.Chart, error) {
+	if name == "" {
+		return nil, fmt.Errorf("helm chart must have a name")
+	}
+
+	opts := helmopts.HelmOptions{
+		ChartLoadOpts: e.chartLoadOpts,
+	}
+	opts.ChartLoadOpts.DefaultChartName = name
+
+	// Suppress nelm's indiscriminate symlink/Chart.lock logging during load.
+	stdlogWriter := stdlog.Writer()
+	stdlog.SetOutput(io.Discard)
+
+	chrt, err := loader.LoadDir(chartDir, opts)
+
+	stdlog.SetOutput(stdlogWriter)
+
+	if err != nil {
+		return nil, fmt.Errorf("load chart: %w", err)
+	}
+	return chrt, nil
+}
+
+// RenderChart loads the chart at chartDir and renders it with the given values.
+// name is used as DefaultChartName; lintMode controls strictness of rendering.
+func (e *NelmEngine) RenderChart(chartDir, name string, values map[string]any, lintMode bool) (map[string]string, error) {
+	chrt, err := e.LoadChart(chartDir, name)
+	if err != nil {
+		return nil, err
+	}
+
+	eng := engine.Engine{LintMode: lintMode}
+	out, err := eng.Render(chrt, chartutil.Values(values), helmopts.HelmOptions{
+		ChartLoadOpts: e.chartLoadOpts,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/helm/render.go
+++ b/internal/helm/render.go
@@ -18,8 +18,6 @@ package helm
 
 import (
 	"fmt"
-	"io"
-	stdlog "log"
 	"path"
 
 	"github.com/werf/nelm/pkg/helm/pkg/chart"
@@ -38,6 +36,12 @@ func init() {
 	loader.NoChartLockWarning = ""
 }
 
+// Renderer is a convenience wrapper around NelmEngine that carries DMT-specific
+// rendering concerns: chart name, namespace, lint mode, and helm_lib template
+// overrides. It delegates chart loading and rendering to NelmEngine.
+//
+// Renderer is the stable public API for module rendering. For new consumers that
+// do not need helm_lib overrides, use NelmEngine directly.
 type Renderer struct {
 	Name      string
 	Namespace string
@@ -61,41 +65,20 @@ func (r Renderer) RenderChartFromDir(chartDir string, values map[string]any) (ma
 		return nil, fmt.Errorf("helm chart must have a name")
 	}
 
-	opts := helmopts.HelmOptions{
-		ChartLoadOpts: helmopts.ChartLoadOptions{
-			// deckhouse modules may omit Chart.yaml; provide sane defaults so the
-			// directory still loads as a chart.
-			DefaultChartAPIVersion: "v2",
-			DefaultChartName:       r.Name,
-			DefaultChartVersion:    "0.2.0",
-			// Nelm's chart loader calls DepDownloader.SetChartPath / Build when
-			// the chart has a Chart.lock with external (non-file://) dependencies.
-			// Leave it nil and the loader panics with a nil pointer dereference.
-			DepDownloader: &lintDepDownloader{},
-		},
-	}
+	eng := NewEngine()
 
-	// nelm's chart loader calls sympath.Walk which indiscriminately logs
-	// "found symbolic link in path: %s resolves to %s" via the standard
-	// log package. Deckhouse modules use symlinks for helm_lib and other
-	// shared resources; those messages are expected noise. Mute std log
-	// during the load call and restore it afterwards.
-	stdlogWriter := stdlog.Writer()
-
-	stdlog.SetOutput(io.Discard)
-
-	chrt, err := loader.LoadDir(chartDir, opts)
-
-	stdlog.SetOutput(stdlogWriter)
-
+	chrt, err := eng.LoadChart(chartDir, r.Name)
 	if err != nil {
-		return nil, fmt.Errorf("load chart: %w", err)
+		return nil, err
 	}
 
 	r.applyTemplateOverrides(chrt)
 
-	e := engine.Engine{LintMode: r.LintMode}
+	opts := helmopts.HelmOptions{
+		ChartLoadOpts: eng.chartLoadOpts,
+	}
 
+	e := engine.Engine{LintMode: r.LintMode}
 	out, err := e.Render(chrt, chartutil.Values(values), opts)
 	if err != nil {
 		return nil, err

--- a/internal/module/helm_overrides.go
+++ b/internal/module/helm_overrides.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package module
+
+// HelmLibOverrides returns the deterministic helm_lib helper stubs dmt injects
+// during rendering so that image and module-name references resolve to stable
+// values regardless of the helm_lib version a module ships with.
+func HelmLibOverrides() map[string][]byte {
+	return map[string][]byte{
+		"_module_name.tpl":  moduleNameTemplate,
+		"_module_image.tpl": moduleImageTemplate,
+	}
+}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -53,6 +53,7 @@ type Module struct {
 	chart       *chart.Chart
 	objectStore *storage.UnstructuredObjectStore
 	werfFile    string
+	values      map[string]any
 
 	linterConfig *pkg.LintersSettings
 }
@@ -143,6 +144,13 @@ func (m *Module) GetModuleConfig() *pkg.LintersSettings {
 	}
 
 	return m.linterConfig
+}
+
+func (m *Module) GetValues() map[string]any {
+	if m == nil {
+		return nil
+	}
+	return m.values
 }
 
 // remapLinterSettings converts configuration settings from the config package format
@@ -528,6 +536,7 @@ func NewModule(path string, vals *chartutil.Values, globalSchema *spec.Schema, r
 	}
 
 	module.objectStore = objectStore
+	module.values = schemas
 
 	werfFile, err := werf.GetWerfConfig(path)
 	if err != nil {

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -348,6 +348,7 @@ func mapTemplatesRules(linterSettings *pkg.LintersSettings, configSettings *conf
 	rules.EnabledModulesRule.SetLevel(globalRules.EnabledModulesRule.Impact, fallbackImpact)
 	rules.MountPointsRule.SetLevel(globalRules.MountPointsRule.Impact, fallbackImpact)
 	rules.WebhookConfigurationRule.SetLevel(globalRules.WebhookConfigurationRule.Impact, fallbackImpact)
+	rules.HelmRenderRule.SetLevel(globalRules.HelmRenderRule.Impact, fallbackImpact)
 }
 
 // mapOpenAPIRules configures OpenAPI linter rules

--- a/internal/module/render_templates.go
+++ b/internal/module/render_templates.go
@@ -28,10 +28,7 @@ import (
 // during rendering so that image and module-name references resolve to stable
 // values regardless of the helm_lib version a module ships with.
 func helmLibOverrides() map[string][]byte {
-	return map[string][]byte{
-		"_module_name.tpl":  moduleNameTemplate,
-		"_module_image.tpl": moduleImageTemplate,
-	}
+	return HelmLibOverrides()
 }
 
 // RenderModuleWithValues renders the module at modulePath with the supplied

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -144,6 +144,7 @@ type TemplatesLinterRules struct {
 	EnabledModulesRule       RuleConfig
 	WebhookConfigurationRule RuleConfig
 	MountPointsRule          RuleConfig
+	HelmRenderRule           RuleConfig
 }
 
 type PrometheusRuleSettings struct {

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -143,6 +143,7 @@ type TemplatesLinterRules struct {
 	EnabledModulesRule       RuleConfig `mapstructure:"enabled-modules"`
 	WebhookConfigurationRule RuleConfig `mapstructure:"webhook-configuration-annotations"`
 	MountPointsRule          RuleConfig `mapstructure:"mount-points"`
+	HelmRenderRule           RuleConfig `mapstructure:"helm-render"`
 }
 
 func (c LinterConfig) IsWarn() bool {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -233,6 +233,7 @@ type TemplatesLinterRules struct {
 	EnabledModulesRule       RuleConfig `mapstructure:"enabled-modules"`
 	WebhookConfigurationRule RuleConfig `mapstructure:"webhook-configuration-annotations"`
 	MountPointsRule          RuleConfig `mapstructure:"mount-points"`
+	HelmRenderRule           RuleConfig `mapstructure:"helm-render"`
 }
 
 type TemplatesExcludeRules struct {

--- a/pkg/linters/module/rules/helmignore.go
+++ b/pkg/linters/module/rules/helmignore.go
@@ -53,10 +53,8 @@ var moduleTemplateExclude = map[string]bool{
 	"values.yaml": true,
 
 	// Read by Deckhouse directly, not part of the Helm chart
-	"module.yaml": true,
-	".namespace":  true,
-	"oss.yaml":    true,
-	"rbac.yaml":   true,
+	".namespace": true,
+	"rbac.yaml":  true,
 }
 
 func NewHelmignoreRule(disable bool) *HelmignoreRule {

--- a/pkg/linters/module/rules/helmignore.go
+++ b/pkg/linters/module/rules/helmignore.go
@@ -41,16 +41,14 @@ const (
 )
 
 // moduleTemplateExclude is the set of files and directories that belong to
-// the standard Deckhouse module (Helm chart) template and therefore should
-// NOT be listed in .helmignore.
-// moduleTemplateExclude is the set of files and directories that belong to
-// the Deckhouse module template and therefore should NOT be listed in
-// .helmignore. These are either required by Helm or read by Deckhouse
-// directly from the module filesystem (not from the rendered chart).
+// the Deckhouse module and therefore should NOT be listed in .helmignore.
+// These are either required by Helm for rendering or read by Deckhouse
+// directly from the module filesystem.
 var moduleTemplateExclude = map[string]bool{
-	// Required by Helm
+	// Required by Helm for chart rendering
 	"templates":   true,
 	"charts":      true,
+	"monitoring":  true,
 	"Chart.yaml":  true,
 	"values.yaml": true,
 

--- a/pkg/linters/module/rules/helmignore.go
+++ b/pkg/linters/module/rules/helmignore.go
@@ -51,10 +51,6 @@ var moduleTemplateExclude = map[string]bool{
 	"monitoring":  true,
 	"Chart.yaml":  true,
 	"values.yaml": true,
-
-	// Read by Deckhouse directly, not part of the Helm chart
-	".namespace": true,
-	"rbac.yaml":  true,
 }
 
 func NewHelmignoreRule(disable bool) *HelmignoreRule {

--- a/pkg/linters/module/rules/helmignore_test.go
+++ b/pkg/linters/module/rules/helmignore_test.go
@@ -159,10 +159,10 @@ func TestHelmignoreRule_CheckHelmignore(t *testing.T) {
 			name:        "multiple missing directories",
 			createFile:  true,
 			fileContent: "hooks/",
-			directories: []string{"hooks", "images", "docs"},
+			directories: []string{"hooks", "images", "scripts"},
 			expectedErrors: []string{
 				"Directory 'images/' is not listed in .helmignore",
-				"Directory 'docs/' is not listed in .helmignore",
+				"Directory 'scripts/' is not listed in .helmignore",
 			},
 		},
 		{
@@ -211,10 +211,10 @@ func TestHelmignoreRule_CheckHelmignore(t *testing.T) {
 		{
 			name:        "negated pattern does not count as covered",
 			createFile:  true,
-			fileContent: "!hooks/",
-			directories: []string{"hooks"},
+			fileContent: "!images/",
+			directories: []string{"images"},
 			expectedErrors: []string{
-				"Directory 'hooks/' is not listed in .helmignore",
+				"Directory 'images/' is not listed in .helmignore",
 			},
 		},
 		{
@@ -230,6 +230,25 @@ func TestHelmignoreRule_CheckHelmignore(t *testing.T) {
 			fileContent:    "hooks/",
 			directories:    []string{"hooks", "charts"},
 			expectedErrors: []string{},
+		},
+		{
+			name:           "monitoring directory is skipped (needed in chart)",
+			createFile:     true,
+			fileContent:    ".git/",
+			directories:    []string{"monitoring"},
+			expectedErrors: []string{},
+		},
+		{
+			name:        "only helm rendering dirs are skipped",
+			createFile:  true,
+			fileContent: ".git/",
+			directories: []string{"docs", "crds", "hooks", "monitoring", "openapi", "templates", "charts"},
+			expectedErrors: []string{
+				"Directory 'docs/' is not listed in .helmignore",
+				"Directory 'crds/' is not listed in .helmignore",
+				"Directory 'hooks/' is not listed in .helmignore",
+				"Directory 'openapi/' is not listed in .helmignore",
+			},
 		},
 		{
 			name:           "empty module root only templates",

--- a/pkg/linters/templates/rules/helm_render.go
+++ b/pkg/linters/templates/rules/helm_render.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"github.com/deckhouse/dmt/internal/helm"
+	"github.com/deckhouse/dmt/internal/module"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const HelmRenderRuleName = "helm-render"
+
+func NewHelmRenderRule() *HelmRenderRule {
+	return &HelmRenderRule{
+		RuleMeta: pkg.RuleMeta{Name: HelmRenderRuleName},
+	}
+}
+
+type HelmRenderRule struct {
+	pkg.RuleMeta
+}
+
+// Check renders module templates with nelm and reports any rendering errors.
+// It uses the module's pre-computed render values (from openapi schemas) and
+// reports rendering failures as lint findings via the errorList.
+func (r *HelmRenderRule) Check(m *module.Module, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName())
+
+	renderer := helm.Renderer{
+		Name:             m.GetName(),
+		Namespace:        m.GetNamespace(),
+		LintMode:         true,
+		HelmLibOverrides: module.HelmLibOverrides(),
+	}
+
+	_, err := renderer.RenderChartFromDir(m.GetPath(), m.GetValues())
+	if err != nil {
+		errorList.Errorf("helm render failed: %s", err.Error())
+	}
+}

--- a/pkg/linters/templates/rules/helm_render_test.go
+++ b/pkg/linters/templates/rules/helm_render_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelmRenderRule_Name(t *testing.T) {
+	rule := NewHelmRenderRule()
+	assert.Equal(t, HelmRenderRuleName, rule.GetName())
+}
+
+func TestNewHelmRenderRule(t *testing.T) {
+	rule := NewHelmRenderRule()
+	assert.NotNil(t, rule)
+	assert.IsType(t, &HelmRenderRule{}, rule)
+}

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -108,6 +108,9 @@ func (l *Templates) Run(m *module.Module) {
 
 	// MountPoints rule
 	rules.NewMountPointsRule(l.cfg.ExcludeRules.MountPoints.Get()).ValidateMountPoints(m, errorList.WithMaxLevel(l.cfg.Rules.MountPointsRule.GetLevel()))
+
+	// HelmRender rule
+	rules.NewHelmRenderRule().Check(m, errorList.WithMaxLevel(l.cfg.Rules.HelmRenderRule.GetLevel()))
 }
 
 func (l *Templates) Name() string {

--- a/test/e2e/testdata/module/helmignore-all-covered/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-all-covered/module/.helmignore
@@ -2,3 +2,4 @@ hooks/
 openapi/
 crds/
 docs/
+module.yaml

--- a/test/e2e/testdata/module/helmignore-dir-covered-without-slash/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-dir-covered-without-slash/module/.helmignore
@@ -1,3 +1,4 @@
 hooks
 openapi
 docs
+module.yaml

--- a/test/e2e/testdata/module/helmignore-missing-dir/expected.yaml
+++ b/test/e2e/testdata/module/helmignore-missing-dir/expected.yaml
@@ -1,7 +1,6 @@
 description: >
-  .helmignore only lists hooks/ but the module also has images/ and openapi/
-  directories. module.yaml is excluded (read by Deckhouse directly).
-  The rule must report each uncovered directory.
+  .helmignore lists hooks/ and module.yaml but the module also has images/
+  and openapi/ directories. The rule must report each uncovered directory.
 module: module
 expect:
   - linter: module

--- a/test/e2e/testdata/module/helmignore-missing-dir/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-missing-dir/module/.helmignore
@@ -1,1 +1,2 @@
 hooks/
+module.yaml

--- a/test/e2e/testdata/module/helmignore-multiple-missing/expected.yaml
+++ b/test/e2e/testdata/module/helmignore-multiple-missing/expected.yaml
@@ -1,7 +1,7 @@
 description: >
-  .helmignore only lists hooks/ but the module has images/, docs/, openapi/,
-  crds/ directories. module.yaml is excluded (read by Deckhouse directly).
-  templates/ and charts/ are skipped (module-template).
+  .helmignore lists hooks/ and module.yaml but the module has images/,
+  docs/, openapi/, crds/ directories. templates/ and charts/ are skipped
+  (module-template).
 module: module
 expect:
   - linter: module

--- a/test/e2e/testdata/module/helmignore-multiple-missing/module/.helmignore
+++ b/test/e2e/testdata/module/helmignore-multiple-missing/module/.helmignore
@@ -1,1 +1,2 @@
 hooks/
+module.yaml


### PR DESCRIPTION
## Summary

Refactor the monolithic `internal/helm/render.go` into a pluggable NelmEngine following the d8-package-plugin architecture, and add a configurable `helm-render` rule to the templates linter.

## Changes

| Action | File | Purpose |
|--------|------|---------|
| Create | `internal/helm/engine.go` | `NelmEngine` with DI via `EngineOption` functional options |
| Modify | `internal/helm/render.go` | `Renderer` delegates to `NelmEngine` internally |
| Modify | `pkg/config.go` | `HelmRenderRule` in `TemplatesLinterRules` |
| Modify | `pkg/config/linters_settings.go` | mapstructure type `helm-render` |
| Modify | `pkg/config/global/global.go` | global config field |
| Modify | `internal/module/module.go` | `values` field + `GetValues()` + config wiring |
| Create | `internal/module/helm_overrides.go` | Export `HelmLibOverrides()` for shared use |
| Create | `pkg/linters/templates/rules/helm_render.go` | `HelmRenderRule` with `Check()` |
| Create | `pkg/linters/templates/rules/helm_render_test.go` | Unit tests |
| Modify | `pkg/linters/templates/templates.go` | Register helm-render rule in linter |

## Architecture

```
Before:  Renderer (monolith) -> nelm chart loader/engine
After:   NelmEngine (DI) -> loaded by Rules -> through Linters -> managed by Manager
                              ^
         HelmRenderRule ------+ (pluggable, configurable via .dmt.yaml)
```

## Config

```yaml
# .dmt.yaml
linters-settings:
  templates:
    rules:
      helm-render: warn  # per-rule severity
```

## Verification

- All existing tests pass (internal/helm: 3/3, module, templates rules)
- New `helm_render_test.go` passes
- `go vet` clean on all affected packages
- Full `go test ./internal/... ./pkg/...` passes