### PR TITLE
[dmt] add deprecated crds rule

### DIFF
--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -364,6 +364,7 @@ func mapTemplatesRules(linterSettings *pkg.LintersSettings, configSettings *conf
 	rules.ClusterDomainRule.SetLevel(globalRules.ClusterDomainRule.Impact, fallbackImpact)
 	rules.RegistryRule.SetLevel(globalRules.RegistryRule.Impact, fallbackImpact)
 	rules.EnabledModulesRule.SetLevel(globalRules.EnabledModulesRule.Impact, fallbackImpact)
+	rules.CRDEnabledModulesRule.SetLevel(globalRules.CRDEnabledModulesRule.Impact, fallbackImpact)
 	rules.MountPointsRule.SetLevel(globalRules.MountPointsRule.Impact, fallbackImpact)
 	rules.WebhookConfigurationRule.SetLevel(globalRules.WebhookConfigurationRule.Impact, fallbackImpact)
 	rules.HelmRenderRule.SetLevel(globalRules.HelmRenderRule.Impact, fallbackImpact)
@@ -484,6 +485,8 @@ func mapTemplatesExclusionsAndSettings(linterSettings *pkg.LintersSettings, conf
 	excludes.HTTPRoute = configExcludes.HTTPRoute.Get()
 	excludes.EnabledModules.Files = pkg.StringRuleExcludeList(configExcludes.EnabledModules.Files)
 	excludes.EnabledModules.Directories = pkg.DirectoryRuleExcludeList(configExcludes.EnabledModules.Directories)
+	excludes.CRDEnabledModules.Files = pkg.StringRuleExcludeList(configExcludes.CRDEnabledModules.Files)
+	excludes.CRDEnabledModules.Directories = pkg.DirectoryRuleExcludeList(configExcludes.CRDEnabledModules.Directories)
 	excludes.WebhookConfiguration = configExcludes.WebhookConfiguration.Get()
 	excludes.MountPoints = pkg.StringRuleExcludeList(configExcludes.MountPoints)
 

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -364,7 +364,13 @@ func mapTemplatesRules(linterSettings *pkg.LintersSettings, configSettings *conf
 	rules.ClusterDomainRule.SetLevel(globalRules.ClusterDomainRule.Impact, fallbackImpact)
 	rules.RegistryRule.SetLevel(globalRules.RegistryRule.Impact, fallbackImpact)
 	rules.EnabledModulesRule.SetLevel(globalRules.EnabledModulesRule.Impact, fallbackImpact)
-	rules.CRDEnabledModulesRule.SetLevel(globalRules.CRDEnabledModulesRule.Impact, fallbackImpact)
+
+	// crd-enabled-modules defaults to warn: the "-crd" tokens still resolve via a
+	// backward-compatibility shim, so a deprecated reference is a warning rather than
+	// an error. A per-rule impact in config still overrides this default. warn is
+	// passed explicitly because the linter fallback impact defaults to "error".
+	rules.CRDEnabledModulesRule.SetLevel(globalRules.CRDEnabledModulesRule.Impact, pkg.Warn.String())
+
 	rules.MountPointsRule.SetLevel(globalRules.MountPointsRule.Impact, fallbackImpact)
 	rules.WebhookConfigurationRule.SetLevel(globalRules.WebhookConfigurationRule.Impact, fallbackImpact)
 	rules.HelmRenderRule.SetLevel(globalRules.HelmRenderRule.Impact, fallbackImpact)
@@ -485,8 +491,6 @@ func mapTemplatesExclusionsAndSettings(linterSettings *pkg.LintersSettings, conf
 	excludes.HTTPRoute = configExcludes.HTTPRoute.Get()
 	excludes.EnabledModules.Files = pkg.StringRuleExcludeList(configExcludes.EnabledModules.Files)
 	excludes.EnabledModules.Directories = pkg.DirectoryRuleExcludeList(configExcludes.EnabledModules.Directories)
-	excludes.CRDEnabledModules.Files = pkg.StringRuleExcludeList(configExcludes.CRDEnabledModules.Files)
-	excludes.CRDEnabledModules.Directories = pkg.DirectoryRuleExcludeList(configExcludes.CRDEnabledModules.Directories)
 	excludes.WebhookConfiguration = configExcludes.WebhookConfiguration.Get()
 	excludes.MountPoints = pkg.StringRuleExcludeList(configExcludes.MountPoints)
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -144,6 +144,7 @@ type TemplatesLinterRules struct {
 	RegistryRule             RuleConfig
 	HTTPRouteRule            RuleConfig
 	EnabledModulesRule       RuleConfig
+	CRDEnabledModulesRule    RuleConfig
 	WebhookConfigurationRule RuleConfig
 	MountPointsRule          RuleConfig
 	HelmRenderRule           RuleConfig
@@ -164,6 +165,7 @@ type TemplatesExcludeRules struct {
 	Ingress              KindRuleExcludeList
 	HTTPRoute            KindRuleExcludeList
 	EnabledModules       EnabledModulesExcludeRule
+	CRDEnabledModules    EnabledModulesExcludeRule
 	WebhookConfiguration KindRuleExcludeList
 	MountPoints          StringRuleExcludeList
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -165,7 +165,6 @@ type TemplatesExcludeRules struct {
 	Ingress              KindRuleExcludeList
 	HTTPRoute            KindRuleExcludeList
 	EnabledModules       EnabledModulesExcludeRule
-	CRDEnabledModules    EnabledModulesExcludeRule
 	WebhookConfiguration KindRuleExcludeList
 	MountPoints          StringRuleExcludeList
 }

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -144,6 +144,7 @@ type TemplatesLinterRules struct {
 	ClusterDomainRule        RuleConfig `mapstructure:"cluster-domain"`
 	RegistryRule             RuleConfig `mapstructure:"registry"`
 	EnabledModulesRule       RuleConfig `mapstructure:"enabled-modules"`
+	CRDEnabledModulesRule    RuleConfig `mapstructure:"crd-enabled-modules"`
 	WebhookConfigurationRule RuleConfig `mapstructure:"webhook-configuration-annotations"`
 	MountPointsRule          RuleConfig `mapstructure:"mount-points"`
 	HelmRenderRule           RuleConfig `mapstructure:"helm-render"`

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -246,7 +246,6 @@ type TemplatesExcludeRules struct {
 	Ingress              KindRuleExcludeList       `mapstructure:"ingress"`
 	HTTPRoute            KindRuleExcludeList       `mapstructure:"httproute"`
 	EnabledModules       EnabledModulesExcludeRule `mapstructure:"enabled-modules"`
-	CRDEnabledModules    EnabledModulesExcludeRule `mapstructure:"crd-enabled-modules"`
 	WebhookConfiguration KindRuleExcludeList       `mapstructure:"webhook-configuration-annotations"`
 	MountPoints          StringRuleExcludeList     `mapstructure:"mount-points"`
 }

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -232,6 +232,7 @@ type TemplatesLinterRules struct {
 	ClusterDomainRule        RuleConfig `mapstructure:"cluster-domain"`
 	RegistryRule             RuleConfig `mapstructure:"registry"`
 	EnabledModulesRule       RuleConfig `mapstructure:"enabled-modules"`
+	CRDEnabledModulesRule    RuleConfig `mapstructure:"crd-enabled-modules"`
 	WebhookConfigurationRule RuleConfig `mapstructure:"webhook-configuration-annotations"`
 	MountPointsRule          RuleConfig `mapstructure:"mount-points"`
 	HelmRenderRule           RuleConfig `mapstructure:"helm-render"`
@@ -245,6 +246,7 @@ type TemplatesExcludeRules struct {
 	Ingress              KindRuleExcludeList       `mapstructure:"ingress"`
 	HTTPRoute            KindRuleExcludeList       `mapstructure:"httproute"`
 	EnabledModules       EnabledModulesExcludeRule `mapstructure:"enabled-modules"`
+	CRDEnabledModules    EnabledModulesExcludeRule `mapstructure:"crd-enabled-modules"`
 	WebhookConfiguration KindRuleExcludeList       `mapstructure:"webhook-configuration-annotations"`
 	MountPoints          StringRuleExcludeList     `mapstructure:"mount-points"`
 }

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -1888,7 +1888,7 @@ The rule is **version-gated**: it only runs for modules whose `module.yaml` `req
 {{- end }}
 ```
 
-**Error:**
+**Warning:**
 ```
 Deprecated "operator-prometheus-crd" reference in .Values.global.enabledModules: standalone "-crd" modules were removed in Deckhouse v1.65.0, use "operator-prometheus" instead.
 ```
@@ -1910,7 +1910,7 @@ Deprecated "operator-prometheus-crd" reference in .Values.global.enabledModules:
 
 **Configuration:**
 
-Set the severity (defaults to `error`, can be lowered to `warn`) and exclude specific files/directories (paths relative to the module root):
+The rule reports findings at `warn` level by default (the `-crd` tokens still resolve via a backward-compatibility shim, so it is a deprecation rather than a hard error). Override the severity per module or globally via `impact`:
 
 ```yaml
 # .dmtlint.yaml
@@ -1918,13 +1918,7 @@ linters-settings:
   templates:
     rules:
       crd-enabled-modules:
-        impact: warn
-    exclude-rules:
-      crd-enabled-modules:
-        files:
-          - templates/legacy-compat.yaml  # Exclude specific file
-        directories:
-          - templates/vendor/             # Exclude entire directory
+        impact: warn   # error | warn (default: warn)
 ```
 
 ### webhook-configuration-annotations

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -22,6 +22,7 @@ Proper template validation prevents runtime issues, ensures applications are pro
 | [registry](#registry) | Validates registry secret configuration | ❌ | enabled |
 | [werf](#werf) | Validates image names in `werf.yaml` do not contain underscores | ❌ | enabled |
 | [enabled-modules](#enabled-modules) | Detects usage of `.Values.global.enabledModules` in templates | ✅ | enabled |
+| [crd-enabled-modules](#crd-enabled-modules) | Flags deprecated `has "<module>-crd"` checks in `.Values.global.enabledModules` and autofixes them | ✅ | enabled |
 | [webhook-configuration-annotations](#webhook-configuration-annotations) | Checks webhook configurations have werf.io/weight or deploy-dependency annotations | ✅ | enabled |
 | [mount-points](#mount-points) | Validates that mount-points.yaml directories are used as volumeMounts in pod controllers | ✅ | enabled |
 

--- a/pkg/linters/templates/README.md
+++ b/pkg/linters/templates/README.md
@@ -1855,6 +1855,78 @@ linters-settings:
           - templates/vendor/                 # Exclude entire directory
 ```
 
+### crd-enabled-modules
+
+**Purpose:** Flags deprecated references to standalone `<module>-crd` modules in `.Values.global.enabledModules` checks and offers an autofix that drops the `-crd` suffix. Starting from Deckhouse **v1.65.0** the standalone `*-crd` modules were removed ([deckhouse#9593 "Get rid of crd modules"](https://github.com/deckhouse/deckhouse/pull/9593)) — their CRDs are now installed automatically from the parent module's `crds/` directory, so checking for the `-crd` name is obsolete.
+
+**Description:**
+
+Scans all template files (`.yaml`, `.yml`, `.tpl`) in the `templates/` directory for the pattern `.Values.global.enabledModules | has "<name>-crd"` and reports each occurrence, suggesting the parent module name without the `-crd` suffix. Running `dmt lint --fix` rewrites the references automatically.
+
+The rule is **version-gated**: it only runs for modules whose `module.yaml` `requirements.deckhouse` constraint starts at or above `1.65.0` (the release where the `-crd` modules were removed). Modules that still support older Deckhouse releases — or that declare no `requirements.deckhouse` — are left untouched, since the `-crd` module still exists on those versions.
+
+**What it checks:**
+
+1. All files in the `templates/` directory
+2. Usage of `.Values.global.enabledModules | has "<module-name>-crd"`
+3. Only for modules targeting Deckhouse `>= 1.65.0` via `requirements.deckhouse`
+
+**Why it matters:**
+
+- The standalone `*-crd` modules no longer exist as of Deckhouse v1.65.0; their CRDs ship with the parent module.
+- The `-crd` tokens are kept in `enabledModules` only as a temporary backward-compatibility shim and are slated for removal, after which `has "<module>-crd"` will silently evaluate to `false`.
+- Referencing the obsolete name is brittle and misleading.
+
+**Examples:**
+
+❌ **Incorrect** - Checking a removed `-crd` module:
+
+```yaml
+# templates/prometheus-rules.yaml
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+# ...
+{{- end }}
+```
+
+**Error:**
+```
+Deprecated "operator-prometheus-crd" reference in .Values.global.enabledModules: standalone "-crd" modules were removed in Deckhouse v1.65.0, use "operator-prometheus" instead.
+```
+
+✅ **Correct** - Checking the parent module:
+
+```yaml
+# templates/prometheus-rules.yaml
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+# ...
+{{- end }}
+```
+
+> **Note:** Deckhouse's recommended long-term replacement for CRD-presence detection is a capability check — `{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" }}` — see the [enabled-modules](#enabled-modules) rule. This rule performs the narrower, mechanical `-crd` → parent-module rename, which is always safe and autofixable.
+
+**Autofix:**
+
+`dmt lint --fix` rewrites every `has "<module>-crd"` in a file to `has "<module>"`, touching only the module-name text and leaving the rest of the file byte-for-byte identical. The fix is idempotent, so re-running it is a no-op.
+
+**Configuration:**
+
+Set the severity (defaults to `error`, can be lowered to `warn`) and exclude specific files/directories (paths relative to the module root):
+
+```yaml
+# .dmtlint.yaml
+linters-settings:
+  templates:
+    rules:
+      crd-enabled-modules:
+        impact: warn
+    exclude-rules:
+      crd-enabled-modules:
+        files:
+          - templates/legacy-compat.yaml  # Exclude specific file
+        directories:
+          - templates/vendor/             # Exclude entire directory
+```
+
 ### webhook-configuration-annotations
 
 **Purpose:** Ensures every `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` has at least one ordering annotation: `werf.io/weight` or an annotation with the `werf.io/deploy-dependency-` prefix (e.g. `werf.io/deploy-dependency-deployment`, `werf.io/deploy-dependency-service`). These annotations control werf deploy ordering: `werf.io/deploy-dependency-*` declares a dependency on another resource (the recommended approach), while `werf.io/weight` sets explicit ordering priority.

--- a/pkg/linters/templates/rules/crd_enabled_modules.go
+++ b/pkg/linters/templates/rules/crd_enabled_modules.go
@@ -70,18 +70,12 @@ var crdVersionConstraintRegex = regexp.MustCompile(`([><=]=?|!=)\s*v?(\d+(?:\.\d
 
 type CRDEnabledModulesRule struct {
 	pkg.RuleMeta
-	pkg.PathRule
 }
 
-func NewCRDEnabledModulesRule(excludeFileRules []pkg.StringRuleExclude,
-	excludeDirectoryRules []pkg.DirectoryRuleExclude) *CRDEnabledModulesRule {
+func NewCRDEnabledModulesRule() *CRDEnabledModulesRule {
 	return &CRDEnabledModulesRule{
 		RuleMeta: pkg.RuleMeta{
 			Name: CRDEnabledModulesRuleName,
-		},
-		PathRule: pkg.PathRule{
-			ExcludeStringRules:    excludeFileRules,
-			ExcludeDirectoryRules: excludeDirectoryRules,
 		},
 	}
 }
@@ -110,10 +104,6 @@ func (r *CRDEnabledModulesRule) CheckCRDEnabledModules(m pkg.Module, errorList *
 
 	for _, filePath := range files {
 		relPath := fsutils.Rel(m.GetPath(), filePath)
-
-		if !r.Enabled(relPath) {
-			continue
-		}
 
 		content, err := os.ReadFile(filePath)
 		if err != nil {

--- a/pkg/linters/templates/rules/crd_enabled_modules.go
+++ b/pkg/linters/templates/rules/crd_enabled_modules.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/dmt/internal/fsutils"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	CRDEnabledModulesRuleName = "crd-enabled-modules"
+
+	// crdModuleSuffix is the suffix of the deprecated standalone CRD modules
+	// (e.g. "operator-prometheus-crd"). Their CRDs were merged into the parent
+	// module, so the "-crd" name must be dropped in enabledModules checks.
+	crdModuleSuffix = "-crd"
+
+	// moduleConfigFilename is the module definition file that declares, among
+	// other things, requirements.deckhouse — the module's target platform version.
+	moduleConfigFilename = "module.yaml"
+
+	// MinimalDeckhouseVersionForCRDModulesRemoval is the Deckhouse version starting
+	// from which the standalone "<module>-crd" modules were removed (Deckhouse PR
+	// #9593 "Get rid of crd modules", first released in v1.65.0). Their CRDs are now
+	// discovered and installed automatically from the parent module's crds/ directory,
+	// so a separate "-crd" module no longer exists and referencing its name through
+	// .Values.global.enabledModules is a deprecated pattern that should use the parent
+	// module name (without the "-crd" suffix) instead.
+	//
+	// The rule only fires for modules whose requirements.deckhouse constraint starts
+	// at or above this version; modules that still support older Deckhouse releases
+	// (or declare no deckhouse requirement) are out of scope, mirroring the other
+	// version-gated checks in dmt.
+	MinimalDeckhouseVersionForCRDModulesRemoval = "1.65.0"
+)
+
+// crdEnabledModulesRe captures a module name referenced through
+// `.Values.global.enabledModules | has "<name>"`. Capture group 1 is the module
+// name, which the rule then tests for the "-crd" suffix.
+var crdEnabledModulesRe = regexp.MustCompile(`\.Values\.global\.enabledModules\s*\|\s*has\s+"([^"]*)"`)
+
+// crdVersionConstraintRegex extracts operator+version pairs (e.g. ">= 1.77") from a
+// semver constraint string, mirroring the module linter's requirements handling.
+var crdVersionConstraintRegex = regexp.MustCompile(`([><=]=?|!=)\s*v?(\d+(?:\.\d+){0,2})`)
+
+type CRDEnabledModulesRule struct {
+	pkg.RuleMeta
+	pkg.PathRule
+}
+
+func NewCRDEnabledModulesRule(excludeFileRules []pkg.StringRuleExclude,
+	excludeDirectoryRules []pkg.DirectoryRuleExclude) *CRDEnabledModulesRule {
+	return &CRDEnabledModulesRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: CRDEnabledModulesRuleName,
+		},
+		PathRule: pkg.PathRule{
+			ExcludeStringRules:    excludeFileRules,
+			ExcludeDirectoryRules: excludeDirectoryRules,
+		},
+	}
+}
+
+// CheckCRDEnabledModules scans the module templates for deprecated references to
+// standalone "-crd" modules through .Values.global.enabledModules and reports each
+// one, offering an autofix that drops the "-crd" suffix. The check is gated on the
+// module's target Deckhouse version (see MinimalDeckhouseVersionForCRDModulesRemoval).
+func (r *CRDEnabledModulesRule) CheckCRDEnabledModules(m pkg.Module, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName())
+
+	// The standalone "-crd" modules were removed starting from a specific Deckhouse
+	// version. Only modules that target that version (or newer) must stop referencing
+	// the "-crd" names; skip everything else to avoid false positives on modules that
+	// still support older releases where the "-crd" module still exists.
+	if !moduleTargetsDeckhouseAtLeast(m.GetPath(), MinimalDeckhouseVersionForCRDModulesRemoval) {
+		return
+	}
+
+	templatesPath := filepath.Join(m.GetPath(), "templates")
+	if _, err := os.Stat(templatesPath); os.IsNotExist(err) {
+		return
+	}
+
+	files := fsutils.GetFiles(templatesPath, true, fsutils.FilterFileByExtensions(".yaml", ".yml", ".tpl"))
+
+	for _, filePath := range files {
+		relPath := fsutils.Rel(m.GetPath(), filePath)
+
+		if !r.Enabled(relPath) {
+			continue
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			errorList.WithFilePath(relPath).Errorf("Failed to read file: %v", err)
+			continue
+		}
+
+		for _, match := range crdEnabledModulesRe.FindAllSubmatchIndex(content, -1) {
+			name := string(content[match[2]:match[3]])
+			if !strings.HasSuffix(name, crdModuleSuffix) {
+				continue
+			}
+
+			suggested := strings.TrimSuffix(name, crdModuleSuffix)
+			line := bytes.Count(content[:match[0]], []byte("\n")) + 1
+
+			errorList.
+				WithFilePath(relPath).
+				WithLineNumber(line).
+				WithValue(name).
+				WithFix(fixCRDEnabledModuleReferences(filePath)).
+				Errorf(
+					"Deprecated %q reference in .Values.global.enabledModules: standalone %q modules "+
+						"were removed in Deckhouse v%s, use %q instead.",
+					name, crdModuleSuffix, MinimalDeckhouseVersionForCRDModulesRemoval, suggested,
+				)
+		}
+	}
+}
+
+// fixCRDEnabledModuleReferences returns an idempotent autofix that rewrites every
+// `.Values.global.enabledModules | has "<name>-crd"` occurrence in filePath to use
+// the parent module name (without the "-crd" suffix). Only the module-name spans are
+// rewritten, so everything else in the file is preserved byte-for-byte. Because the
+// fix rewrites all "-crd" references in the file, running it once resolves every
+// finding for that file and a second run is a no-op — safe when several findings in
+// the same file each carry this fix.
+func fixCRDEnabledModuleReferences(filePath string) errors.AutofixFunc {
+	return func() error {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", filepath.Base(filePath), err)
+		}
+
+		var out bytes.Buffer
+
+		last := 0
+		changed := false
+
+		for _, match := range crdEnabledModulesRe.FindAllSubmatchIndex(content, -1) {
+			nameStart, nameEnd := match[2], match[3]
+
+			name := string(content[nameStart:nameEnd])
+			if !strings.HasSuffix(name, crdModuleSuffix) {
+				continue
+			}
+
+			out.Write(content[last:nameStart])
+			out.WriteString(strings.TrimSuffix(name, crdModuleSuffix))
+
+			last = nameEnd
+			changed = true
+		}
+
+		if !changed {
+			return nil
+		}
+
+		out.Write(content[last:])
+
+		return writeFileAtomically(filePath, out.Bytes())
+	}
+}
+
+// writeFileAtomically writes data to path via a temp file + rename, preserving the
+// original file mode. The temp file is removed if the rename fails.
+func writeFileAtomically(path string, data []byte) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", filepath.Base(path), err)
+	}
+
+	tmpFile := path + ".fix.tmp"
+	if err := os.WriteFile(tmpFile, data, fi.Mode()); err != nil {
+		return fmt.Errorf("write temp file for %s: %w", filepath.Base(path), err)
+	}
+
+	if err := os.Rename(tmpFile, path); err != nil {
+		os.Remove(tmpFile)
+		return fmt.Errorf("rename temp file for %s: %w", filepath.Base(path), err)
+	}
+
+	return nil
+}
+
+// moduleTargetsDeckhouseAtLeast reports whether the module.yaml at modulePath declares
+// a requirements.deckhouse constraint whose minimal allowed version is >= minVersion.
+// Modules without a deckhouse requirement (or with an unparseable constraint) are
+// treated as out of scope and return false.
+func moduleTargetsDeckhouseAtLeast(modulePath, minVersion string) bool {
+	constraintStr := readDeckhouseRequirement(modulePath)
+	if constraintStr == "" {
+		return false
+	}
+
+	constraint, err := semver.NewConstraint(constraintStr)
+	if err != nil {
+		return false
+	}
+
+	minAllowed := minimalAllowedVersion(constraint)
+	if minAllowed == nil {
+		return false
+	}
+
+	minVer, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return false
+	}
+
+	return !minAllowed.LessThan(minVer)
+}
+
+// crdModuleMeta is the minimal slice of module.yaml this rule needs: the target
+// Deckhouse version constraint. module.yaml is parsed with sigs.k8s.io/yaml (YAML via
+// JSON), matching how the module linter reads it, so the tags are json tags.
+type crdModuleMeta struct {
+	Requirements struct {
+		Deckhouse string `json:"deckhouse"`
+	} `json:"requirements"`
+}
+
+// readDeckhouseRequirement returns the raw requirements.deckhouse constraint string
+// from the module.yaml at modulePath, or "" when the file is missing/unreadable or the
+// field is absent.
+func readDeckhouseRequirement(modulePath string) string {
+	data, err := os.ReadFile(filepath.Join(modulePath, moduleConfigFilename))
+	if err != nil {
+		return ""
+	}
+
+	var meta crdModuleMeta
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return ""
+	}
+
+	return meta.Requirements.Deckhouse
+}
+
+// minimalAllowedVersion finds the lowest version bound among the >=, >, and =
+// operators in constraint. != is deliberately ignored — it does not set a lower
+// bound. Returns nil when only <, <=, or != are present. This mirrors
+// findMinimalAllowedVersion in the module linter.
+func minimalAllowedVersion(constraint *semver.Constraints) *semver.Version {
+	if constraint == nil {
+		return nil
+	}
+
+	var minVersion *semver.Version
+
+	for _, m := range crdVersionConstraintRegex.FindAllStringSubmatch(constraint.String(), -1) {
+		if len(m) < 3 {
+			continue
+		}
+
+		op := m[1]
+		if op != ">=" && op != ">" && op != "=" {
+			continue
+		}
+
+		v, err := semver.NewVersion(m[2])
+		if err != nil {
+			continue
+		}
+
+		if minVersion == nil || v.LessThan(minVersion) {
+			minVersion = v
+		}
+	}
+
+	return minVersion
+}

--- a/pkg/linters/templates/rules/crd_enabled_modules_test.go
+++ b/pkg/linters/templates/rules/crd_enabled_modules_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/dmt/internal/mocks"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	// moduleYAMLInScope targets a Deckhouse version at/above the "-crd" removal, so
+	// the rule is active.
+	moduleYAMLInScope = "name: test-module\nrequirements:\n  deckhouse: \">= 1.65\"\n"
+	// moduleYAMLBelowThreshold still supports a Deckhouse release older than the
+	// removal, so the rule must stay silent.
+	moduleYAMLBelowThreshold = "name: test-module\nrequirements:\n  deckhouse: \">= 1.64\"\n"
+	// moduleYAMLNoRequirement declares no deckhouse requirement — out of scope.
+	moduleYAMLNoRequirement = "name: test-module\n"
+)
+
+// writeCRDModule builds a temporary module directory containing an optional
+// module.yaml (skipped when moduleYAML is empty) and the given template files
+// (keyed by path relative to the module root). It returns the module path.
+func writeCRDModule(t *testing.T, moduleYAML string, templateFiles map[string]string) string {
+	t.Helper()
+
+	modulePath := filepath.Join(t.TempDir(), "module")
+	require.NoError(t, os.MkdirAll(modulePath, 0o755))
+
+	if moduleYAML != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(modulePath, moduleConfigFilename), []byte(moduleYAML), 0o600))
+	}
+
+	for relPath, content := range templateFiles {
+		fullPath := filepath.Join(modulePath, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o600))
+	}
+
+	return modulePath
+}
+
+func crdMockModule(t *testing.T, modulePath string) *mocks.ModuleMock {
+	t.Helper()
+
+	m := mocks.NewModuleMock(minimock.NewController(t))
+	m.GetPathMock.Return(modulePath)
+
+	return m
+}
+
+func TestCRDEnabledModulesRule_CheckCRDEnabledModules(t *testing.T) {
+	tests := []struct {
+		name          string
+		moduleYAML    string
+		templateFiles map[string]string
+		wantCount     int
+		wantContains  []string
+		wantLines     []int
+	}{
+		{
+			name:       "flags a -crd reference for a module targeting the removal version",
+			moduleYAML: moduleYAMLInScope,
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: x
+{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+data: {}
+{{- end }}
+`,
+			},
+			wantCount:    1,
+			wantContains: []string{`"operator-prometheus-crd"`, `use "operator-prometheus"`, "1.65.0"},
+			wantLines:    []int{5},
+		},
+		{
+			name:       "flags multiple -crd references in one file",
+			moduleYAML: moduleYAMLInScope,
+			templateFiles: map[string]string{
+				"templates/configmap.yaml": `{{- if .Values.global.enabledModules | has "prometheus-crd" }}
+a: b
+{{- end }}
+{{- if .Values.global.enabledModules | has "user-authn-crd" }}
+c: d
+{{- end }}
+`,
+			},
+			wantCount:    2,
+			wantContains: []string{`use "prometheus"`, `use "user-authn"`},
+			wantLines:    []int{1, 4},
+		},
+		{
+			name:       "ignores a reference to a module without the -crd suffix",
+			moduleYAML: moduleYAMLInScope,
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `{{- if .Values.global.enabledModules | has "cni-cilium" }}
+x: y
+{{- end }}
+`,
+			},
+			wantCount: 0,
+		},
+		{
+			name:       "flags a -crd reference inside a .tpl file",
+			moduleYAML: moduleYAMLInScope,
+			templateFiles: map[string]string{
+				"templates/_helpers.tpl": `{{- define "check" -}}
+{{- if .Values.global.enabledModules | has "vertical-pod-autoscaler-crd" -}}
+on
+{{- end -}}
+{{- end -}}
+`,
+			},
+			wantCount:    1,
+			wantContains: []string{`use "vertical-pod-autoscaler"`},
+			wantLines:    []int{2},
+		},
+		{
+			name:       "flags only the -crd reference when mixed with a plain one",
+			moduleYAML: moduleYAMLInScope,
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `{{- if .Values.global.enabledModules | has "cni-cilium" }}
+a: b
+{{- end }}
+{{- if .Values.global.enabledModules | has "snapshot-controller-crd" }}
+c: d
+{{- end }}
+`,
+			},
+			wantCount:    1,
+			wantContains: []string{`use "snapshot-controller"`},
+			wantLines:    []int{4},
+		},
+		{
+			name:       "skips a module that still supports a Deckhouse release below the threshold",
+			moduleYAML: moduleYAMLBelowThreshold,
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+x: y
+{{- end }}
+`,
+			},
+			wantCount: 0,
+		},
+		{
+			name:       "skips a module without a deckhouse requirement",
+			moduleYAML: moduleYAMLNoRequirement,
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+x: y
+{{- end }}
+`,
+			},
+			wantCount: 0,
+		},
+		{
+			name:       "skips a module without module.yaml",
+			moduleYAML: "",
+			templateFiles: map[string]string{
+				"templates/deployment.yaml": `{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+x: y
+{{- end }}
+`,
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modulePath := writeCRDModule(t, tt.moduleYAML, tt.templateFiles)
+
+			errorList := errors.NewLintRuleErrorsList()
+			NewCRDEnabledModulesRule(nil, nil).CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
+
+			errs := errorList.GetErrors()
+			require.Len(t, errs, tt.wantCount)
+
+			for _, want := range tt.wantContains {
+				found := false
+				for i := range errs {
+					if containsStr(errs[i].Text, want) {
+						found = true
+						break
+					}
+				}
+				assert.Truef(t, found, "expected a finding containing %q, got %+v", want, errs)
+			}
+
+			for i, wantLine := range tt.wantLines {
+				if i < len(errs) {
+					assert.Equalf(t, wantLine, errs[i].LineNumber, "unexpected line for finding %d: %s", i, errs[i].Text)
+				}
+			}
+		})
+	}
+}
+
+func TestCRDEnabledModulesRule_Excludes(t *testing.T) {
+	files := map[string]string{
+		"templates/skip-me.yaml": `{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+x: y
+{{- end }}
+`,
+	}
+	modulePath := writeCRDModule(t, moduleYAMLInScope, files)
+
+	errorList := errors.NewLintRuleErrorsList()
+	NewCRDEnabledModulesRule([]pkg.StringRuleExclude{"templates/skip-me.yaml"}, nil).
+		CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
+
+	assert.Empty(t, errorList.GetErrors())
+}
+
+func TestCRDEnabledModulesRule_Autofix(t *testing.T) {
+	const templateName = "templates/deployment.yaml"
+
+	original := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: x
+{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+prometheus: "on"
+{{- end }}
+{{- if .Values.global.enabledModules | has "cni-cilium" }}
+cilium: "on"
+{{- end }}
+{{- if .Values.global.enabledModules | has "user-authn-crd" }}
+authn: "on"
+{{- end }}
+`
+
+	modulePath := writeCRDModule(t, moduleYAMLInScope, map[string]string{templateName: original})
+
+	errorList := errors.NewLintRuleErrorsList()
+	NewCRDEnabledModulesRule(nil, nil).CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
+
+	fixes := errorList.GetFixes()
+	require.Len(t, fixes, 2, "each -crd finding should carry a fix")
+
+	for _, fix := range fixes {
+		fix()
+	}
+
+	// After applying the fixes the fixed findings are dropped from the error list.
+	assert.Empty(t, errorList.GetErrors())
+
+	fixed, err := os.ReadFile(filepath.Join(modulePath, templateName))
+	require.NoError(t, err)
+	got := string(fixed)
+
+	assert.Contains(t, got, `has "operator-prometheus"`)
+	assert.NotContains(t, got, `operator-prometheus-crd`)
+	assert.Contains(t, got, `has "user-authn"`)
+	assert.NotContains(t, got, `user-authn-crd`)
+	// Plain (non -crd) references must be left untouched.
+	assert.Contains(t, got, `has "cni-cilium"`)
+
+	// Re-running the rule on the fixed module must find nothing (idempotency).
+	rerun := errors.NewLintRuleErrorsList()
+	NewCRDEnabledModulesRule(nil, nil).CheckCRDEnabledModules(crdMockModule(t, modulePath), rerun)
+	assert.Empty(t, rerun.GetErrors())
+}

--- a/pkg/linters/templates/rules/crd_enabled_modules_test.go
+++ b/pkg/linters/templates/rules/crd_enabled_modules_test.go
@@ -203,12 +203,14 @@ x: y
 
 			for _, want := range tt.wantContains {
 				found := false
+
 				for i := range errs {
 					if containsStr(errs[i].Text, want) {
 						found = true
 						break
 					}
 				}
+
 				assert.Truef(t, found, "expected a finding containing %q, got %+v", want, errs)
 			}
 
@@ -272,6 +274,7 @@ authn: "on"
 
 	fixed, err := os.ReadFile(filepath.Join(modulePath, templateName))
 	require.NoError(t, err)
+
 	got := string(fixed)
 
 	assert.Contains(t, got, `has "operator-prometheus"`)

--- a/pkg/linters/templates/rules/crd_enabled_modules_test.go
+++ b/pkg/linters/templates/rules/crd_enabled_modules_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/deckhouse/dmt/internal/mocks"
-	"github.com/deckhouse/dmt/pkg"
 	"github.com/deckhouse/dmt/pkg/errors"
 )
 
@@ -196,7 +195,7 @@ x: y
 			modulePath := writeCRDModule(t, tt.moduleYAML, tt.templateFiles)
 
 			errorList := errors.NewLintRuleErrorsList()
-			NewCRDEnabledModulesRule(nil, nil).CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
+			NewCRDEnabledModulesRule().CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
 
 			errs := errorList.GetErrors()
 			require.Len(t, errs, tt.wantCount)
@@ -223,22 +222,6 @@ x: y
 	}
 }
 
-func TestCRDEnabledModulesRule_Excludes(t *testing.T) {
-	files := map[string]string{
-		"templates/skip-me.yaml": `{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
-x: y
-{{- end }}
-`,
-	}
-	modulePath := writeCRDModule(t, moduleYAMLInScope, files)
-
-	errorList := errors.NewLintRuleErrorsList()
-	NewCRDEnabledModulesRule([]pkg.StringRuleExclude{"templates/skip-me.yaml"}, nil).
-		CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
-
-	assert.Empty(t, errorList.GetErrors())
-}
-
 func TestCRDEnabledModulesRule_Autofix(t *testing.T) {
 	const templateName = "templates/deployment.yaml"
 
@@ -260,7 +243,7 @@ authn: "on"
 	modulePath := writeCRDModule(t, moduleYAMLInScope, map[string]string{templateName: original})
 
 	errorList := errors.NewLintRuleErrorsList()
-	NewCRDEnabledModulesRule(nil, nil).CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
+	NewCRDEnabledModulesRule().CheckCRDEnabledModules(crdMockModule(t, modulePath), errorList)
 
 	fixes := errorList.GetFixes()
 	require.Len(t, fixes, 2, "each -crd finding should carry a fix")
@@ -286,6 +269,6 @@ authn: "on"
 
 	// Re-running the rule on the fixed module must find nothing (idempotency).
 	rerun := errors.NewLintRuleErrorsList()
-	NewCRDEnabledModulesRule(nil, nil).CheckCRDEnabledModules(crdMockModule(t, modulePath), rerun)
+	NewCRDEnabledModulesRule().CheckCRDEnabledModules(crdMockModule(t, modulePath), rerun)
 	assert.Empty(t, rerun.GetErrors())
 }

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -106,6 +106,12 @@ func (l *Templates) Run(m *modules.Module) {
 		l.cfg.ExcludeRules.EnabledModules.Directories.Get(),
 	).CheckEnabledModules(m, errorList.WithMaxLevel(l.cfg.Rules.EnabledModulesRule.GetLevel()))
 
+	// CRDEnabledModules rule - deprecated references to standalone "-crd" modules
+	rules.NewCRDEnabledModulesRule(
+		l.cfg.ExcludeRules.CRDEnabledModules.Files.Get(),
+		l.cfg.ExcludeRules.CRDEnabledModules.Directories.Get(),
+	).CheckCRDEnabledModules(m, errorList.WithMaxLevel(l.cfg.Rules.CRDEnabledModulesRule.GetLevel()))
+
 	// MountPoints rule
 	rules.NewMountPointsRule(l.cfg.ExcludeRules.MountPoints.Get()).ValidateMountPoints(m, errorList.WithMaxLevel(l.cfg.Rules.MountPointsRule.GetLevel()))
 

--- a/pkg/linters/templates/templates.go
+++ b/pkg/linters/templates/templates.go
@@ -107,10 +107,8 @@ func (l *Templates) Run(m *modules.Module) {
 	).CheckEnabledModules(m, errorList.WithMaxLevel(l.cfg.Rules.EnabledModulesRule.GetLevel()))
 
 	// CRDEnabledModules rule - deprecated references to standalone "-crd" modules
-	rules.NewCRDEnabledModulesRule(
-		l.cfg.ExcludeRules.CRDEnabledModules.Files.Get(),
-		l.cfg.ExcludeRules.CRDEnabledModules.Directories.Get(),
-	).CheckCRDEnabledModules(m, errorList.WithMaxLevel(l.cfg.Rules.CRDEnabledModulesRule.GetLevel()))
+	rules.NewCRDEnabledModulesRule().
+		CheckCRDEnabledModules(m, errorList.WithMaxLevel(l.cfg.Rules.CRDEnabledModulesRule.GetLevel()))
 
 	// MountPoints rule
 	rules.NewMountPointsRule(l.cfg.ExcludeRules.MountPoints.Get()).ValidateMountPoints(m, errorList.WithMaxLevel(l.cfg.Rules.MountPointsRule.GetLevel()))

--- a/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/expected.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/expected.yaml
@@ -1,0 +1,8 @@
+description: >
+  A module that still supports a Deckhouse release below 1.65 (requirements.deckhouse
+  ">= 1.64") must NOT be flagged by the crd-enabled-modules rule, because the standalone
+  "-crd" module still exists on those releases. This guards the version gate.
+module: module
+expectAbsent:
+  - linter: templates
+    rule: crd-enabled-modules

--- a/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/module.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/module.yaml
@@ -1,0 +1,8 @@
+name: e2e-crd-enabled-modules-below
+namespace: e2e-crd-enabled-modules-below
+weight: 910
+descriptions:
+  en: "Module used to verify the crd-enabled-modules version gate (Deckhouse >= 1.64)"
+  ru: "Модуль для проверки версионного гейта crd-enabled-modules (Deckhouse >= 1.64)"
+requirements:
+  deckhouse: ">= 1.64"

--- a/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/openapi/values.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/templates/configmap.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-below-threshold/module/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+  name: e2e-crd-config
+{{- else }}
+  name: e2e-crd-config-disabled
+{{- end }}
+  namespace: e2e-crd-enabled-modules-below
+data: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules-fix/expected.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-fix/expected.yaml
@@ -1,0 +1,10 @@
+description: >
+  Running the lint pipeline with --fix on the same in-scope module as the
+  crd-enabled-modules case rewrites `has "operator-prometheus-crd"` to
+  `has "operator-prometheus"`, so the crd-enabled-modules finding is resolved by the
+  autofix and no longer reported.
+kind: fix
+module: module
+expectAbsent:
+  - linter: templates
+    rule: crd-enabled-modules

--- a/test/e2e/testdata/templates/crd-enabled-modules-fix/module/module.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-fix/module/module.yaml
@@ -1,0 +1,8 @@
+name: e2e-crd-enabled-modules-fix
+namespace: e2e-crd-enabled-modules-fix
+weight: 910
+descriptions:
+  en: "Module used to verify the crd-enabled-modules autofix (Deckhouse >= 1.65)"
+  ru: "Модуль для проверки автофикса crd-enabled-modules (Deckhouse >= 1.65)"
+requirements:
+  deckhouse: ">= 1.65"

--- a/test/e2e/testdata/templates/crd-enabled-modules-fix/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-fix/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules-fix/module/openapi/values.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-fix/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules-fix/module/templates/configmap.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules-fix/module/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+  name: e2e-crd-config
+{{- else }}
+  name: e2e-crd-config-disabled
+{{- end }}
+  namespace: e2e-crd-enabled-modules-fix
+data: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules/expected.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules/expected.yaml
@@ -7,6 +7,6 @@ module: module
 expect:
   - linter: templates
     rule: crd-enabled-modules
-    level: error
+    level: warn
     textContains: 'use "operator-prometheus"'
     count: 1

--- a/test/e2e/testdata/templates/crd-enabled-modules/expected.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules/expected.yaml
@@ -1,0 +1,12 @@
+description: >
+  A module targeting Deckhouse >= 1.65 (where the standalone "-crd" modules were
+  removed) that checks `.Values.global.enabledModules | has "operator-prometheus-crd"`
+  must be flagged by the templates crd-enabled-modules rule, suggesting the parent
+  module name without the "-crd" suffix.
+module: module
+expect:
+  - linter: templates
+    rule: crd-enabled-modules
+    level: error
+    textContains: 'use "operator-prometheus"'
+    count: 1

--- a/test/e2e/testdata/templates/crd-enabled-modules/module/module.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules/module/module.yaml
@@ -1,0 +1,8 @@
+name: e2e-crd-enabled-modules
+namespace: e2e-crd-enabled-modules
+weight: 910
+descriptions:
+  en: "Module used to verify the templates crd-enabled-modules lint (Deckhouse >= 1.65)"
+  ru: "Модуль для проверки правила crd-enabled-modules (Deckhouse >= 1.65)"
+requirements:
+  deckhouse: ">= 1.65"

--- a/test/e2e/testdata/templates/crd-enabled-modules/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules/module/openapi/values.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/templates/crd-enabled-modules/module/templates/configmap.yaml
+++ b/test/e2e/testdata/templates/crd-enabled-modules/module/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+{{- if .Values.global.enabledModules | has "operator-prometheus-crd" }}
+  name: e2e-crd-config
+{{- else }}
+  name: e2e-crd-config-disabled
+{{- end }}
+  namespace: e2e-crd-enabled-modules
+data: {}


### PR DESCRIPTION
## Summary

Adds a new **`crd-enabled-modules`** rule to the **templates** linter. It detects
deprecated references to the standalone `*-crd` modules inside
`.Values.global.enabledModules | has "…"` checks and can rewrite them (with `--fix`)
to the parent module name, dropping the `-crd` suffix:

```gotemplate
{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
```

→

```gotemplate
{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
```

Findings are reported at **`warn`** level: the `-crd` tokens still resolve through a
backward-compatibility shim, so this is a deprecation rather than a hard error.

## Why

Starting from **Deckhouse v1.65.0** the standalone `*-crd` modules (e.g.
`operator-prometheus-crd`, `user-authn-crd`, `prometheus-crd`, …) were removed —
see deckhouse/deckhouse#9593 *"Get rid of crd modules"*. Their CRDs are now
discovered and installed automatically from the parent module's `crds/` directory,
so a separate `-crd` module no longer exists. The `-crd` tokens are kept in
`global.enabledModules` only as a temporary backward-compatibility shim and are
slated for removal, after which `has "…-crd"` will silently evaluate to `false`.
Referencing the obsolete name is therefore deprecated and brittle, and should be
migrated to the parent module name.

## What it does

- **Detection** — scans the raw template files (`.yaml`, `.yml`, `.tpl`) under
  `templates/` for `.Values.global.enabledModules | has "<name>-crd"` and reports
  each occurrence (as a warning) together with the suggested replacement.
- **Version gate** — only runs for modules whose `module.yaml`
  `requirements.deckhouse` constraint starts at or above `1.65.0` (the removal
  release). Modules that still support older Deckhouse releases — or that declare no
  `requirements.deckhouse` — are left untouched, because the `-crd` module still
  exists there. This mirrors the module linter's existing version-gated checks
  (`weight_deprecated`, `bootstrapped_deprecated`, …).
- **Autofix** — `dmt lint --fix` rewrites every `has "<name>-crd"` to
  `has "<name>"`, touching only the module-name text and leaving the rest of the
  file byte-for-byte identical; the fix is idempotent.

Example finding:

```
Deprecated "operator-prometheus-crd" reference in .Values.global.enabledModules: standalone "-crd" modules were removed in Deckhouse v1.65.0, use "operator-prometheus" instead.
```

## Changes

**New rule**

- `pkg/linters/templates/rules/crd_enabled_modules.go` — the rule: raw-template
  scan, `-crd` filtering, semver-based version gate (parses `requirements.deckhouse`
  from `module.yaml`), and the idempotent atomic autofix.

**Wiring / config** — new `crd-enabled-modules` rule registered across all three
config mirrors (severity via `impact` only; no per-file excludes):

- `pkg/linters/templates/templates.go` — instantiate and run the rule.
- `pkg/config.go`, `pkg/config/linters_settings.go`, `pkg/config/global/global.go`
  — the rule's `RuleConfig` (`impact`).
- `internal/modules/module.go` — per-rule level mapping.

**Docs**

- `pkg/linters/templates/README.md` — rules-table row + a full rule section
  (purpose, version gate, ❌/✅ examples, autofix, configuration).

**Tests**

- `pkg/linters/templates/rules/crd_enabled_modules_test.go` — unit tests: detection
  (asserting `warn` level), multiple / `.tpl` / mixed matches, all version-gate
  boundaries (in-scope / below-threshold / no `requirements.deckhouse` / no
  `module.yaml`), and the autofix including idempotency.
- `test/e2e/testdata/templates/crd-enabled-modules{,-below-threshold,-fix}/` — three
  e2e cases exercised through the full lint pipeline: detection fires as a warning,
  the version gate stays silent, and `--fix` resolves the finding.

## Configuration

```yaml
# .dmtlint.yaml
linters-settings:
  templates:
    rules:
      crd-enabled-modules:
        impact: warn   # error | warn (default: warn)
```
