### PR TITLE
[dmt] keep array shape for values generated from schema examples

### DIFF
--- a/internal/modules/values/schema/defaults/generator.go
+++ b/internal/modules/values/schema/defaults/generator.go
@@ -148,6 +148,15 @@ func synthesizeDefault(key string, prop *spec.Schema, extension string, result m
 		}
 	}
 
+	// An array property is often illustrated with a single element (one
+	// toleration, one host) instead of a one-element list. Keep the shape the
+	// schema declares: a helper that renders the value with toYaml would
+	// otherwise emit a map where the chart appends list items, producing
+	// invalid YAML.
+	if prop.Type.Contains(arrayObject) {
+		def = asList(def)
+	}
+
 	ex, ok := def.(map[string]any)
 	if !ok {
 		result[key] = def
@@ -172,6 +181,17 @@ func synthesizeDefault(key string, prop *spec.Schema, extension string, result m
 	result[key] = def
 
 	return nil
+}
+
+// asList returns v unchanged when it already is a list, and wraps it into a
+// one-element list otherwise.
+func asList(v any) any {
+	switch v.(type) {
+	case []any, []map[string]any:
+		return v
+	default:
+		return []any{v}
+	}
 }
 
 // pickExample chooses which x-examples entry to render. x-examples is a list of

--- a/internal/modules/values/schema/defaults/generator_test.go
+++ b/internal/modules/values/schema/defaults/generator_test.go
@@ -449,6 +449,69 @@ func Test_synthesizeProperties(t *testing.T) {
 			want:    map[string]any{"tenantName": "a"},
 			wantErr: false,
 		},
+		{
+			name: "array example given as a single object stays a list",
+			schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"tolerations": {
+							SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"array"}},
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									examplesDefault: []any{
+										map[string]any{"key": "key1", "operator": "Equal"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]any{
+				"tolerations": []any{map[string]any{"key": "key1", "operator": "Equal"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "array example given as a bare scalar stays a list",
+			schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"hosts": {
+							SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"array"}},
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									examplesDefault: []any{"example.com"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    map[string]any{"hosts": []any{"example.com"}},
+			wantErr: false,
+		},
+		{
+			name: "array example already given as a list is kept as is",
+			schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"hosts": {
+							SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"array"}},
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									examplesDefault: []any{
+										[]any{"a.example.com", "b.example.com"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    map[string]any{"hosts": []any{"a.example.com", "b.example.com"}},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Values generated from an openapi schema now keep the array shape the schema declares.

## Problem

A module may illustrate an array property with a single element rather than a one-element list:

```yaml
tolerations:
  type: array
  x-examples:
    - key: key1
      operator: Equal
```

The generator took that example verbatim, so `tolerations` became a map. `helm_lib_tolerations` renders the value with `toYaml` and then appends its own list items, which produced map keys followed by sequence items — invalid YAML. Strict rendering fails the whole module with `non-map value is specified`, pointing at the rendered manifest (not the template), and at whichever manifest is parsed first, so the reported file varies between runs.

The same applies to an array of strings illustrated with a bare scalar: the value became a string and any `range` over it failed.

## Fix

When the property is typed as an array, the generated value is wrapped into a list unless it already is one. A value that is already a list is left untouched.

## Tests

Unit cases for the generator cover the three inputs the normalization distinguishes: an object example, a scalar example, and an example that already is a list (which must be left untouched).

