### PR TITLE
[dmt] add docs size check and fix weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ release-build
 dist
 /dmt
 /bin
+/build
 # Ignore Go coverage output
 coverage.out
 coverage.svg

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -324,6 +324,10 @@ func mapDocumentationRules(linterSettings *pkg.LintersSettings, configSettings *
 	// intentionally NOT used as the fallback here — only an explicit rule-level
 	// markdownlint impact overrides the warn default.
 	rules.MarkdownlintRule.SetLevel(globalRules.MarkdownlintRule.Impact, pkg.Warn.String())
+	// size, like markdownlint, defaults to warn (non-fatal): the linter-level
+	// impact (fallbackImpact) is intentionally NOT used as the fallback here, so
+	// only an explicit rule-level size impact overrides the warn default.
+	rules.SizeRule.SetLevel(globalRules.SizeRule.Impact, pkg.Warn.String())
 }
 
 func mapModuleRules(linterSettings *pkg.LintersSettings, configSettings *config.LintersSettings, globalConfig *global.Linters) {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -88,6 +88,7 @@ type DocumentationLinterRules struct {
 	CyrillicInEnglishRule RuleConfig
 	NoLangKeyRule         RuleConfig
 	MarkdownlintRule      RuleConfig
+	SizeRule              RuleConfig
 }
 
 type NoCyrillicLinterConfig struct {

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -97,6 +97,7 @@ type DocumentationRules struct {
 	NoCyrillicExcludeRules RuleConfig `mapstructure:"cyrillic-in-english"`
 	NoLangKeyRule          RuleConfig `mapstructure:"no-lang-key"`
 	MarkdownlintRule       RuleConfig `mapstructure:"markdownlint"`
+	SizeRule               RuleConfig `mapstructure:"size"`
 }
 
 type OpenAPILinterConfig struct {

--- a/pkg/linters/docs/README.md
+++ b/pkg/linters/docs/README.md
@@ -15,6 +15,7 @@ Proper documentation is critical for Deckhouse modules as it helps users underst
 | [cyrillic-in-english](#cyrillic-in-english) | Validates English documentation doesn't contain cyrillic characters | ✅ | enabled |
 | [no-lang-key](#no-lang-key) | Validates documentation front matter doesn't contain `lang` key | ✅ | enabled |
 | [markdownlint](#markdownlint) | Validates markdown files in docs/ follow deckhouse markdown style | ✅ | enabled |
+| [size](#size) | Validates the total size of docs/ (excluding docs/internal) does not exceed 15 MB | ✅ | enabled |
 
 "Configurable" means that this rule can be configured using the `.dmtlint.yaml` file, including customizing the rule's parameters and/or disabling the rule.
 
@@ -508,6 +509,70 @@ linters-settings:
       markdownlint:
         impact: error  # fail the run on violations (default is warn)
         # impact: ignored   # disable the rule entirely
+```
+
+---
+
+### size
+
+**Purpose:** Keeps the rendered documentation lightweight by ensuring the total size of the `docs/` directory stays within a 15 MB budget. Oversized documentation usually signals binary assets (large images, videos, archives) that bloat the module artifact and slow down cloning and distribution.
+
+**Description:**
+
+This rule walks the `docs/` directory recursively, sums the size of every file and reports a violation when the total exceeds **15 MB**. The `docs/internal/` subtree is excluded on purpose: it holds content that is not rendered as documentation, so it does not count towards the limit. Every other subfolder is scanned.
+
+Like `markdownlint`, this rule reports at `warn` **by default** — an oversized `docs/` directory is flagged but does not fail the run. The 15 MB limit is fixed and not configurable; only the rule's impact level can be changed.
+
+**What it checks:**
+
+1. Recursively walks the `docs/` directory and sums the size of every file, skipping the `docs/internal/` subtree
+2. Reports a violation (at `warn` by default) when the combined size exceeds 15 MB
+
+**Why it matters:**
+
+Documentation is meant to be text-first. Large binary assets committed under `docs/` inflate the repository and the resulting module artifact, making distribution slower and more expensive. Keeping `docs/` under a fixed budget encourages hosting heavy assets elsewhere (e.g. an external CDN) and linking to them instead.
+
+**Examples:**
+
+❌ **Incorrect** - Heavy binary asset directly under docs/:
+
+```
+my-module/
+└── docs/
+    ├── README.md
+    └── demo.mp4                  # 40 MB screencast at the top level → exceeds the limit
+```
+
+**Error:**
+```
+docs/ directory size exceeds the limit of 15.0 MB
+File: docs/
+Value: 41.2 MB
+```
+
+✅ **Correct** - Rendered docs stay light; non-rendered assets live under docs/internal/:
+
+```
+my-module/
+└── docs/
+    ├── README.md                 # links to the screencast hosted on a CDN
+    ├── README.ru.md
+    ├── guides/                   # regular subfolder → scanned and counted
+    │   └── setup.md
+    └── internal/                 # excluded from the size budget (not rendered)
+        └── data.bin
+```
+
+**Configuration:**
+
+The `size` rule reports at `warn` by default. Only the impact level is configurable — set it to `error` to make an oversized `docs/` fatal, or to `ignored` to disable the rule entirely:
+```yaml
+# .dmtlint.yaml
+linters-settings:
+  documentation:
+    rules:
+      size:
+        impact: warn   # report but do not fail the run (this is the default)
 ```
 
 ---

--- a/pkg/linters/docs/documentation.go
+++ b/pkg/linters/docs/documentation.go
@@ -46,6 +46,8 @@ func (l *Documentation) Run(m *modules.Module) {
 	rules.NewNoLangKeyRule().CheckFiles(m, errorList.WithMaxLevel(l.cfg.Rules.NoLangKeyRule.GetLevel()))
 
 	rules.NewMarkdownRule().CheckFiles(m, errorList.WithMaxLevel(l.cfg.Rules.MarkdownlintRule.GetLevel()))
+
+	rules.NewSizeRule().CheckSize(m, errorList.WithMaxLevel(l.cfg.Rules.SizeRule.GetLevel()))
 }
 
 func (l *Documentation) Name() string {

--- a/pkg/linters/docs/rules/size.go
+++ b/pkg/linters/docs/rules/size.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Flant JSC
+// Licensed under the Apache License, Version 2.0
+
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	SizeRuleName = "size"
+
+	// maxDocsSizeBytes is the maximum allowed total size of the documentation
+	// files under the docs/ directory, excluding the docs/internal subtree.
+	maxDocsSizeBytes = 15 * 1024 * 1024 // 15 MB
+
+	// internalDirName is the docs/ subdirectory that holds content which is not
+	// rendered as documentation and is therefore excluded from the size budget.
+	internalDirName = "internal"
+)
+
+func NewSizeRule() *SizeRule {
+	return &SizeRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: SizeRuleName,
+		},
+	}
+}
+
+type SizeRule struct {
+	pkg.RuleMeta
+}
+
+// CheckSize sums the size of the documentation files under the docs/ directory
+// and reports an error when the total exceeds maxDocsSizeBytes. The docs/internal
+// subtree is skipped on purpose: it holds content that is not rendered as
+// documentation, so it must not count towards the limit. Every other subfolder is
+// scanned recursively. Oversized docs bloat the module artifact and usually
+// signal binary assets that don't belong there.
+func (r *SizeRule) CheckSize(m pkg.Module, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName())
+
+	modulePath := m.GetPath()
+	if modulePath == "" {
+		return
+	}
+
+	docsPath := filepath.Join(modulePath, "docs")
+	if _, err := os.Stat(docsPath); err != nil {
+		return
+	}
+
+	internalPath := filepath.Join(docsPath, internalDirName)
+
+	var total int64
+
+	err := filepath.WalkDir(docsPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if path == internalPath {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		total += info.Size()
+
+		return nil
+	})
+	if err != nil {
+		errorList.
+			WithFilePath(docsPath).
+			WithValue(err.Error()).
+			Error("failed to calculate docs/ directory size")
+
+		return
+	}
+
+	if total > maxDocsSizeBytes {
+		errorList.
+			WithFilePath(docsPath).
+			WithValue(formatBytes(total)).
+			Errorf("docs/ directory size exceeds the limit of %s", formatBytes(maxDocsSizeBytes))
+	}
+}
+
+// formatBytes renders a byte count as a human-readable string (e.g. "12.3 MB").
+func formatBytes(size int64) string {
+	const unit = 1024
+
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+
+	div, exp := int64(unit), 0
+	for n := size / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f %cB", float64(size)/float64(div), "KMGTPE"[exp])
+}

--- a/pkg/linters/docs/rules/size_test.go
+++ b/pkg/linters/docs/rules/size_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Flant JSC
+// Licensed under the Apache License, Version 2.0
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/dmt/internal/mocks"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+func TestNewSizeRule(t *testing.T) {
+	rule := NewSizeRule()
+	assert.Equal(t, SizeRuleName, rule.GetName())
+	assert.Equal(t, "size", rule.GetName())
+}
+
+// writeSparseFile creates a file of the requested logical size without actually
+// writing the bytes, so the size rule sees a large docs/ directory cheaply.
+func writeSparseFile(t *testing.T, path string, size int64) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(size))
+	require.NoError(t, f.Close())
+}
+
+func TestSizeRule_CheckSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     map[string]int64 // path relative to module root -> size in bytes
+		noDocsDir bool
+		wantError bool
+	}{
+		{
+			name:      "no docs directory is skipped",
+			noDocsDir: true,
+			wantError: false,
+		},
+		{
+			name:      "small docs directory passes",
+			files:     map[string]int64{"docs/README.md": 1024},
+			wantError: false,
+		},
+		{
+			name:      "docs exactly at the limit passes",
+			files:     map[string]int64{"docs/README.md": maxDocsSizeBytes},
+			wantError: false,
+		},
+		{
+			name:      "single oversized file fails",
+			files:     map[string]int64{"docs/big.png": maxDocsSizeBytes + 1},
+			wantError: true,
+		},
+		{
+			name: "sum across files and non-internal subfolders exceeds the limit",
+			files: map[string]int64{
+				"docs/README.md":       8 * 1024 * 1024,
+				"docs/guides/setup.md": 8 * 1024 * 1024,
+			},
+			wantError: true,
+		},
+		{
+			name: "large file in a non-internal subfolder fails",
+			files: map[string]int64{
+				"docs/guides/big.png": maxDocsSizeBytes + 1,
+			},
+			wantError: true,
+		},
+		{
+			name: "docs/internal subtree is ignored",
+			files: map[string]int64{
+				"docs/README.md":         1024,
+				"docs/internal/data.bin": maxDocsSizeBytes + 1,
+			},
+			wantError: false,
+		},
+		{
+			name: "only the top-level docs/internal is excluded",
+			files: map[string]int64{
+				"docs/guides/internal/data.bin": maxDocsSizeBytes + 1,
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := minimock.NewController(t)
+			mockModule := mocks.NewModuleMock(mc)
+
+			tempDir := t.TempDir()
+			mockModule.GetPathMock.Return(tempDir)
+
+			if !tt.noDocsDir {
+				require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "docs"), 0o755))
+			}
+
+			for relPath, size := range tt.files {
+				writeSparseFile(t, filepath.Join(tempDir, relPath), size)
+			}
+
+			rule := NewSizeRule()
+			errorList := errors.NewLintRuleErrorsList()
+
+			rule.CheckSize(mockModule, errorList)
+
+			if tt.wantError {
+				assert.NotEmpty(t, errorList.GetErrors(), "expected an error for oversized docs/ directory")
+			} else {
+				assert.Empty(t, errorList.GetErrors(), "expected no error for docs/ directory within the limit")
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		size int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{10 * 1024 * 1024, "10.0 MB"},
+		{maxDocsSizeBytes + 1, "15.0 MB"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, formatBytes(tt.size))
+	}
+}

--- a/pkg/linters/module/README.md
+++ b/pkg/linters/module/README.md
@@ -426,6 +426,17 @@ This rule automatically detects feature usage and ensures proper version constra
 | **Module-SDK ≥ 0.3** | ≥ 1.71.0 | `module-sdk ≥ 0.3.0` in `go.mod` |
 | **Optional Modules** | ≥ 1.73.0 | `!optional` flag in module requirements |
 
+#### Module Weight
+
+The `weight` field for non-critical modules is validated against the Deckhouse **1.72.0** boundary:
+
+| Module supports | `weight` rule | Check |
+|-----------------|---------------|-------|
+| Deckhouse `< 1.72` (constraint lower bound below 1.72, e.g. `>= 1.68`) | **Required**, must be between **900 and 999** | `weight_required` |
+| Deckhouse `>= 1.72` only (constraint lower bound `>= 1.72`) | Must be **removed** | `weight_deprecated` |
+
+Rationale: on Deckhouse `< 1.72` the platform itself rejects an external module whose weight is outside 900–999 (`external module weight must be between 900 and 999`); from 1.72 the weight is assigned automatically for non-critical modules, so a leftover `weight` must be removed. `critical` modules are exempt from both checks — a critical module only needs a non-zero `weight` (see the [definition-file](#definition-file) rule). `weight_required` applies only when `requirements.deckhouse` is set.
+
 **Validation:**
 - ✅ Minimum version constraints are declared
 - ✅ Version format is valid (semver)
@@ -458,6 +469,8 @@ requirements:
 ❌ Module uses stage field but requirements.deckhouse is not specified
 ❌ requirements.deckhouse version should be >= 1.68.0 (found: >= 1.60.0)
 ❌ Invalid version constraint: "not-a-version"
+❌ requirements [weight_required]: external module weight must be between 900 and 999 for non-critical modules that support Deckhouse < 1.72.0
+❌ requirements [weight_deprecated]: weight must be removed for non-critical modules when Deckhouse >= 1.72.0
 ```
 
 ---

--- a/pkg/linters/module/rules/requirements.go
+++ b/pkg/linters/module/rules/requirements.go
@@ -53,6 +53,14 @@ const (
 	// MinimalDeckhouseVersionForBootstrappedDeprecation defines the version where bootstrapped was deprecated
 	MinimalDeckhouseVersionForBootstrappedDeprecation = "1.72.0"
 
+	// ExternalModuleWeightMin and ExternalModuleWeightMax bound the weight that
+	// Deckhouse requires for external (non-critical) modules on versions where
+	// weight is still meaningful (< MinimalDeckhouseVersionForWeightDeprecation).
+	// Those versions reject an out-of-range weight with
+	// "external module weight must be between 900 and 999".
+	ExternalModuleWeightMin uint32 = 900
+	ExternalModuleWeightMax uint32 = 999
+
 	// Common patterns used in Go files
 	AppRunPattern = `\w+\.Run\(`
 )
@@ -196,6 +204,25 @@ func NewRequirementsRegistry() *RequirementsRegistry {
 				module.Weight > 0 &&
 				!module.Critical &&
 				deckhouseVersionAtLeast(module, MinimalDeckhouseVersionForWeightDeprecation)
+		},
+	})
+
+	// Weight required check - the counterpart of weight_deprecated. While a
+	// non-critical module can still run on Deckhouse < 1.72, weight is mandatory
+	// and must be in the 900-999 range; Deckhouse itself rejects anything else on
+	// those versions ("external module weight must be between 900 and 999"). A
+	// module without requirements.deckhouse is out of scope here (it is expected to
+	// always be pinned), consistent with the other version-gated checks above.
+	registry.RegisterCheck(RequirementCheck{
+		Name:        "weight_required",
+		Description: "external module weight must be between 900 and 999 for non-critical modules that support Deckhouse < " + MinimalDeckhouseVersionForWeightDeprecation,
+		Detector: func(_ string, module *DeckhouseModule) bool {
+			return module != nil &&
+				!module.Critical &&
+				module.Requirements != nil &&
+				module.Requirements.Deckhouse != "" &&
+				!deckhouseVersionAtLeast(module, MinimalDeckhouseVersionForWeightDeprecation) &&
+				(module.Weight < ExternalModuleWeightMin || module.Weight > ExternalModuleWeightMax)
 		},
 	})
 

--- a/pkg/linters/module/rules/requirements_edge_cases_test.go
+++ b/pkg/linters/module/rules/requirements_edge_cases_test.go
@@ -693,6 +693,7 @@ func TestBootstrappedDeprecationCheck(t *testing.T) {
 				Name:      "test-module",
 				Namespace: "test",
 				Stage:     "Experimental",
+				Weight:    950,
 				Requirements: &ModuleRequirements{
 					ModulePlatformRequirements: ModulePlatformRequirements{
 						Deckhouse:    ">= 1.71.0",
@@ -872,6 +873,171 @@ func TestWeightDeprecationCheck(t *testing.T) {
 	}
 }
 
+func TestWeightRequiredCheck(t *testing.T) {
+	helper := NewTestHelper(t)
+
+	const weightRequiredErr = "requirements [weight_required]: external module weight must be between 900 and 999 for non-critical modules that support Deckhouse < 1.72.0"
+
+	tests := []struct {
+		name           string
+		module         *DeckhouseModule
+		expectedErrors []string
+		description    string
+	}{
+		{
+			name: "deckhouse >= 1.68 non-critical without weight - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.68.0",
+					},
+				},
+			},
+			expectedErrors: []string{weightRequiredErr},
+			description:    "Should error when a module supporting Deckhouse < 1.72 has no weight",
+		},
+		{
+			name: "deckhouse >= 1.68 non-critical with valid weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    950,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.68.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Should not error when weight is within 900-999",
+		},
+		{
+			name: "deckhouse >= 1.68 non-critical with out-of-range weight - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    500,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.68.0",
+					},
+				},
+			},
+			expectedErrors: []string{weightRequiredErr},
+			description:    "Should error when weight is set but outside 900-999",
+		},
+		{
+			name: "weight at lower bound 900 - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    900,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.71.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "900 is inside the allowed range",
+		},
+		{
+			name: "weight at upper bound 999 - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    999,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.71.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "999 is inside the allowed range",
+		},
+		{
+			name: "weight just below range 899 - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    899,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.71.0",
+					},
+				},
+			},
+			expectedErrors: []string{weightRequiredErr},
+			description:    "899 is just below the allowed range",
+		},
+		{
+			name: "weight just above range 1000 - error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Weight:    1000,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.71.0",
+					},
+				},
+			},
+			expectedErrors: []string{weightRequiredErr},
+			description:    "1000 is just above the allowed range",
+		},
+		{
+			name: "deckhouse >= 1.72 non-critical without weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.72.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Weight is not required once the module only supports Deckhouse >= 1.72",
+		},
+		{
+			name: "critical module without weight - no weight_required error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+				Critical:  true,
+				Requirements: &ModuleRequirements{
+					ModulePlatformRequirements: ModulePlatformRequirements{
+						Deckhouse: ">= 1.68.0",
+					},
+				},
+			},
+			expectedErrors: []string{},
+			description:    "weight_required ignores critical modules (zero weight for critical is a separate check)",
+		},
+		{
+			name: "no deckhouse requirement without weight - no error",
+			module: &DeckhouseModule{
+				Name:      "test-module",
+				Namespace: "test",
+			},
+			expectedErrors: []string{},
+			description:    "Out of scope when requirements.deckhouse is not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			registry := NewRequirementsRegistry()
+			errorList := errors.NewLintRuleErrorsList()
+			registry.RunAllChecks("", tt.module, errorList)
+			helper.AssertErrors(errorList, tt.expectedErrors)
+		})
+	}
+}
+
 func TestOptionalModulesRequirementCheck(t *testing.T) {
 	helper := NewTestHelper(t)
 
@@ -934,6 +1100,7 @@ func TestOptionalModulesRequirementCheck(t *testing.T) {
 			module: &DeckhouseModule{
 				Name:      "test-module",
 				Namespace: "test",
+				Weight:    950,
 				Requirements: &ModuleRequirements{
 					ModulePlatformRequirements: ModulePlatformRequirements{
 						Deckhouse: ">= 1.70.0",

--- a/test/e2e/testdata/module/disable-message-fallback/module/module.yaml
+++ b/test/e2e/testdata/module/disable-message-fallback/module/module.yaml
@@ -4,6 +4,7 @@ stage: Experimental
 descriptions:
   en: "Module used to verify the disable.message fallback warning"
   ru: "Модуль для проверки предупреждения о fallback disable.message"
+weight: 910
 requirements:
   deckhouse: ">= 1.60"
 disable:

--- a/test/e2e/testdata/module/enabled-script-deprecated/module/module.yaml
+++ b/test/e2e/testdata/module/enabled-script-deprecated/module/module.yaml
@@ -1,6 +1,7 @@
 name: enabled-script-deprecated
 namespace: d8-enabled-script-deprecated
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/enabled-script-empty/module/module.yaml
+++ b/test/e2e/testdata/module/enabled-script-empty/module/module.yaml
@@ -1,6 +1,7 @@
 name: enabled-script-empty
 namespace: d8-enabled-script-empty
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/helmignore-all-covered/module/module.yaml
+++ b/test/e2e/testdata/module/helmignore-all-covered/module/module.yaml
@@ -1,6 +1,7 @@
 name: helmignore-covered
 namespace: d8-helmignore-covered
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/helmignore-dir-covered-without-slash/module/module.yaml
+++ b/test/e2e/testdata/module/helmignore-dir-covered-without-slash/module/module.yaml
@@ -1,6 +1,7 @@
 name: helmignore-no-slash
 namespace: d8-helmignore-no-slash
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/helmignore-missing-dir/module/module.yaml
+++ b/test/e2e/testdata/module/helmignore-missing-dir/module/module.yaml
@@ -1,6 +1,7 @@
 name: helmignore-missing
 namespace: d8-helmignore-missing
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/helmignore-multiple-missing/module/module.yaml
+++ b/test/e2e/testdata/module/helmignore-multiple-missing/module/module.yaml
@@ -1,6 +1,7 @@
 name: helmignore-multi-miss
 namespace: d8-helmignore-multi-miss
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/oss-version-not-semver-excluded/module/module.yaml
+++ b/test/e2e/testdata/module/oss-version-not-semver-excluded/module/module.yaml
@@ -1,6 +1,7 @@
 name: oss-semver
 namespace: d8-oss-semver
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/oss-version-not-semver/module/module.yaml
+++ b/test/e2e/testdata/module/oss-version-not-semver/module/module.yaml
@@ -1,6 +1,7 @@
 name: oss-semver
 namespace: d8-oss-semver
 stage: General Availability
+weight: 910
 requirements:
   deckhouse: ">= 1.68.0"
 descriptions:

--- a/test/e2e/testdata/module/package-consistency-fix/module/module.yaml
+++ b/test/e2e/testdata/module/package-consistency-fix/module/module.yaml
@@ -1,5 +1,6 @@
 name: wrong-name
 namespace: e2e
+weight: 910
 requirements:
   deckhouse: ">=0.0.0"
   modules:

--- a/test/e2e/testdata/module/weight-deprecated/expected.yaml
+++ b/test/e2e/testdata/module/weight-deprecated/expected.yaml
@@ -1,0 +1,15 @@
+description: >
+  From Deckhouse 1.72 weight is assigned automatically for non-critical modules, so a
+  module pinned to ">= 1.72" that still declares weight must remove it. The module
+  linter reports the requirements weight_deprecated check as an error, and no
+  weight_required finding is produced (weight is not required at >= 1.72).
+module: module
+expect:
+  - linter: module
+    rule: requirements
+    level: error
+    textContains: "weight must be removed for non-critical modules when Deckhouse >= 1.72.0"
+expectAbsent:
+  - linter: module
+    rule: requirements
+    textContains: "must be between 900 and 999"

--- a/test/e2e/testdata/module/weight-deprecated/module/module.yaml
+++ b/test/e2e/testdata/module/weight-deprecated/module/module.yaml
@@ -1,0 +1,9 @@
+name: e2e-module-weight-deprecated
+namespace: e2e-module-weight-deprecated
+stage: Experimental
+weight: 910
+descriptions:
+  en: "Module used to verify the weight-deprecated lint (weight on Deckhouse >= 1.72)"
+  ru: "Модуль для проверки правила weight-deprecated (вес при Deckhouse >= 1.72)"
+requirements:
+  deckhouse: ">= 1.72"

--- a/test/e2e/testdata/module/weight-deprecated/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/module/weight-deprecated/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/module/weight-deprecated/module/openapi/values.yaml
+++ b/test/e2e/testdata/module/weight-deprecated/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/module/weight-required-missing/expected.yaml
+++ b/test/e2e/testdata/module/weight-required-missing/expected.yaml
@@ -1,0 +1,12 @@
+description: >
+  A non-critical module that still supports Deckhouse < 1.72 (requirements.deckhouse
+  ">= 1.68") must declare weight in the 900-999 range. With weight omitted the module
+  linter reports the requirements weight_required check as an error, mirroring the
+  platform's own "external module weight must be between 900 and 999" validation on
+  Deckhouse < 1.72.
+module: module
+expect:
+  - linter: module
+    rule: requirements
+    level: error
+    textContains: "external module weight must be between 900 and 999"

--- a/test/e2e/testdata/module/weight-required-missing/module/module.yaml
+++ b/test/e2e/testdata/module/weight-required-missing/module/module.yaml
@@ -1,0 +1,8 @@
+name: e2e-module-weight-required-missing
+namespace: e2e-module-weight-required-missing
+stage: Experimental
+descriptions:
+  en: "Module used to verify the weight-required lint (weight missing)"
+  ru: "Модуль для проверки правила weight-required (вес отсутствует)"
+requirements:
+  deckhouse: ">= 1.68"

--- a/test/e2e/testdata/module/weight-required-missing/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/module/weight-required-missing/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/module/weight-required-missing/module/openapi/values.yaml
+++ b/test/e2e/testdata/module/weight-required-missing/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/module/weight-required-valid/expected.yaml
+++ b/test/e2e/testdata/module/weight-required-valid/expected.yaml
@@ -1,0 +1,9 @@
+description: >
+  A non-critical module supporting Deckhouse < 1.72 with weight inside the 900-999
+  range is accepted: the requirements linter emits no weight-related finding (neither
+  weight_required nor weight_deprecated).
+module: module
+expectAbsent:
+  - linter: module
+    rule: requirements
+    textContains: "weight"

--- a/test/e2e/testdata/module/weight-required-valid/module/module.yaml
+++ b/test/e2e/testdata/module/weight-required-valid/module/module.yaml
@@ -1,0 +1,9 @@
+name: e2e-module-weight-required-valid
+namespace: e2e-module-weight-required-valid
+stage: Experimental
+weight: 910
+descriptions:
+  en: "Module used to verify the weight-required lint (valid weight)"
+  ru: "Модуль для проверки правила weight-required (валидный вес)"
+requirements:
+  deckhouse: ">= 1.68"

--- a/test/e2e/testdata/module/weight-required-valid/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/module/weight-required-valid/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/module/weight-required-valid/module/openapi/values.yaml
+++ b/test/e2e/testdata/module/weight-required-valid/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}


### PR DESCRIPTION

### Summary

Adds two new linter checks and documents them:

1. A **`size`** rule in the **documentation** linter that keeps the rendered `docs/` directory within a fixed 15 MB budget.
2. A **`weight_required`** check in the **module** linter — the counterpart of the existing `weight_deprecated` check — that enforces the `900–999` weight range Deckhouse requires for non-critical modules supporting Deckhouse `< 1.72`.

---

### 1. Documentation linter: `size` rule

A new `size` rule ([`pkg/linters/docs/rules/size.go`](pkg/linters/docs/rules/size.go)) recursively walks the module's `docs/` directory, sums the size of every file, and reports a violation when the total exceeds **15 MB**. Oversized documentation usually signals binary assets (images, videos, archives) that bloat the module artifact and slow down cloning and distribution.

- The top-level **`docs/internal/`** subtree is excluded on purpose — it is not rendered as documentation, so it does not count toward the limit. Every other subfolder is scanned.
- The rule reports at **`warn` by default** (non-fatal), consistent with `markdownlint`: the linter-level fallback impact is intentionally not used, so only an explicit rule-level impact overrides the warn default.
- The 15 MB limit is **fixed and not configurable**; only the rule's impact level can be changed (`warn` / `error` / `ignored`).
- A missing `docs/` directory is skipped silently.

**Wiring:**
- `SizeRule` config field added to [`pkg/config.go`](pkg/config.go) and [`pkg/config/global/global.go`](pkg/config/global/global.go) (`mapstructure:"size"`).
- Default level set to `warn` in [`internal/modules/module.go`](internal/modules/module.go).
- Rule invoked from [`pkg/linters/docs/documentation.go`](pkg/linters/docs/documentation.go).
- Documented in [`pkg/linters/docs/README.md`](pkg/linters/docs/README.md).

### 2. Module linter: `weight_required` check

A new `weight_required` requirement check ([`pkg/linters/module/rules/requirements.go`](pkg/linters/module/rules/requirements.go)) complements the existing `weight_deprecated` check around the Deckhouse **1.72.0** boundary:

| Module supports | `weight` rule | Check |
|-----------------|---------------|-------|
| Deckhouse `< 1.72` (constraint lower bound below 1.72) | **Required**, must be `900–999` | `weight_required` |
| Deckhouse `>= 1.72` only | Must be **removed** | `weight_deprecated` |

Rationale: on Deckhouse `< 1.72` the platform itself rejects an external module whose weight is outside 900–999 (`external module weight must be between 900 and 999`); from 1.72 the weight is assigned automatically for non-critical modules.

- Applies only to **non-critical** modules that declare `requirements.deckhouse` with a lower bound below `1.72.0`.
- `critical` modules are exempt; modules without `requirements.deckhouse` are out of scope (consistent with the other version-gated checks).
- Adds `ExternalModuleWeightMin` (900) and `ExternalModuleWeightMax` (999) constants.
- Documented in [`pkg/linters/module/README.md`](pkg/linters/module/README.md).
