### PR TITLE
[dmt] add error handling for failed templates. enrich enabled modules with common

### DIFF
--- a/internal/modules/render.go
+++ b/internal/modules/render.go
@@ -32,17 +32,23 @@ import (
 	dmtErrors "github.com/deckhouse/dmt/pkg/errors"
 )
 
-// RunRender strictly renders the module's chart through nelm's public
-// action.ChartRender and stores the resulting objects for the linters. Strict
-// rendering mirrors how deckhouse-controller installs the module: a template error
-// fails the whole render, so the module is reported rather than half-linted. Image
-// references resolve from dmt's value stubs (global.modulesImages, scanned from
-// images/).
+// RunRender renders the module's chart through nelm's public action.ChartRender
+// and stores the resulting objects for the linters. The render is tolerant per
+// template (see render.Render): a template that aborts — an intentional `fail`, or
+// a `required` on a value dmt cannot supply offline — is dropped and reported as a
+// non-fatal warning, so the rest of the chart is still stored and linted. Only a
+// render error that cannot be localized to a droppable template fails module
+// creation. Image references resolve from dmt's value stubs (global.modulesImages,
+// scanned from images/).
 func RunRender(m *Module, vals chartutil.Values, objectStore *storage.UnstructuredObjectStore, errorList *dmtErrors.LintRuleErrorsList) error {
 	objects, err := render.Render(context.Background(), m.GetNamespace(), m.GetName(), render.Options{
 		Path:             m.GetPath(),
 		Values:           vals,
 		ExtraAPIVersions: render.ExtraAPIVersions(),
+		OnDrop: func(templatePath, cause string) {
+			errorList.WithModule(m.GetName()).WithFilePath(templatePath).WithValue(cause).
+				Warnf("template %q failed to render and was skipped; the rest of the chart was still linted", templatePath)
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("helm chart render: %w", err)

--- a/internal/modules/render/render.go
+++ b/internal/modules/render/render.go
@@ -22,7 +22,11 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
+	"log/slog"
 	"os"
+	"path"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/werf/nelm/pkg/action"
@@ -30,6 +34,8 @@ import (
 	"github.com/werf/nelm/pkg/helm/pkg/chart/loader"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 func init() {
@@ -71,17 +77,31 @@ type Options struct {
 	// ExtraAPIVersions extends .Capabilities.APIVersions (e.g. VPA, cert-manager,
 	// gateway kinds) so templates gating on them render offline.
 	ExtraAPIVersions []string
+	// OnDrop, if set, is called once for each template the tolerant render had to
+	// neutralize to make the chart render: templatePath is the chart-relative path
+	// (e.g. "templates/postgres.yaml") and renderErr is the abort that caused the
+	// drop. Linting callers use it to surface a warning; others may leave it nil.
+	OnDrop func(templatePath, renderErr string)
 }
 
 // Render renders the chart at opts.Path with nelm's public action.ChartRender,
-// offline (no cluster) and strictly: the first template error aborts the render.
-// This is the same public entrypoint deckhouse-controller and d8-package-plugin use,
-// so dmt renders modules the way they are actually installed. nelm parses the
-// manifests, so callers get []Object and need no manifest splitting.
+// offline (no cluster). This is the same public entrypoint deckhouse-controller
+// and d8-package-plugin use, so dmt renders modules the way they are actually
+// installed. nelm parses the manifests, so callers get []Object and need no
+// manifest splitting.
 //
 // Before rendering it injects an image-resolution override (see injectImageStub) so
 // image names dmt cannot know offline — werf-computed names, werf-defined aliases —
 // still resolve instead of aborting the render, and removes it again afterwards.
+//
+// The render is tolerant per template. A single manifest template that aborts the
+// render — an intentional `fail`, or a `required` on a value dmt cannot supply
+// offline — would otherwise abort the WHOLE chart and hide every other resource
+// from the linters. Instead Render neutralizes just that one template and
+// re-renders, so the remaining resources are still returned and linted; every
+// neutralized template is restored before Render returns. An error that cannot be
+// localized to a droppable manifest template (a failing partial, a values/schema
+// error) is a genuine render failure and is surfaced to the caller.
 func Render(ctx context.Context, namespace, releaseName string, opts Options) ([]Object, error) {
 	if releaseName == "" {
 		return nil, fmt.Errorf("helm chart must have a name")
@@ -99,9 +119,34 @@ func Render(ctx context.Context, namespace, releaseName string, opts Options) ([
 	}
 	defer cleanup()
 
-	res, err := renderChart(ctx, namespace, releaseName, valuesFile, opts)
-	if err != nil {
-		return nil, err
+	// Neutralized templates are restored once the render loop settles.
+	neutralizer := newTemplateNeutralizer(opts.Path)
+	defer neutralizer.restore()
+
+	var res *action.ChartRenderResultV2
+
+	for {
+		var renderErr error
+
+		res, renderErr = renderChart(ctx, namespace, releaseName, valuesFile, opts)
+		if renderErr == nil {
+			break
+		}
+
+		// Localize the failure to a droppable manifest template and blank just that
+		// one, then re-render the rest. Give up (surface the error) when the failure
+		// is not a droppable template or that template was already neutralized.
+		rel := failingManifestTemplate(renderErr)
+		if rel == "" || !neutralizer.neutralize(rel) {
+			return nil, renderErr
+		}
+
+		if opts.OnDrop != nil {
+			opts.OnDrop(rel, renderErr.Error())
+		}
+
+		log.Debug("dmt: template failed to render; dropping it and continuing with the rest of the chart",
+			slog.String("chart", releaseName), slog.String("template", rel), log.Err(renderErr))
 	}
 
 	objects := make([]Object, 0, len(res.Resources))
@@ -179,4 +224,101 @@ func writeTempValues(values map[string]any) (string, func(), error) {
 	}
 
 	return f.Name(), cleanup, nil
+}
+
+// failingTemplateRe extracts the chart-relative template path from a nelm render
+// error. nelm formats a template execution failure as
+//
+//	... execution error at (<chart-name>/templates/foo.yaml:LINE:COL): <message>
+//
+// so the capture group holds "<chart-name>/templates/foo.yaml".
+var failingTemplateRe = regexp.MustCompile(`\(([^():]+):\d+:\d+\)`)
+
+// failingManifestTemplate returns the chart-dir-relative path (forward-slashed,
+// e.g. "templates/postgres.yaml") of the manifest template a render error is
+// localized to, or "" when the error cannot be attributed to a droppable manifest
+// template. Only non-partial YAML templates under templates/ are droppable:
+// blanking a partial (_*.tpl, helm_lib) or reacting to a values/schema error would
+// not make the rest of the chart renderable, so those are surfaced to the caller.
+func failingManifestTemplate(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	m := failingTemplateRe.FindStringSubmatch(err.Error())
+	if m == nil {
+		return ""
+	}
+
+	// The path is chart-name-prefixed (e.g. "commander/templates/foo.yaml"); the
+	// on-disk layout has no such prefix, so drop the leading segment.
+	_, rel, found := strings.Cut(m[1], "/")
+	if !found || !strings.HasPrefix(rel, "templates/") {
+		return ""
+	}
+
+	if strings.HasPrefix(path.Base(rel), "_") {
+		return ""
+	}
+
+	switch strings.ToLower(path.Ext(rel)) {
+	case ".yaml", ".yml":
+		return rel
+	default:
+		return ""
+	}
+}
+
+// templateNeutralizer blanks manifest templates that abort the render so the rest
+// of the chart can render, then restores each one (content and mode) afterwards.
+type templateNeutralizer struct {
+	chartDir string
+	backups  map[string]neutralizedFile
+}
+
+type neutralizedFile struct {
+	content []byte
+	mode    os.FileMode
+}
+
+func newTemplateNeutralizer(chartDir string) *templateNeutralizer {
+	return &templateNeutralizer{chartDir: chartDir, backups: map[string]neutralizedFile{}}
+}
+
+// neutralize replaces the template at rel (chart-relative, forward-slashed) with a
+// comment-only file so it renders no resources. It returns false when the template
+// was already neutralized (so the caller stops instead of looping) or the file
+// cannot be read/written.
+func (n *templateNeutralizer) neutralize(rel string) bool {
+	if _, done := n.backups[rel]; done {
+		return false
+	}
+
+	full := filepath.Join(n.chartDir, filepath.FromSlash(rel))
+
+	info, err := os.Stat(full)
+	if err != nil {
+		return false
+	}
+
+	orig, err := os.ReadFile(full)
+	if err != nil {
+		return false
+	}
+
+	if err := os.WriteFile(full, []byte("# dmt: template neutralized after render failure\n"), info.Mode().Perm()); err != nil {
+		return false
+	}
+
+	n.backups[rel] = neutralizedFile{content: orig, mode: info.Mode().Perm()}
+
+	return true
+}
+
+// restore rewrites every neutralized template with its original content and mode.
+func (n *templateNeutralizer) restore() {
+	for rel, f := range n.backups {
+		full := filepath.Join(n.chartDir, filepath.FromSlash(rel))
+		_ = os.WriteFile(full, f.content, f.mode)
+	}
 }

--- a/internal/modules/values/global-openapi/values.yaml
+++ b/internal/modules/values/global-openapi/values.yaml
@@ -279,7 +279,24 @@ properties:
       - ["cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus-crd"]
       - ["cert-manager", "prometheus", "priority-class"]
     x-dmt-default:
-      ["cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus-crd"]
+      - cert-manager
+      - vertical-pod-autoscaler
+      - vertical-pod-autoscaler-crd
+      - prometheus
+      - prometheus-crd
+      - operator-prometheus
+      - operator-prometheus-crd
+      - managed-cassandra
+      - managed-clickhouse
+      - managed-hive-metastore
+      - managed-kafka
+      - managed-memcached
+      - managed-opensearch
+      - managed-postgres
+      - managed-starrocks
+      - managed-trino
+      - managed-valkey
+      - operator-postgres
   discovery:
     additionalProperties: true
     type: object

--- a/internal/modules/values/global_stubs.yaml
+++ b/internal/modules/values/global_stubs.yaml
@@ -6,8 +6,24 @@
 global:
   # https.mode below is CertManager, and deckhouse_lib_helm fails a module that
   # inherits it unless cert-manager is enabled — keep the two consistent.
+  # The rest are modules commonly gated on with
+  # `has "<name>" .Values.global.enabledModules`, kept enabled so those guards
+  # pass during the offline render (vertical-pod-autoscaler, the managed-services
+  # data stores, and operator-postgres).
   enabledModules:
     - cert-manager
+    - vertical-pod-autoscaler
+    - managed-cassandra
+    - managed-clickhouse
+    - managed-hive-metastore
+    - managed-kafka
+    - managed-memcached
+    - managed-opensearch
+    - managed-postgres
+    - managed-starrocks
+    - managed-trino
+    - managed-valkey
+    - operator-postgres
   clusterIsBootstrapped: true
   highAvailability: false
   defaultClusterStorageClass: ""

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -141,6 +141,38 @@ go test ./test/e2e/ -run 'TestE2E/<linter>/<your-case>' -v
 | `templates/registry` | `registry` (global dockercfg without module override) |
 | `templates/enabled-modules` | `enabled-modules` (deprecated `.Values.global.enabledModules | has`) |
 
+### manager (module creation)
+
+These cases exercise how the lint pipeline handles templates that abort the helm
+render. dmt renders offline and cannot reproduce all the cluster state a template
+gates on, so it handles aborts two ways:
+
+1. **Enabled dependencies.** Modules commonly gate rendering on
+   `has "<module>" .Values.global.enabledModules`. dmt seeds `global.enabledModules`
+   with a default set (see `internal/modules/values/global-openapi/values.yaml` ->
+   `enabledModules` `x-dmt-default`: cert-manager, vertical-pod-autoscaler, the
+   managed-services data stores, operator-postgres, ...), so a guard on any of those
+   passes and the guarded resource renders and is linted normally.
+
+2. **Tolerant per-template render.** For an abort dmt cannot satisfy — a `fail` on a
+   module NOT in that default set, or a `required` on a value dmt never sets —
+   `render.Render` localizes the abort to the offending manifest template,
+   neutralizes just that one, and re-renders, so the remaining resources are still
+   produced and linted. `NewModule` succeeds and each dropped template is reported as
+   a single non-fatal `manager` **warning** (`template "..." failed to render and was
+   skipped`) rather than the error-level `cannot create module` it used to fail with.
+   An abort that cannot be localized to a droppable manifest template (a failing
+   `_*.tpl` partial, a values/schema error) is a genuine render failure and still
+   surfaces as an error-level `manager` `cannot create module`.
+
+Every fixture ships a valid `service.yaml` whose numeric targetPort trips the
+templates `service-port` rule, proving the chart was rendered AND object-linted.
+
+| Case | Exercises |
+|------|-----------|
+| `manager/enabled-dependency-renders` | `has "operator-postgres"` guard passes because operator-postgres is a standard-enabled module → postgres.yaml renders (no drop, no warn); the Service is object-linted |
+| `manager/helm-render-error-required` | `{{ required }}` (a mandatory value is missing) drops only that template through the same per-template path, with the same `manager` warn; the sibling Service still renders and is object-linted |
+
 ## Running
 
 ```bash

--- a/test/e2e/testdata/container/mount-points-builtin-excluded/expected.yaml
+++ b/test/e2e/testdata/container/mount-points-builtin-excluded/expected.yaml
@@ -3,4 +3,9 @@ description: >
   because they are built-in excluded system paths, even when
   they are not declared in mount-points.yaml.
 module: module
-expect: []
+# The deployment mounts only built-in-excluded paths (/sys, /dev), so the
+# container mount-points rule must stay silent; expectPass fails the moment a
+# built-in path stops being excluded.
+expectPass:
+  - linter: container
+    rule: mount-points

--- a/test/e2e/testdata/container/mount-points-builtin-mixed/expected.yaml
+++ b/test/e2e/testdata/container/mount-points-builtin-mixed/expected.yaml
@@ -7,3 +7,13 @@ expect:
     rule: mount-points
     level: warn
     textContains: 'mountPath "/etc/missing" is not declared'
+    count: 1
+# The built-in-excluded paths mounted alongside /etc/missing must NOT be flagged —
+# this is what distinguishes the "mixed" case from mount-points-missing.
+expectAbsent:
+  - linter: container
+    rule: mount-points
+    textContains: 'mountPath "/sys"'
+  - linter: container
+    rule: mount-points
+    textContains: 'mountPath "/proc"'

--- a/test/e2e/testdata/manager/enabled-dependency-renders/expected.yaml
+++ b/test/e2e/testdata/manager/enabled-dependency-renders/expected.yaml
@@ -1,0 +1,20 @@
+description: >
+  A module whose postgres.yaml renders only when operator-postgres is enabled
+  (`{{- if not (has "operator-postgres" .Values.global.enabledModules) }}{{ fail }}`,
+  mirroring the real commander/templates/postgres.yaml). operator-postgres is a
+  standard dmt-enabled module (in the default global.enabledModules x-dmt-default),
+  so the guard passes, postgres.yaml renders, and the whole module is linted — no
+  template is dropped (no `manager` "failed to render and was skipped" warning) and
+  no `cannot create module` / `helm-render` error appears. The sibling Service's
+  numeric targetPort trips templates `service-port`, confirming the chart rendered
+  and was object-linted. This is the fix for `dmt lint` failing with "cannot create
+  module ...: operator-postgres module is required for internal postgres mode".
+module: module
+expect:
+  - linter: templates
+    rule: service-port
+    textContains: "Service port must use a named (non-numeric) target port"
+expectAbsent:
+  - linter: manager
+  - linter: templates
+    rule: helm-render

--- a/test/e2e/testdata/manager/enabled-dependency-renders/module/module.yaml
+++ b/test/e2e/testdata/manager/enabled-dependency-renders/module/module.yaml
@@ -1,0 +1,2 @@
+name: commander
+namespace: d8-commander

--- a/test/e2e/testdata/manager/enabled-dependency-renders/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/manager/enabled-dependency-renders/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/manager/enabled-dependency-renders/module/openapi/values.yaml
+++ b/test/e2e/testdata/manager/enabled-dependency-renders/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/manager/enabled-dependency-renders/module/templates/postgres.yaml
+++ b/test/e2e/testdata/manager/enabled-dependency-renders/module/templates/postgres.yaml
@@ -1,0 +1,16 @@
+{{- /*
+  Mirrors a real module template (commander/templates/postgres.yaml) that aborts
+  rendering unless operator-postgres is enabled. operator-postgres is a standard
+  dmt-enabled module (global-openapi/values.yaml -> enabledModules x-dmt-default),
+  so this guard passes during a dmt lint and the ConfigMap renders and is linted —
+  it is NOT dropped.
+*/ -}}
+{{- if not (has "operator-postgres" .Values.global.enabledModules) }}
+  {{- fail "operator-postgres module is required for internal postgres mode" }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: commander-postgres
+  namespace: d8-commander
+data: {}

--- a/test/e2e/testdata/manager/enabled-dependency-renders/module/templates/service.yaml
+++ b/test/e2e/testdata/manager/enabled-dependency-renders/module/templates/service.yaml
@@ -1,0 +1,16 @@
+# A second, well-formed resource that renders fine. It exists to prove that when
+# the sibling postgres.yaml aborts the render (fail), dmt drops ONLY that template
+# and still renders this Service — which the object-based linters then check (its
+# numeric targetPort trips the templates `service-port` rule).
+apiVersion: v1
+kind: Service
+metadata:
+  name: commander-api
+  namespace: d8-commander
+spec:
+  selector:
+    app: commander
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/test/e2e/testdata/manager/helm-render-error-required/expected.yaml
+++ b/test/e2e/testdata/manager/helm-render-error-required/expected.yaml
@@ -1,12 +1,12 @@
 description: >
-  A module whose configmap.yaml calls {{ fail }} aborts rendering that one
-  template. dmt drops only the failing template and renders the rest, so the
+  A second, structurally different render abort: postgres.yaml's `required` builtin
+  fails because a mandatory value is never provided during a dmt lint. Like the
+  `fail`-based case, dmt drops only that template and renders the rest, so the
   sibling Service still renders and is object-linted (its numeric targetPort trips
   templates `service-port`), while a non-fatal `manager` warning names the skipped
   template and no error-level `cannot create module` nor `templates` `helm-render`
-  finding appears. See manager/helm-render-error-required for the other
-  tolerant-render case, and manager/enabled-dependency-renders for the
-  enabled-dependency path.
+  finding appears. Proves dmt localizes any render abort to the offending resource
+  instead of failing the lint or dropping the whole chart.
 module: module
 expect:
   - linter: manager

--- a/test/e2e/testdata/manager/helm-render-error-required/module/module.yaml
+++ b/test/e2e/testdata/manager/helm-render-error-required/module/module.yaml
@@ -1,0 +1,2 @@
+name: commander
+namespace: d8-commander

--- a/test/e2e/testdata/manager/helm-render-error-required/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/manager/helm-render-error-required/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/manager/helm-render-error-required/module/openapi/values.yaml
+++ b/test/e2e/testdata/manager/helm-render-error-required/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/manager/helm-render-error-required/module/templates/postgres.yaml
+++ b/test/e2e/testdata/manager/helm-render-error-required/module/templates/postgres.yaml
@@ -1,0 +1,14 @@
+{{- /*
+  A different render-failure shape than the `fail`-based case: the `required`
+  builtin aborts rendering because a mandatory value is never provided during a
+  dmt lint (the key is absent, so `required` evaluates to an error). dmt drops
+  only this template and renders the rest of the chart (see service.yaml), instead
+  of failing the whole render.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: commander-postgres
+  namespace: d8-commander
+data:
+  password: {{ required "postgres password is required for internal postgres mode" .Values.postgresPasswordNeverSet }}

--- a/test/e2e/testdata/manager/helm-render-error-required/module/templates/service.yaml
+++ b/test/e2e/testdata/manager/helm-render-error-required/module/templates/service.yaml
@@ -1,0 +1,16 @@
+# A second, well-formed resource that renders fine. It exists to prove that when
+# the sibling postgres.yaml aborts the render (required), dmt drops ONLY that
+# template and still renders this Service — which the object-based linters then
+# check (its numeric targetPort trips the templates `service-port` rule).
+apiVersion: v1
+kind: Service
+metadata:
+  name: commander-api
+  namespace: d8-commander
+spec:
+  selector:
+    app: commander
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/test/e2e/testdata/module/helmignore-all-covered/expected.yaml
+++ b/test/e2e/testdata/module/helmignore-all-covered/expected.yaml
@@ -1,6 +1,6 @@
 description: >
-  .helmignore covers all module root directories (hooks/, images/, openapi/,
-  docs/, crds/) except templates/ which is required by Helm. No helmignore
-  errors should be reported.
+  .helmignore covers all module root directories (hooks/, openapi/, crds/,
+  docs/) except templates/ which is required by Helm. No helmignore errors
+  should be reported.
 module: module
 expectClean: true

--- a/test/e2e/testdata/module/helmignore-dir-covered-without-slash/expected.yaml
+++ b/test/e2e/testdata/module/helmignore-dir-covered-without-slash/expected.yaml
@@ -1,5 +1,5 @@
 description: >
-  .helmignore lists directories without trailing slash (hooks, images).
+  .helmignore lists directories without a trailing slash (hooks, openapi, docs).
   The rule must recognise these patterns as covering the directories.
   No errors expected.
 module: module

--- a/test/e2e/testdata/module/oss-version-not-semver-excluded/expected.yaml
+++ b/test/e2e/testdata/module/oss-version-not-semver-excluded/expected.yaml
@@ -4,3 +4,9 @@ description: >
   semver-compatibility warning must be suppressed, leaving a clean run.
 module: module
 expectClean: true
+# Name the excluded rule explicitly: the sibling oss-version-not-semver produces
+# exactly this finding, so expectPass fails if the exclude stops working.
+expectPass:
+  - linter: module
+    rule: oss
+    textContains: "is not semver-compatible"

--- a/test/e2e/testdata/module/package-consistency-fix/expected.yaml
+++ b/test/e2e/testdata/module/package-consistency-fix/expected.yaml
@@ -27,3 +27,9 @@ expect:
     rule: readme
     level: error
     textContains: "README.md file is missing in docs/ directory"
+# The case's own rule: the module-package-consistency divergences (name/deckhouse/
+# modules) are all auto-fixable, so after --fix none remain. Names the rule the
+# case is about rather than relying on `exhaustive` alone.
+expectAbsent:
+  - linter: module
+    rule: module-package-consistency

--- a/test/e2e/testdata/templates/helm-render-broken/module/templates/service.yaml
+++ b/test/e2e/testdata/templates/helm-render-broken/module/templates/service.yaml
@@ -1,0 +1,16 @@
+# A second, well-formed resource that renders fine. It exists to prove that when
+# the sibling configmap.yaml aborts the render (fail), dmt drops ONLY that template
+# and still renders this Service — which the object-based linters then check (its
+# numeric targetPort trips the templates `service-port` rule).
+apiVersion: v1
+kind: Service
+metadata:
+  name: helm-render-broken-svc
+  namespace: e2e-helm-render-broken
+spec:
+  selector:
+    app: e2e-app
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/test/e2e/testdata/templates/helm-render-clean/expected.yaml
+++ b/test/e2e/testdata/templates/helm-render-clean/expected.yaml
@@ -1,8 +1,9 @@
 description: >
-  A valid module with renderable templates must pass the helm-render rule
-  without producing any findings. Other linters may produce findings for
-  the minimal module structure, but none from helm-render.
+  A valid module with renderable templates must render cleanly: the templates
+  linter (helm-render and every other templates rule) produces no findings. Other
+  linters may still flag the minimal module structure (definition-file, helmignore,
+  readme). The sibling templates/mount-points-files et al. prove templates rules do
+  fire when warranted, so this expectPass is a live guard.
 module: module
-expectAbsent:
+expectPass:
   - linter: templates
-    rule: helm-render

--- a/test/e2e/testdata/templates/mount-points-builtin-excluded/expected.yaml
+++ b/test/e2e/testdata/templates/mount-points-builtin-excluded/expected.yaml
@@ -3,4 +3,9 @@ description: >
   because they are built-in excluded system paths. /etc/app is in
   the template, so no warnings at all.
 module: module
-expect: []
+# All mount paths are built-in-excluded (/sys, /dev, /proc) and the declared
+# /etc/app is used, so the templates mount-points rule must stay silent. The rule
+# provably fires elsewhere (templates/mount-points-files), so this guard is live.
+expectPass:
+  - linter: templates
+    rule: mount-points

--- a/test/e2e/testdata/templates/webhook-config-annotations-present/expected.yaml
+++ b/test/e2e/testdata/templates/webhook-config-annotations-present/expected.yaml
@@ -1,31 +1,9 @@
 description: >
-  A ValidatingWebhookConfiguration with werf.io/weight annotation must pass
-  the webhook-configuration-annotations rule without errors. Uses exhaustive
-  matching to confirm the rule produces no findings.
+  A ValidatingWebhookConfiguration carrying a werf.io/weight annotation must NOT
+  be flagged by the templates webhook-configuration-annotations rule. Contrast
+  webhook-config-annotations-absent, where the missing annotation IS flagged — so
+  this expectPass is a live guard, not a vacuous check.
 module: module
-exhaustive: true
-expect:
-  - linter: container
-    rule: object-recommended-labels
-    level: error
-    textContains: '"module"'
-  - linter: container
-    rule: object-recommended-labels
-    level: error
-    textContains: '"heritage"'
-  - linter: module
-    rule: definition-file
-    level: error
-    textContains: "'stage' is required"
-  - linter: module
-    rule: definition-file
-    level: error
-    textContains: '`descriptions.en` field is required'
-  - linter: module
-    rule: helmignore
-    level: error
-    textContains: ".helmignore is required"
-  - linter: documentation
-    rule: readme
-    level: error
-    textContains: "README.md file is missing"
+expectPass:
+  - linter: templates
+    rule: webhook-configuration-annotations


### PR DESCRIPTION
### Summary

`dmt lint` renders each module's Helm chart offline (via nelm's `action.ChartRender`) before running the object-based linters. Rendering used to be **strict**: the first template that aborted the render — an intentional `{{ fail }}`, or a `{{ required }}` on a value dmt cannot supply outside a cluster — failed the *whole* module with `cannot create module ...`, hiding every other resource from the linters.

This PR makes render aborts non-fatal in two complementary ways so the rest of the chart is still rendered and linted:

1. **Enabled-module defaults.** Modules commonly gate rendering on `has "<module>" .Values.global.enabledModules`. The default `global.enabledModules` set is expanded so those guards pass offline and the guarded resources render normally.
2. **Tolerant per-template render.** For an abort dmt genuinely cannot satisfy, the render localizes the failure to the offending manifest template, neutralizes just that one, and re-renders — dropping only the broken template and reporting it as a single non-fatal `manager` **warning** instead of failing the module.

### Motivation

Real modules abort an offline render for reasons dmt can't reproduce. For example `commander/templates/postgres.yaml` does `{{- if not (has "operator-postgres" .Values.global.enabledModules) }}{{ fail ... }}`, so `dmt lint` failed with `cannot create module ...: operator-postgres module is required for internal postgres mode` and linted **none** of the module. A single unsatisfiable template should not blind the linters to the entire chart.

### What changed

**Enabled-module defaults**
- [internal/modules/values/global-openapi/values.yaml](internal/modules/values/global-openapi/values.yaml) — expand the `enabledModules` `x-dmt-default` list (now also `vertical-pod-autoscaler`, the `managed-*` data stores, and `operator-postgres`); reformatted to a block list for readability.
- [internal/modules/values/global_stubs.yaml](internal/modules/values/global_stubs.yaml) — mirror the same modules into the render stub so `has`-guards pass during the offline render, with a comment on why each is kept enabled.

**Tolerant per-template render**
- [internal/modules/render/render.go](internal/modules/render/render.go) — render in a loop: on a render error, `failingManifestTemplate` extracts the chart-relative path from nelm's error, `templateNeutralizer` blanks that one template and re-renders, and every neutralized template's original content + mode is restored before `Render` returns. Only droppable manifest templates (non-partial `*.yaml`/`*.yml` under `templates/`) are neutralized; a failing `_*.tpl` partial or a values/schema error is still surfaced as a real error. A new `Options.OnDrop` callback reports each dropped template.
- [internal/modules/render.go](internal/modules/render.go) — wire `OnDrop` to emit a non-fatal `manager` warning (`template "..." failed to render and was skipped; the rest of the chart was still linted`) instead of failing module creation.

**Tests & docs**
- New manager fixtures:
  - [test/e2e/testdata/manager/enabled-dependency-renders/](test/e2e/testdata/manager/enabled-dependency-renders/) — `has "operator-postgres"` guard passes because it's now a standard-enabled module → the template renders, nothing is dropped, no warning.
  - [test/e2e/testdata/manager/helm-render-error-required/](test/e2e/testdata/manager/helm-render-error-required/) — a `{{ required }}` abort is dropped via the per-template path with a single `manager` warning; the sibling Service still renders and is object-linted.
- [test/e2e/testdata/templates/helm-render-broken/](test/e2e/testdata/templates/helm-render-broken/) — a `{{ fail }}` now produces a `manager` **warn** (was `error`); added a sibling `service.yaml` proving the rest of the chart still lints.
- [test/e2e/testdata/templates/helm-render-clean/expected.yaml](test/e2e/testdata/templates/helm-render-clean/expected.yaml) — switched to `expectPass` so it's a live guard, not a vacuous absent-check.
- [test/e2e/README.md](test/e2e/README.md) — new "manager (module creation)" section documenting both abort-handling paths.
- Tightened several unrelated fixtures that used vacuous `expect: []` / `exhaustive` into explicit `expectPass` / `expectAbsent` guards (container & templates `mount-points`, `webhook-config-annotations-present`, `oss-version-not-semver-excluded`, `package-consistency-fix`, `helmignore-*`).

Every render fixture ships a valid `service.yaml` whose numeric `targetPort` trips the `templates` `service-port` rule, proving the chart was both **rendered** and **object-linted** after the drop.

### Behavior change

A module template that aborts the offline render no longer fails the whole module. It is reported as a non-fatal `manager` **warning** and the remaining resources are still linted. Aborts that cannot be localized to a droppable manifest template (failing partials, values/schema errors) still surface as an error-level `cannot create module`.
