### PR TITLE
[dmt] Exclude `/sys/fs/cgroup` from the mount-points check

### DIFF
--- a/pkg/linters/container/rules/mount_points.go
+++ b/pkg/linters/container/rules/mount_points.go
@@ -45,10 +45,11 @@ type mountPointsFile struct {
 // builtinExcludedPaths are system paths that are always available on Linux hosts
 // and should not be required in mount-points.yaml.
 var builtinExcludedPaths = map[string]bool{
-	"/sys":  true,
-	"/dev":  true,
-	"/proc": true,
-	"/tmp":  true,
+	"/sys":           true,
+	"/sys/fs/cgroup": true,
+	"/dev":           true,
+	"/proc":          true,
+	"/tmp":           true,
 }
 
 func NewMountPointsRule(excludeRules []pkg.StringRuleExclude, modulePath string) *MountPointsRule {
@@ -74,8 +75,8 @@ type MountPointsRule struct {
 //
 // Direction: templates → mount-points.yaml (reverse of the templates rule).
 //
-// Built-in excluded paths: /sys, /dev, /proc — these Linux system paths
-// are always available and do not need to be declared in mount-points.yaml.
+// Built-in excluded paths: /sys, /sys/fs/cgroup, /dev, /proc, /tmp — these Linux
+// system paths are always available and do not need to be declared in mount-points.yaml.
 //
 // Module-specific exclusions are configured via dmtlint.yaml:
 //

--- a/pkg/linters/container/rules/mount_points_test.go
+++ b/pkg/linters/container/rules/mount_points_test.go
@@ -307,6 +307,29 @@ func TestMountPointsContainerRule_BuiltinExcludedSys(t *testing.T) {
 	assert.Len(t, errorList.GetErrors(), 0)
 }
 
+func TestMountPointsContainerRule_BuiltinExcludedCgroup(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "mpcr-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writeMountPointsFile(t, tmpDir, `dirs:
+  - /etc/app
+`)
+
+	obj := objectWithMounts("Deployment", "controller", "/sys/fs/cgroup", "/etc/app")
+
+	containers, err := obj.GetAllContainers()
+	assert.NoError(t, err)
+
+	errorList := errors.NewLintRuleErrorsList()
+	rule := NewMountPointsRule(nil, tmpDir)
+	rule.CheckMountPaths(obj, containers, errorList)
+
+	assert.Len(t, errorList.GetErrors(), 0)
+}
+
 func TestMountPointsContainerRule_BuiltinExcludedDev(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "mpcr-test")
 	if err != nil {

--- a/pkg/linters/templates/rules/mount_points.go
+++ b/pkg/linters/templates/rules/mount_points.go
@@ -39,10 +39,11 @@ type mountPointsFile struct {
 // builtinExcludedPaths are system paths that are always available on Linux hosts
 // and should not be required in mount-points.yaml.
 var builtinExcludedPaths = map[string]bool{
-	"/sys":  true,
-	"/dev":  true,
-	"/proc": true,
-	"/tmp":  true,
+	"/sys":           true,
+	"/sys/fs/cgroup": true,
+	"/dev":           true,
+	"/proc":          true,
+	"/tmp":           true,
 }
 
 func NewMountPointsRule(excludeRules []pkg.StringRuleExclude) *MountPointsRule {
@@ -66,8 +67,8 @@ type MountPointsRule struct {
 //
 // Direction: mount-points.yaml → templates.
 //
-// Built-in excluded paths: /sys, /dev, /proc — these Linux system paths
-// are always available and do not need to be declared in mount-points.yaml.
+// Built-in excluded paths: /sys, /sys/fs/cgroup, /dev, /proc, /tmp — these Linux
+// system paths are always available and do not need to be declared in mount-points.yaml.
 //
 // Module-specific exclusions are configured via dmtlint.yaml:
 //

--- a/pkg/linters/templates/rules/mount_points_test.go
+++ b/pkg/linters/templates/rules/mount_points_test.go
@@ -572,6 +572,39 @@ func TestMountPointsRule_BuiltinExcludedSys(t *testing.T) {
 	assert.Len(t, errs, 0)
 }
 
+func TestMountPointsRule_BuiltinExcludedCgroup(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "mount-points-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	imagesDir := filepath.Join(tmpDir, "images", "app")
+	if err := os.MkdirAll(imagesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mountPointsYAML := `dirs:
+  - /sys/fs/cgroup
+  - /etc/app
+`
+	if err := os.WriteFile(filepath.Join(imagesDir, "mount-points.yaml"), []byte(mountPointsYAML), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	storageMap := map[storage.ResourceIndex]storage.StoreObject{
+		{Kind: "Deployment", Name: "app", Namespace: "default"}: deploymentWithMounts("app", "/etc/app"),
+	}
+
+	errorList := errors.NewLintRuleErrorsList()
+	rule := NewMountPointsRule(nil)
+	rule.ValidateMountPoints(&mockMountPointsModule{path: tmpDir, storage: storageMap}, errorList)
+
+	// /sys/fs/cgroup is built-in excluded, /etc/app is in templates → 0 errors
+	errs := errorList.GetErrors()
+	assert.Len(t, errs, 0)
+}
+
 func TestMountPointsRule_BuiltinExcludedDev(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "mount-points-test")
 	if err != nil {


### PR DESCRIPTION
## What this PR does

Adds `/sys/fs/cgroup` to the built-in excluded paths of the `mount-points`
linter rule (in both the `container` and `templates` linters), so containers
that mount `/sys/fs/cgroup` no longer produce a false-positive warning.

## Problem

The `mount-points` rule matches a container's `volumeMount.mountPath` against
`builtinExcludedPaths` using **exact** string comparison. `/sys` is already
excluded, but `/sys/fs/cgroup` is a distinct path that the `/sys` entry does
not cover, so it triggered:

```
Container "controller" mountPath "/sys/fs/cgroup" is not declared in any mount-points.yaml
```

Like `/sys`, the cgroup filesystem is a standard Linux system path that is
always present in the build, so it should not need to be declared in
`mount-points.yaml`.

## Changes

- Add `/sys/fs/cgroup` to `builtinExcludedPaths` in:
  - `pkg/linters/container/rules/mount_points.go` — templates → mount-points.yaml
    direction, the source of the warning above.
  - `pkg/linters/templates/rules/mount_points.go` — mount-points.yaml → templates
    direction, kept in sync (the map is duplicated across both linters).
- Update the doc comments that list the built-in excluded paths.
- Add tests `TestMountPointsContainerRule_BuiltinExcludedCgroup` and
  `TestMountPointsRule_BuiltinExcludedCgroup`.

## Notes

`/sys/fs/cgroup` is added as an explicit, exact-match exclusion rather than a
`/sys/*` prefix rule, to avoid unintentionally suppressing legitimate warnings
for other sub-paths.
