### PR TITLE
[dmt] Add `sys-cgroup-mount` container rule

### DIFF
--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -296,6 +296,16 @@ func mapContainerRules(linterSettings *pkg.LintersSettings, configSettings *conf
 		globalConfig.Container.Rules.MountPointsRule.Impact,
 		configSettings.Container.Impact,
 	)
+	// sys-cgroup-mount defaults to warn: a container that mounts /sys but not
+	// /sys/fs/cgroup only breaks on a hardened (read-only) containerd such as the
+	// CSE edition, so a missing cgroup mount is a portability warning rather than
+	// an error. A per-rule impact in config still overrides this default. warn is
+	// passed explicitly because the container linter fallback impact
+	// (configSettings.Container.Impact) defaults to "error".
+	linterSettings.Container.Rules.SysCgroupMountRule.SetLevel(
+		globalConfig.Container.Rules.SysCgroupMountRule.Impact,
+		pkg.Warn.String(),
+	)
 }
 
 // mapImageRules configures Image linter rules
@@ -441,6 +451,7 @@ func mapContainerExclusions(linterSettings *pkg.LintersSettings, configSettings 
 	excludes.Readiness = configExcludes.Readiness.Get()
 	excludes.SeccompProfile = configExcludes.SeccompProfile.Get()
 	excludes.NoNewPrivileges = configExcludes.NoNewPrivileges.Get()
+	excludes.SysCgroupMount = configExcludes.SysCgroupMount.Get()
 	excludes.Description = pkg.StringRuleExcludeList(configExcludes.Description)
 	excludes.MountPoints = pkg.StringRuleExcludeList(configExcludes.MountPoints)
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -353,6 +353,7 @@ type ContainerLinterRules struct {
 	LivenessRule                 RuleConfig
 	ReadinessRule                RuleConfig
 	MountPointsRule              RuleConfig
+	SysCgroupMountRule           RuleConfig
 }
 
 type ContainerExcludeRules struct {
@@ -372,6 +373,7 @@ type ContainerExcludeRules struct {
 	SecurityContext        ContainerRuleExcludeList
 	Liveness               ContainerRuleExcludeList
 	Readiness              ContainerRuleExcludeList
+	SysCgroupMount         ContainerRuleExcludeList
 
 	Description StringRuleExcludeList
 	MountPoints StringRuleExcludeList

--- a/pkg/config/global/global.go
+++ b/pkg/config/global/global.go
@@ -68,6 +68,7 @@ type ContainerRules struct {
 	LivenessRule                 RuleConfig `mapstructure:"liveness-probe"`
 	ReadinessRule                RuleConfig `mapstructure:"readiness-probe"`
 	MountPointsRule              RuleConfig `mapstructure:"mount-points"`
+	SysCgroupMountRule           RuleConfig `mapstructure:"sys-cgroup-mount"`
 }
 
 type ImagesLinterConfig struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -71,6 +71,7 @@ type ContainerExcludeRules struct {
 	SecurityContext        ContainerRuleExcludeList `mapstructure:"security-context"`
 	Liveness               ContainerRuleExcludeList `mapstructure:"liveness-probe"`
 	Readiness              ContainerRuleExcludeList `mapstructure:"readiness-probe"`
+	SysCgroupMount         ContainerRuleExcludeList `mapstructure:"sys-cgroup-mount"`
 
 	Description StringRuleExcludeList `mapstructure:"description"`
 	MountPoints StringRuleExcludeList `mapstructure:"mount-points"`

--- a/pkg/linters/container/README.md
+++ b/pkg/linters/container/README.md
@@ -43,6 +43,7 @@ Proper container configuration is critical for cluster stability, security, and 
 | [readiness-probe](#readiness-probe) | Validates readiness probe configuration | ✅ | enabled |
 | [no-new-privileges](#no-new-privileges) | Validates containers don't allow privilege escalation | ✅ | enabled |
 | [seccomp-profile](#seccomp-profile) | Validates seccomp profile configuration | ✅ | enabled |
+| [sys-cgroup-mount](#sys-cgroup-mount) | Requires `/sys/fs/cgroup` when a container mounts the host `/sys` | ✅ | enabled |
 
 "Configurable" means that this rule can be configured using the `.dmtlint.yaml` file, including customizing the rule's parameters and/or disabling the rule.
 
@@ -1899,3 +1900,96 @@ Error: Pod running in hostNetwork and it's container port doesn't fit the range 
              ports:
                - containerPort: 4250  # Within [4200-4299]
    ```
+
+---
+
+### sys-cgroup-mount
+
+**Purpose:** Ensures that a container mounting the host `/sys` also mounts `/sys/fs/cgroup`, so the workload keeps access to cgroup data on a hardened container runtime.
+
+**Description:**
+
+On a hardened containerd (integrity checks and a fully read-only root, as used by the CSE edition) the recursive bind that normally carries the nested `/sys/fs/cgroup` submount along with `/sys` does not apply. A container that reads cgroup data therefore has to mount `/sys/fs/cgroup` explicitly. The extra read-only mount is harmless on ordinary runtimes (there the submount is already present), so declaring it keeps a module portable to the CSE edition by default.
+
+**What it checks:**
+
+The rule is self-scoping — it fires only for containers that actually mount `/sys`. For every such container (in `Deployment`, `DaemonSet`, `StatefulSet`, `Pod`, `Job` or `CronJob`) it requires a matching `/sys/fs/cgroup` volumeMount in the **same** container, because mounts are per-container. Containers that do not mount `/sys` are never touched.
+
+**Why it matters:**
+
+Without the explicit cgroup mount, a workload that relies on cgroup data (metrics/monitoring agents, storage drivers such as ceph/nfs, and similar node-level components) silently passes on an ordinary runtime but breaks on the hardened runtime used by the CSE edition, where the nested mount is not propagated.
+
+**Examples:**
+
+❌ **Incorrect** - mounts `/sys` but not `/sys/fs/cgroup`:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: agent
+          image: my-image
+          volumeMounts:
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys
+```
+
+✅ **Correct** - mounts both:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: agent
+          image: my-image
+          volumeMounts:
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+              readOnly: true
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+```
+
+> **Warning:** this rule defaults to `warn`, not `error` — a missing cgroup mount only breaks on the hardened (read-only) containerd used by the CSE edition, so it is reported as a portability warning. Set `impact: error` to enforce it as a hard failure.
+
+**Configuration:**
+
+Raise the severity to a hard error (the default is `warn`). Per-rule impact for container rules is set under the `global` section:
+
+```yaml
+# .dmtlint.yaml
+global:
+  linters-settings:
+    container:
+      rules:
+        sys-cgroup-mount:
+          impact: error   # error | warn (default: warn)
+```
+
+Opt a container out of the rule when it is known not to need cgroup data:
+
+```yaml
+# .dmtlint.yaml
+linters-settings:
+  container:
+    exclude-rules:
+      sys-cgroup-mount:
+        - kind: DaemonSet
+          name: network-agent
+          container: agent
+```

--- a/pkg/linters/container/rules.go
+++ b/pkg/linters/container/rules.go
@@ -96,6 +96,10 @@ func (l *Container) applyContainerRules(object storage.StoreObject, storageMap m
 			rules.NewMountPointsRule(l.cfg.ExcludeRules.MountPoints.Get(), l.modulePath).
 				CheckMountPaths(object, containers, errorList.WithMaxLevel(l.cfg.Rules.MountPointsRule.GetLevel()))
 		},
+		func(object storage.StoreObject, containers []corev1.Container, errorList *errors.LintRuleErrorsList) {
+			rules.NewSysCgroupMountRule(l.cfg.ExcludeRules.SysCgroupMount.Get()).
+				CheckSysCgroupMount(object, containers, errorList.WithMaxLevel(l.cfg.Rules.SysCgroupMountRule.GetLevel()))
+		},
 	}
 
 	for _, rule := range containerRules {

--- a/pkg/linters/container/rules/sys_cgroup_mount.go
+++ b/pkg/linters/container/rules/sys_cgroup_mount.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+const (
+	SysCgroupMountRuleName = "sys-cgroup-mount"
+
+	// sysMountPath is the host sysfs mount whose presence triggers the rule.
+	sysMountPath = "/sys"
+	// sysCgroupMountPath is the cgroup mount that must accompany a /sys mount.
+	sysCgroupMountPath = "/sys/fs/cgroup"
+)
+
+func NewSysCgroupMountRule(excludeRules []pkg.ContainerRuleExclude) *SysCgroupMountRule {
+	return &SysCgroupMountRule{
+		RuleMeta: pkg.RuleMeta{
+			Name: SysCgroupMountRuleName,
+		},
+		ContainerRule: pkg.ContainerRule{
+			ExcludeRules: excludeRules,
+		},
+	}
+}
+
+type SysCgroupMountRule struct {
+	pkg.RuleMeta
+	pkg.ContainerRule
+}
+
+// CheckSysCgroupMount verifies that every container mounting the host /sys also
+// mounts /sys/fs/cgroup.
+//
+// Rationale: on a hardened containerd (integrity checks + full read-only root, as
+// used by the CSE edition) the recursive bind that normally carries the nested
+// /sys/fs/cgroup submount along with /sys does not apply, so a container that
+// relies on cgroup data has to mount /sys/fs/cgroup explicitly. The extra
+// read-only mount is harmless on ordinary runtimes (there the submount is already
+// present), so requiring it keeps modules portable to the CSE edition by default.
+//
+// The rule is self-scoping: it only fires for containers that actually mount /sys.
+// The check is per container, because mounts are per-container — the very
+// container that mounts /sys must also mount /sys/fs/cgroup.
+func (r *SysCgroupMountRule) CheckSysCgroupMount(object storage.StoreObject, containers []corev1.Container, errorList *errors.LintRuleErrorsList) {
+	errorList = errorList.WithRule(r.GetName())
+
+	switch object.Unstructured.GetKind() {
+	case "Deployment", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob":
+	default:
+		return
+	}
+
+	for i := range containers {
+		c := &containers[i]
+
+		if !r.Enabled(object, c) {
+			continue
+		}
+
+		var hasSys, hasCgroup bool
+
+		for j := range c.VolumeMounts {
+			switch strings.TrimRight(c.VolumeMounts[j].MountPath, "/") {
+			case sysMountPath:
+				hasSys = true
+			case sysCgroupMountPath:
+				hasCgroup = true
+			}
+		}
+
+		if hasSys && !hasCgroup {
+			errorList.WithObjectID(object.Identity()+" ; container = "+c.Name).
+				WithValue(sysCgroupMountPath).
+				Errorf("Container %q mounts %q but not %q: on a hardened (read-only) containerd the nested cgroup mount is not propagated together with %q, so %q must be mounted explicitly", c.Name, sysMountPath, sysCgroupMountPath, sysMountPath, sysCgroupMountPath)
+		}
+	}
+}

--- a/pkg/linters/container/rules/sys_cgroup_mount_test.go
+++ b/pkg/linters/container/rules/sys_cgroup_mount_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/dmt/internal/storage"
+	"github.com/deckhouse/dmt/pkg"
+	"github.com/deckhouse/dmt/pkg/errors"
+)
+
+// objectWithContainerMounts builds a pod controller with one container per entry
+// in containers, each carrying the given volumeMount paths. Unlike
+// objectWithMounts it lets a test place mounts in distinct containers, which the
+// per-container check depends on.
+func objectWithContainerMounts(kind, name string, containers map[string][]string) storage.StoreObject {
+	specContainers := make([]any, 0, len(containers))
+
+	for containerName, mountPaths := range containers {
+		mounts := make([]any, 0, len(mountPaths))
+		for _, mp := range mountPaths {
+			mounts = append(mounts, map[string]any{
+				"name":      "vol",
+				"mountPath": mp,
+			})
+		}
+
+		specContainers = append(specContainers, map[string]any{
+			"name":         containerName,
+			"image":        "test:latest",
+			"volumeMounts": mounts,
+		})
+	}
+
+	return storage.StoreObject{
+		Unstructured: unstructured.Unstructured{
+			Object: map[string]any{
+				"kind":       kind,
+				"apiVersion": "apps/v1",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": specContainers,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSysCgroupMountRule_CheckSysCgroupMount(t *testing.T) {
+	tests := []struct {
+		name         string
+		object       storage.StoreObject
+		wantCount    int
+		wantContains string
+	}{
+		{
+			name:         "flags a container mounting /sys but not /sys/fs/cgroup",
+			object:       objectWithMounts("Deployment", "app", "/sys"),
+			wantCount:    1,
+			wantContains: `not "/sys/fs/cgroup"`,
+		},
+		{
+			name:      "accepts a container mounting both /sys and /sys/fs/cgroup",
+			object:    objectWithMounts("Deployment", "app", "/sys", "/sys/fs/cgroup"),
+			wantCount: 0,
+		},
+		{
+			name:      "ignores a container mounting only /sys/fs/cgroup",
+			object:    objectWithMounts("Deployment", "app", "/sys/fs/cgroup"),
+			wantCount: 0,
+		},
+		{
+			name:      "ignores a container that does not mount /sys",
+			object:    objectWithMounts("Deployment", "app", "/etc/app", "/var/data"),
+			wantCount: 0,
+		},
+		{
+			name:         "normalizes a trailing slash on /sys",
+			object:       objectWithMounts("Deployment", "app", "/sys/"),
+			wantCount:    1,
+			wantContains: `mounts "/sys"`,
+		},
+		{
+			name:      "fires for a DaemonSet (the classic node-agent case)",
+			object:    objectWithMounts("DaemonSet", "node-agent", "/sys"),
+			wantCount: 1,
+		},
+		{
+			name:      "skips objects that are not pod controllers",
+			object:    objectWithMounts("ConfigMap", "cm", "/sys"),
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containers, err := tt.object.GetAllContainers()
+			require.NoError(t, err)
+
+			errorList := errors.NewLintRuleErrorsList()
+			NewSysCgroupMountRule(nil).CheckSysCgroupMount(tt.object, containers, errorList)
+
+			errs := errorList.GetErrors()
+			require.Len(t, errs, tt.wantCount)
+
+			if tt.wantContains != "" {
+				assert.Truef(t, strings.Contains(errs[0].Text, tt.wantContains),
+					"expected finding to contain %q, got %q", tt.wantContains, errs[0].Text)
+			}
+		})
+	}
+}
+
+// TestSysCgroupMountRule_PerContainer verifies the check is per container: a
+// sibling container mounting /sys/fs/cgroup does not satisfy the requirement for
+// the container that actually mounts /sys.
+func TestSysCgroupMountRule_PerContainer(t *testing.T) {
+	object := objectWithContainerMounts("Deployment", "app", map[string][]string{
+		"needs-sys":  {"/sys"},
+		"has-cgroup": {"/sys/fs/cgroup"},
+	})
+
+	containers, err := object.GetAllContainers()
+	require.NoError(t, err)
+
+	errorList := errors.NewLintRuleErrorsList()
+	NewSysCgroupMountRule(nil).CheckSysCgroupMount(object, containers, errorList)
+
+	errs := errorList.GetErrors()
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Text, "needs-sys")
+}
+
+func TestSysCgroupMountRule_Excludes(t *testing.T) {
+	object := objectWithMounts("Deployment", "app", "/sys")
+
+	containers, err := object.GetAllContainers()
+	require.NoError(t, err)
+
+	t.Run("exclude by kind and name silences the finding", func(t *testing.T) {
+		excludes := []pkg.ContainerRuleExclude{{Kind: "Deployment", Name: "app"}}
+
+		errorList := errors.NewLintRuleErrorsList()
+		NewSysCgroupMountRule(excludes).CheckSysCgroupMount(object, containers, errorList)
+
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	t.Run("exclude scoped to the container silences the finding", func(t *testing.T) {
+		excludes := []pkg.ContainerRuleExclude{{Kind: "Deployment", Name: "app", Container: "main"}}
+
+		errorList := errors.NewLintRuleErrorsList()
+		NewSysCgroupMountRule(excludes).CheckSysCgroupMount(object, containers, errorList)
+
+		assert.Empty(t, errorList.GetErrors())
+	})
+
+	t.Run("exclude for a different object leaves the finding", func(t *testing.T) {
+		excludes := []pkg.ContainerRuleExclude{{Kind: "Deployment", Name: "other"}}
+
+		errorList := errors.NewLintRuleErrorsList()
+		NewSysCgroupMountRule(excludes).CheckSysCgroupMount(object, containers, errorList)
+
+		assert.Len(t, errorList.GetErrors(), 1)
+	})
+}

--- a/test/e2e/testdata/container/sys-cgroup-mount-missing/expected.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-missing/expected.yaml
@@ -1,0 +1,10 @@
+description: >
+  A container that mounts the host /sys but not /sys/fs/cgroup is flagged, so the
+  module stays portable to the hardened (read-only) containerd used by the CSE
+  edition where the nested cgroup mount is not propagated automatically.
+module: module
+expect:
+  - linter: container
+    rule: sys-cgroup-mount
+    level: warn
+    textContains: '/sys/fs/cgroup'

--- a/test/e2e/testdata/container/sys-cgroup-mount-missing/module/module.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-missing/module/module.yaml
@@ -1,0 +1,2 @@
+name: e2e-sys-cgroup-mount-missing
+namespace: e2e-sys-cgroup-mount-missing

--- a/test/e2e/testdata/container/sys-cgroup-mount-missing/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-missing/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/container/sys-cgroup-mount-missing/module/openapi/values.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-missing/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/container/sys-cgroup-mount-missing/module/templates/daemonset.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-missing/module/templates/daemonset.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-agent
+  namespace: e2e-sys-cgroup-mount-missing
+spec:
+  selector:
+    matchLabels:
+      app: node-agent
+  template:
+    metadata:
+      labels:
+        app: node-agent
+    spec:
+      containers:
+      - name: agent
+        image: test:latest
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys

--- a/test/e2e/testdata/container/sys-cgroup-mount-ok/expected.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-ok/expected.yaml
@@ -1,0 +1,7 @@
+description: >
+  A container that mounts both /sys and /sys/fs/cgroup must NOT be flagged by the
+  sys-cgroup-mount rule.
+module: module
+expectAbsent:
+  - linter: container
+    rule: sys-cgroup-mount

--- a/test/e2e/testdata/container/sys-cgroup-mount-ok/module/module.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-ok/module/module.yaml
@@ -1,0 +1,2 @@
+name: e2e-sys-cgroup-mount-ok
+namespace: e2e-sys-cgroup-mount-ok

--- a/test/e2e/testdata/container/sys-cgroup-mount-ok/module/openapi/config-values.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-ok/module/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/test/e2e/testdata/container/sys-cgroup-mount-ok/module/openapi/values.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-ok/module/openapi/values.yaml
@@ -1,0 +1,4 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties: {}

--- a/test/e2e/testdata/container/sys-cgroup-mount-ok/module/templates/daemonset.yaml
+++ b/test/e2e/testdata/container/sys-cgroup-mount-ok/module/templates/daemonset.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-agent
+  namespace: e2e-sys-cgroup-mount-ok
+spec:
+  selector:
+    matchLabels:
+      app: node-agent
+  template:
+    metadata:
+      labels:
+        app: node-agent
+    spec:
+      containers:
+      - name: agent
+        image: test:latest
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: cgroup
+          mountPath: /sys/fs/cgroup
+          readOnly: true
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup


### PR DESCRIPTION
## Summary

Adds a new container linter rule, **`sys-cgroup-mount`**, that flags any container which mounts the host `/sys` but does **not** also mount `/sys/fs/cgroup`, and suggests adding the missing mount.

The rule defaults to **`warn`** (configurable to `error`) and is self-scoping: it only fires for containers that actually mount `/sys`.

## Why

On a hardened container runtime — containerd with integrity checks and a fully read-only root, as used by the **CSE** edition — the recursive bind mount that normally carries the nested `/sys/fs/cgroup` submount along with `/sys` does not apply. A container that reads cgroup data therefore has to mount `/sys/fs/cgroup` explicitly, or it silently loses cgroup access on that runtime.

This is a quiet, edition-specific failure: a workload passes on an ordinary containerd (where the submount is present automatically) but breaks on the hardened runtime. It affects node-level components that host-mount `/sys` (metrics/monitoring agents, storage drivers such as ceph/nfs, and similar). Catching it at lint time — before the module ships — is exactly what this rule is for. Declaring the extra read-only mount is harmless on ordinary runtimes, so requiring it keeps modules portable to CSE by default.

## What it does

- **Detection.** For each container in a pod controller (`Deployment`, `DaemonSet`, `StatefulSet`, `Pod`, `Job`, `CronJob`), if the container has a `volumeMount` at `/sys` but none at `/sys/fs/cgroup`, it reports a finding.
- **Self-scoping.** The rule is a no-op for containers that do not mount `/sys` — no configuration or version gate needed to keep its blast radius small.
- **Per container.** The check is per container, because mounts are per-container: a sibling container mounting `/sys/fs/cgroup` does not satisfy the requirement for the container that mounts `/sys`.
- **Path normalization.** A trailing slash is normalized (`/sys/` is treated as `/sys`).

### Example

❌ Flagged — mounts `/sys` only:

```yaml
volumeMounts:
  - name: sys
    mountPath: /sys
    readOnly: true
```

✅ Clean — mounts both:

```yaml
volumeMounts:
  - name: sys
    mountPath: /sys
    readOnly: true
  - name: cgroup
    mountPath: /sys/fs/cgroup
    readOnly: true
```

## Severity & configuration

Default severity is **`warn`**: a missing cgroup mount only breaks on the hardened (read-only) containerd used by CSE, so it is reported as a portability warning rather than a hard failure. It can be raised to a hard error per rule:

```yaml
# .dmtlint.yaml
global:
  linters-settings:
    container:
      rules:
        sys-cgroup-mount:
          impact: error   # error | warn (default: warn)
```

A container that is known not to need cgroup data can opt out via `exclude-rules`:

```yaml
# .dmtlint.yaml
linters-settings:
  container:
    exclude-rules:
      sys-cgroup-mount:
        - kind: DaemonSet
          name: network-agent
          container: agent
```

## Changes

- `pkg/linters/container/rules/sys_cgroup_mount.go` — the rule.
- `pkg/linters/container/rules.go` — registers the rule in `applyContainerRules`.
- `pkg/config.go`, `pkg/config/global/global.go`, `pkg/config/linters_settings.go` — config wiring for the rule (per-rule impact) and its `exclude-rules`.
- `internal/modules/module.go` — sets the `warn` default in `mapContainerRules` and maps the exclude rule in `mapContainerExclusions`.
- `pkg/linters/container/README.md` — table entry and a rule-details section.

## Notes on design

- **Not a universal Kubernetes invariant.** Mounting `/sys` does not by itself imply a need for `/sys/fs/cgroup` (e.g. a container reading only `/sys/class/net`). The rule intentionally uses the blunt heuristic anyway: the extra read-only mount is cheap and harmless, and whether a container reads cgroup data cannot be determined statically. The residual false positives are handled by the `warn` default and the per-container `exclude-rules` opt-out, not by trying to detect intent.
- **No edition gate.** The hardened runtime is a cluster property, not visible in module source, so the rule does not try to detect CSE. Requiring the mount whenever `/sys` is host-mounted simply makes every such module CSE-safe by default.
